### PR TITLE
Move centos /home directory

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -23,10 +23,6 @@
             regexp: "{{ connection_user.home }}"
             replace: "{{ ansible_user_home }}"
           register: etc_passwd
-         # NB: reboot is not always needed - not clear yet which service is causing problems
-        - name: reboot
-          reboot:
-          when: etc_passwd.changed
         # TODO: delete old homedir
       when:
         - ansible_user_home is defined # TODO: and defined etc etc

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -1,9 +1,38 @@
 ---
 
 - hosts: cluster
-  gather_facts: false
+  gather_facts: true
+  become: yes
   tasks:
+    - name: Get homedir for ansible_user # note ansible_env.HOME is /root when using become!
+      user:
+        name: "{{ ansible_user }}"
+        state: present
+      register: connection_user
+    - block:
+        - name: Copy ansible_user homedir
+          ansible.posix.synchronize:
+            src: "{{ connection_user.home }}/" # trailing-/ needed so we don't copy the directory itself, just contents
+            dest: "{{ ansible_user_home }}"
+            delete: yes
+            recursive: yes
+          delegate_to: "{{ inventory_hostname }}"
+        - name: modify /etc/passwd
+          replace:
+            path: /etc/passwd
+            regexp: "{{ connection_user.home }}"
+            replace: "{{ ansible_user_home }}"
+          register: etc_passwd
+         # NB: reboot is not always needed - not clear yet which service is causing problems
+        - name: reboot
+          reboot:
+          when: etc_passwd.changed
+        # TODO: delete old homedir
+      when:
+        - ansible_user_home is defined # TODO: and defined etc etc
+        - "connection_user.home != ansible_user_home"
+    - meta: reset_connection # needed for previous only but does not support conditional
+
     - name: Add users
       ansible.builtin.user: "{{ item }}"
       with_items: "{{ appliances_local_users }}"
-      become: true

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -22,13 +22,18 @@
             path: /etc/passwd
             regexp: "{{ connection_user.home }}"
             replace: "{{ ansible_user_home }}"
-          register: etc_passwd
-        # TODO: delete old homedir
       when:
-        - ansible_user_home is defined # TODO: and defined etc etc
+        - ansible_user_home is defined
         - "connection_user.home != ansible_user_home"
-    - meta: reset_connection # needed for previous only but does not support conditional
-
+    - meta: reset_connection # needed for same "when" conditions but does not support conditional
+    - name: delete old homedir
+      file:
+        path: "{{ connection_user.home }}"
+        state: absent
+      when:
+        - ansible_user_home is defined
+        - "connection_user.home != ansible_user_home"
+        
     - name: Add users
       ansible.builtin.user: "{{ item }}"
       with_items: "{{ appliances_local_users }}"

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -1,6 +1,7 @@
 ---
 # Miscellaneous
 ansible_user: centos
+ansible_user_home: /var/lib/{{ ansible_user }} # for use when /home is going to be mounted over
 appliances_repository_root: "{{ lookup('env', 'APPLIANCES_REPO_ROOT') }}"
 appliances_environment_root: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}"
 


### PR DESCRIPTION
When mounting /home via e.g. NFS we really want `centos` to remain a local user.

I've moved it by default to `/var/lib/centos`, see `ansible_user_home`.

Comments show some non-obvious issues.