### PR TITLE
Fixes for centos 8.4

### DIFF
--- a/ansible/roles/opendistro/tasks/deploy.yml
+++ b/ansible/roles/opendistro/tasks/deploy.yml
@@ -1,11 +1,4 @@
 ---
-- name: Setup volume for opendistro
-  containers.podman.podman_volume:
-    state: present
-    name: opendistro
-  become: true
-  become_user: "{{ opendistro_podman_user }}"
-  notify: Restart opendistro container
 
 - name: Create systemd unit file
   template:

--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -15,6 +15,12 @@
   tags:
     - openhpc
   tasks:
+    - name: Add CentOS 8.3 Vault repo for OpenHPC hwloc dependency
+      yum_repository:
+        name: vault
+        file: CentOS-Linux-Vault8.3
+        description:  CentOS 8.3 packages from Vault
+        baseurl: https://vault.centos.org/8.3.2011/BaseOS/$basearch/os/
     - import_role:
         name: stackhpc.openhpc
 

--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -21,6 +21,7 @@
         file: CentOS-Linux-Vault8.3
         description:  CentOS 8.3 packages from Vault
         baseurl: https://vault.centos.org/8.3.2011/BaseOS/$basearch/os/
+        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
     - import_role:
         name: stackhpc.openhpc
 

--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -16,6 +16,7 @@
     - openhpc
   tasks:
     - name: Add CentOS 8.3 Vault repo for OpenHPC hwloc dependency
+      # NB: REMOVE THIS once OpenHPC works on CentOS 8.4
       yum_repository:
         name: vault
         file: CentOS-Linux-Vault8.3


### PR DESCRIPTION
Now CentOS 8.4 is available even installs on existing 8.3 cloud images hit problems:

1. `slurm-slurmd-ohpc-20.11.7-3.1.ohpc.2.2.x86_64` requires `hwloc-1.11` with soname `libhwloc.so.5` but CentOS 8.4 upgraded hwloc to 2.2.0 with soname `libhwloc.so.15`. **Solution:** add Centos Vault repo. Note there may be a new release from openhpc to fix this, but in the mean-time there is no other solution.

2. yum installing `podman` now gets v3 not v2 as previously.
- Currently the `opendistro` role creates the `opendistro` volume [here](https://github.com/stackhpc/ansible-slurm-appliance/blob/b4c810edd3756b4e16b45ac866c63314f5955a7a/ansible/roles/opendistro/tasks/deploy.yml#L2).
- The permissions on this aren't correct to allow writing by the `elasticsearch` user inside the container. It appears this was OK in `podman` v2, but not in v3.
- The volume is defined in the systemd unit file anyway ([here](https://github.com/stackhpc/ansible-slurm-appliance/blob/main/ansible/roles/opendistro/templates/opendistro.service.j2)) and podman creates this (with correct permissions) on first start, so this PR removes the unneeded volume creation task.