### PR TITLE
Add hardening functionality

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -11,6 +11,15 @@
       become_flags: '-i'
       become: true
 
+- hosts: fail2ban
+  gather_facts: false
+  become: yes
+  tags:
+    - fail2ban
+  tasks:
+    - import_role:
+        name: fail2ban
+
 - hosts: selinux
   gather_facts: false
   become: yes
@@ -48,6 +57,29 @@
           msg: "{{ updates.results | length }} changes to packages - see {{ update_log_path }} for details"
       when: "update_enable | default('false') | bool"
 
+- hosts: hardening
+  gather_facts: true
+  become: yes
+  tags:
+    - hardening
+  tasks:
+    - name: Check FIPs status
+      command:
+        cmd: "fips-mode-setup --check"
+      changed_when: false
+      register: fips_mode_check
+    - name: Enable FIPs mode
+      command:
+        cmd: "fips-mode-setup --enable"
+      register: fips_mode_setup
+      when: "'enabled' not in fips_mode_check.stdout"
+    - name: Reboot to enable FIPS
+      reboot:
+        post_reboot_delay: 30
+      when: fips_mode_setup.changed | default(false)
+    - import_role:
+        name: ansible-hardening
+
 - hosts:
     - selinux
     - update
@@ -60,8 +92,6 @@
       stat: 
         path: /var/run/reboot-required
       register: update_reboot_required
-    - debug:
-        msg: "setstatus:{{ (sestatus.reboot_required | default(false)) }} packages: {{ (update_reboot_required.stat.exists | bool) }}"
     - name: Reboot if required from SELinux state change or package upgrades
       reboot:
         post_reboot_delay: 30
@@ -72,12 +102,3 @@
     - name: update facts
       setup:
       when: (sestatus.changed | default(false)) or (sestatus.reboot_required | default(false))
-
-- hosts: hardening
-  gather_facts: true
-  become: yes
-  tags:
-    - hardening
-  tasks:
-    - import_role:
-        name: ansible-hardening

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -2,6 +2,8 @@
 
 - hosts: cluster
   gather_facts: false
+  tags:
+    - users
   tasks:
     - name: Add users
       ansible.builtin.user: "{{ item }}"
@@ -28,7 +30,7 @@
   tasks:
     - name: Set SELinux state and policy
       ansible.posix.selinux:
-        state: "{{ selinux_state }}"
+        state: "{{ hardening_selinux_state if 'hardening' in group_names else selinux_state }}" # as group_vars all/hardening and all/selinux have same precedence
         policy: "{{ selinux_policy }}"
       register: sestatus
 
@@ -73,6 +75,14 @@
         cmd: "fips-mode-setup --enable"
       register: fips_mode_setup
       when: "'enabled' not in fips_mode_check.stdout"
+    - name: Require password for sudo
+      replace:
+        path: "{{ item.path }}"
+        regexp: "{{ item.regexp }}"
+        replace: "{{ item.replace }}"
+        validate: 'bash -c "cat /etc/sudoers %s | visudo -cf-"'
+      loop: "{{ hardening_sudo_rules }}"
+    - meta: reset_connection
     - name: Reboot to enable FIPS
       reboot:
         post_reboot_delay: 30

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -72,3 +72,12 @@
     - name: update facts
       setup:
       when: (sestatus.changed | default(false)) or (sestatus.reboot_required | default(false))
+
+- hosts: hardening
+  gather_facts: true
+  become: yes
+  tags:
+    - hardening
+  tasks:
+    - import_role:
+        name: ansible-hardening

--- a/ansible/roles/passwords/defaults/main.yml
+++ b/ansible/roles/passwords/defaults/main.yml
@@ -1,13 +1,13 @@
 ---
 
-openhpc_passwords:
-  secrets_openhpc_grafana_admin_password: "{{ secrets_openhpc_grafana_admin_password | default(lookup('password', '/dev/null')) }}"
-  secrets_openhpc_elasticsearch_admin_password: "{{ secrets_openhpc_elasticsearch_admin_password | default(lookup('password', '/dev/null')) }}"
-  secrets_openhpc_elasticsearch_kibana_password: "{{ secrets_openhpc_elasticsearch_kibana_password | default(lookup('password', '/dev/null')) }}"
-  secrets_openhpc_mysql_root_password: "{{ secrets_openhpc_mysql_root_password | default(lookup('password', '/dev/null')) }}"
-  secrets_openhpc_mysql_slurm_password: "{{ secrets_openhpc_mysql_slurm_password | default(lookup('password', '/dev/null')) }}"
-  # TODO: Might be cleaner to write this to a file, but needs modification of the role
-  secrets_openhpc_mungekey: "{{ secrets_openhpc_mungekey | default(secrets_openhpc_mungekey_default) }}"
+slurm_appliance_secrets:
+  vault_grafana_admin_password: "{{ secrets_openhpc_grafana_admin_password | default(vault_grafana_admin_password | default(lookup('password', '/dev/null'))) }}"
+  vault_elasticsearch_admin_password: "{{ secrets_openhpc_elasticsearch_admin_password | default(vault_elasticsearch_admin_password | default(lookup('password', '/dev/null'))) }}"
+  vault_elasticsearch_kibana_password: "{{ secrets_openhpc_elasticsearch_kibana_password | default(vault_elasticsearch_kibana_password |default(lookup('password', '/dev/null'))) }}"
+  vault_mysql_root_password: "{{ secrets_openhpc_mysql_root_password | default(vault_mysql_root_password | default(lookup('password', '/dev/null'))) }}"
+  vault_mysql_slurm_password: "{{ secrets_openhpc_mysql_slurm_password | default(vault_mysql_slurm_password | default(lookup('password', '/dev/null'))) }}"
+  vault_openhpc_mungekey: "{{ secrets_openhpc_mungekey | default(vault_openhpc_mungekey | default(secrets_openhpc_mungekey_default)) }}"
+  ansible_become_password: "{{ ansible_become_password | default(lookup('password', '/dev/null')) }}"
 
 secrets_openhpc_mungekey_default:
   content: "{{ lookup('pipe', 'dd if=/dev/urandom bs=1 count=1024 2>/dev/null | base64') }}"

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -31,6 +31,8 @@ appliances_local_users_ansible_user:
     home: "{{ appliances_local_users_ansible_user_home }}"
     move_home: true
     local: true
+    password: "{{ omit if 'hardening' not in group_names else (ansible_become_password | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string )) }}" # makes it idempotent,
+    # see https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#encrypting-and-checksumming-strings-and-passwords
 
 appliances_local_users_podman_enable: "{{ groups['podman'] | length > 0 }}"
 appliances_local_users_podman_home: /var/lib/podman

--- a/environments/common/inventory/group_vars/all/hardening.yml
+++ b/environments/common/inventory/group_vars/all/hardening.yml
@@ -1,0 +1,1 @@
+security_rhel7_enable_linux_security_module: no

--- a/environments/common/inventory/group_vars/all/hardening.yml
+++ b/environments/common/inventory/group_vars/all/hardening.yml
@@ -1,1 +1,1 @@
-security_rhel7_enable_linux_security_module: no
+selinux_state: enforcing

--- a/environments/common/inventory/group_vars/all/hardening.yml
+++ b/environments/common/inventory/group_vars/all/hardening.yml
@@ -1,1 +1,11 @@
-selinux_state: enforcing
+hardening_selinux_state: enforcing
+hardening_sudo_rules:
+  - path: '/etc/sudoers'
+    regexp: '#\s+%wheel\s+ALL=\(ALL\)\s+NOPASSWD:\s+ALL' # non-functional but still generates warning
+    replace: ''
+  - path: '/etc/sudoers'
+    regexp: 'centos\s+ALL=\(ALL\)\s+NOPASSWD:\s+ALL'
+    replace: 'centos\tALL=(ALL)\tALL'
+  - path: '/etc/sudoers.d/90-cloud-init-users'
+    regexp: 'centos\s+ALL=\(ALL\)\s+NOPASSWD:ALL'
+    replace: 'centos\tALL=(ALL)\tALL'

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -71,3 +71,7 @@ cluster
 
 [update]
 # All hosts to (optionally) run yum update on.
+
+[hardening]
+# Hosts to apply security hardening configuration configuration to
+# https://github.com/openstack/ansible-hardening

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -32,3 +32,9 @@ slurm_stats
 
 [update:children]
 cluster
+
+[fail2ban:children]
+login
+
+[hardening:children]
+login

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,6 +9,7 @@ roles:
   - src: cloudalchemy.grafana
   - src: geerlingguy.mysql
   - src: jriguera.configdrive
+  - src: git+https://github.com/openstack/ansible-hardening
 
 collections:
 - name: containers.podman


### PR DESCRIPTION
This uses the openstack [ansible-hardening](https://github.com/openstack/ansible-hardening) role to apply STIG security configurations to hosts in the `hardening` group. The `environments/common/layouts/everything` template used by cookiecutter puts the `login` group into the `hardening` group.

**NB:** This depends on PR #97.

The `ansible-hardening` role is run with default settings and the following additional changes are made to hosts in the `hardening` group:
- "FIPS mode" for cryptography standards is enabled (ideally this should actually be enabled during system installation but this is clearly not possible using ansible).
- A password is autogenerated for the `centos` user by the `ansible/adhoc/generate-passwords.yml ` playbook and sudo rules are set for for `centos` and `wheel` groups to require a password. Note if other users have been added with sudo rights (e.g. via a `pre-` hook), they will not be affected and a warning will be generated by the `ansible-hardning` role.

Note that hosts in `hardening` will also have their `sestatus` set to enforcing, rather than the appliance default of `permissive`.

On a CentOS 8.4 system the `ansible-hardening` role will still generate warnings about:
- Users without a home directory (`cockpit-ws`, `cockpit-wsinstance`, `rngd` are missing theirs - note the cockpit-* ones are not removed by removing the `cockpit-ws` package).
- Various directories which should be on their own filesystem: `/var`, `/var/log/audit`, `/tmp`.
- "Output from syslog must be sent to another server." (STIG V-72209).

