### PR TITLE
Rename openhpc_packages overrides to follow kolla pattern

### DIFF
--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -15,12 +15,12 @@ openhpc_slurmdbd_mysql_username: slurm
 openhpc_slurm_control_host: "{{ groups['control'] | first }}"
 openhpc_slurm_partitions:
   - name: "compute"
-openhpc_default_packages:
+openhpc_packages_default:
   - slurm-libpmi-ohpc # to allow intel mpi to work properly
   - ohpc-gnu9-openmpi4-perf-tools # for hpctests
   - openblas-gnu9-ohpc # for hpctests (HPL)
-openhpc_extra_packages: []
-openhpc_packages: "{{ openhpc_default_packages + openhpc_extra_packages }}"
+openhpc_packages_extra: []
+openhpc_packages: "{{ openhpc_packages_default + openhpc_packages_extra }}"
 openhpc_munge_key: "{{ vault_openhpc_mungekey | b64decode }}"
 openhpc_slurm_configless: true
 openhpc_login_only_nodes: login


### PR DESCRIPTION
Move to a kolla-style pattern of `role_var = var_default + var_extra` where default is appliance default and extra is from environment.

This is currently safe(-ish) to do as only alaska is using it (NREL are using `openhpc_packages` directly, which doesn't clash with this change but would ideally be updated at some stage).
