### PR TITLE
Fix tests mountpoint now /home is default NFS share

### DIFF
--- a/environments/common/inventory/group_vars/all/openhpc_tests.yml
+++ b/environments/common/inventory/group_vars/all/openhpc_tests.yml
@@ -1,3 +1,3 @@
-openhpc_tests_rootdir: /mnt/nfs/ohcp-tests
+openhpc_tests_rootdir: /home/ohcp-tests
 openhpc_tests_hpl_NB: 192
 openhpc_slurm_login: "{{ groups['login'][0] }}"


### PR DESCRIPTION
This got missed in #81 which changed the default NFS share to /home.

Not we can't use /home/centos/whatever as centos's home is local on /var/lib/centos.
