### PR TITLE
Fix prometheus datasource protocol for grafana

### DIFF
--- a/environments/common/inventory/group_vars/all/grafana.yml
+++ b/environments/common/inventory/group_vars/all/grafana.yml
@@ -36,7 +36,7 @@ grafana_security:
 grafana_datasources:
   - name: prometheus
     ds_type: prometheus
-    ds_url: "{{ prometheus_address }}:9090" # default prometheus port
+    ds_url: "http://{{ prometheus_address }}:9090" # default prometheus port
   - name: slurmstats
     ds_type: elasticsearch
     ds_url: "https://{{ elasticsearch_address }}:9200"


### PR DESCRIPTION
Adds protocol to the prometheus URL in grafana datasources. Used to be ok without it, now it's not:
- Grafana gui has no graphs, just pink triangles in the corner of each, with a message about protocol
- Grafana log has messages about missing protocol too

Seems to be no sensible way to check from ansible whether the defined datasources are OK, other than just looking for `error` in the log which I don't really want to do.
