### PR TITLE
Support instance_id hostvar for rebuild adhoc playbook

### DIFF
--- a/ansible/adhoc/rebuild.yml
+++ b/ansible/adhoc/rebuild.yml
@@ -4,6 +4,8 @@
 # Use --limit to control which hosts to rebuild (either specific hosts or the <cluster_name>_<partition_name> groups defining partitions).
 # Optionally, supply `-e rebuild_image=<image_name_or_id>` to define a specific image, otherwise the current image is reused.
 #
+# NOTE: If a hostvar `instance_id` is defined this is used to select hosts. Otherwise the hostname is used and this must be unique, which may not be the case e.g. if using identically-named staging and production hosts.
+#
 # Example:
 #   ansible-playbook -v --limit ohpc_compute ansible/adhoc/rebuild.yml -e rebuild_image=openhpc_v2.3
 
@@ -11,6 +13,6 @@
   become: no
   gather_facts: no
   tasks:
-    - command: "openstack server rebuild {{ inventory_hostname }}{% if rebuild_image is defined %} --image {{ rebuild_image }}{% endif %}"
+    - command: "openstack server rebuild {{ instance_id | default(inventory_hostname) }}{% if rebuild_image is defined %} --image {{ rebuild_image }}{% endif %}"
       delegate_to: localhost
     - wait_for_connection:


### PR DESCRIPTION
The ad-hoc rebuild command is useful during development but currently uses the hostname to select the instance to rebuild. With multiple environments it may be desirable to have identical hostnames e.g. between staging and prod. This PR uses an `instance_id` hostvar (which could be set e.g. by terraform) to select the host instead, if available, falling back to hostname.
