### PR TITLE
Provide control over packer base image

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -40,7 +40,11 @@ Steps:
   The following variables may also be set:
 
   - `disk_size`: Set the image size ([docs](https://www.packer.io/docs/builders/qemu#disk_size)). Defaults to 20G, so for smaller VMs use e.g: `packer build -var 'disk_size=10G' ...`
-  - `groups`: List of ansible groups the packer VM is added to, to control which nodes to build an image for. Defaults to `["compute"]` to build a generic compute node image. The first element of this list is used as part of the image name. Examples:
+  - `groups`: List of ansible groups the packer VM is added to, to control which nodes to build an image for. Defaults to `["compute"]` to build a generic compute node image. The first element of this list is used as part of the image name.
+  - `base_img_url`: URL or path of base image to use (default is CentOS 8.4 GenericCloud x86_64 image). See the Packer docs for [iso_url](https://www.packer.io/docs/builders/qemu#iso-configuration) details.
+  - `base_img_checksum`: Checksum type:checksum for `base_img_url`.
+  
+  Examples:
 
      - Build an image for a login node: `packer build -var 'groups=["login"]' ...`
 

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -23,9 +23,19 @@ variable "groups" {
   default = ["compute"]
 }
 
+variable "base_img_url" {
+  type = string
+  default = "https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2"
+}
+
+variable "base_img_checksum" {
+  type = string
+  default = "sha256:3510fc7deb3e1939dbf3fe6f65a02ab1efcc763480bc352e4c06eca2e4f7c2a2"
+}
+
 source "qemu" "openhpc-vm" {
-  iso_url = "https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2"
-  iso_checksum = "sha256:d8984b9baee57b127abce310def0f4c3c9d5b3cea7ea8451fc4ffcbc9935b640"
+  iso_url = var.base_img_url
+  iso_checksum = var.base_img_checksum
   disk_image = true # as above is .qcow2 not .iso
   disk_size = var.disk_size
   disk_compression = true


### PR DESCRIPTION
Currently this is hardcoded to centos 8.2. This PR adds packer variables to allow this to be altered, and changes default to 8.4.

Although I think we should continue to push for appliance users to start from a GenericCloud image so that everything is defined in the code, this does allow for cases where client wants/is required to to use their own base image too.