### PR TITLE
Change prometheus targets to be hosts in node_exporter group

### DIFF
--- a/environments/common/inventory/group_vars/all/prometheus.yml
+++ b/environments/common/inventory/group_vars/all/prometheus.yml
@@ -14,7 +14,7 @@ prometheus_alert_rules_files:
 prometheus_alert_rules: []
 
 prometheus_targets:
-  node: "{{ groups['all'] | reject('equalto', 'localhost') | prometheus_node_exporter_targets }}"
+  node: "{{ groups.get('node_exporter', []) | reject('equalto', 'localhost') | prometheus_node_exporter_targets }}"
 
 prometheus_scrape_configs:
 - job_name: "prometheus"


### PR DESCRIPTION
Prometheus targets are currently `all` which is not the intention of the `node_exporter` group. Fixes #115.