### PR TITLE
Don't add centos vault now openhpc v2.3 released to fix centos 8.4 pa…

### DIFF
--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -15,14 +15,6 @@
   tags:
     - openhpc
   tasks:
-    - name: Add CentOS 8.3 Vault repo for OpenHPC hwloc dependency
-      # NB: REMOVE THIS once OpenHPC works on CentOS 8.4
-      yum_repository:
-        name: vault
-        file: CentOS-Linux-Vault8.3
-        description:  CentOS 8.3 packages from Vault
-        baseurl: https://vault.centos.org/8.3.2011/BaseOS/$basearch/os/
-        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
     - import_role:
         name: stackhpc.openhpc
 


### PR DESCRIPTION
Centos Vault was added to when centos 8.4 came out as it changed the `hwloc` package, which was depended on by openhpc packages. 

However now openhpc v2.3 is released any openhpc install will get the rebuild openhpc packages.