### PR TITLE
Update "everything" layout

### DIFF
--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -69,4 +69,4 @@ compute
 cluster
 
 [rebuild]
-# nodes in 'compute' group which can be rebuilt from slurm (on an OpenStack cloud)
+# Enable rebuild of nodes on an OpenStack cloud; add 'control' group plus 'compute' group or a subset of it.

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -1,6 +1,3 @@
-[exporters:children]
-cluster
-
 [nfs:children]
 cluster
 


### PR DESCRIPTION
- `exporters` outdated and already replaced by `node_exporter`
- rebuild group needs to include control (to reconfigure slurm.conf) - note this isn't in everything due to that being used for vagrant test