### PR TITLE
Change facts update after selinux change to depend on reboot status

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -32,4 +32,4 @@
       when: sestatus.reboot_required
     - name: update facts
       setup:
-      when: sestatus.changed
+      when: sestatus.reboot_required


### PR DESCRIPTION
Makes this more robust to issues with selinux state change not being applied.