### PR TITLE
Skip some hpctests when not enough compute nodes

### DIFF
--- a/ansible/roles/hpctests/tasks/main.yml
+++ b/ansible/roles/hpctests/tasks/main.yml
@@ -6,11 +6,13 @@
 - name: pingpong
   block:
     - include: pingpong.yml
+      when: hpctests_computes.stdout_lines | length > 1
   tags: pingpong
 
 - name: pingmatrix
   block:
     - include: pingmatrix.yml
+      when: hpctests_computes.stdout_lines | length > 1
   tags: pingmatrix
 
 - name: build HPL


### PR DESCRIPTION
pingpong and pingmatrix don't make sense with < 2 compute nodes and cause an error, so skip them if this is the case.