### PR TITLE
Add blackbox probing of slurm endpoints

### DIFF
--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -61,6 +61,12 @@
   tasks:
     - import_role: name=cloudalchemy.node_exporter
 
+- name: Deploy blackbox exporter
+  hosts: blackbox_exporter
+  tags: blackbox_exporter
+  tasks:
+    - import_role: name=cloudalchemy.blackbox-exporter
+
 - name: Deploy OpenOndemand exporter
   hosts: openondemand
   become: true

--- a/environments/common/inventory/group_vars/all/blackbox_exporter.yml
+++ b/environments/common/inventory/group_vars/all/blackbox_exporter.yml
@@ -1,0 +1,10 @@
+blackbox_exporter_configuration_modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      valid_status_codes: []
+  tcp_connect:
+    prober: tcp
+    timeout: 5s

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -15,6 +15,7 @@ api_address: "{{ inventory_hostname }}"
 elasticsearch_address: "{{ hostvars[groups['opendistro'].0].api_address }}"
 prometheus_address: "{{ hostvars[groups['prometheus'].0].api_address }}"
 openondemand_address: "{{ hostvars[groups['openondemand'].0].api_address if groups['openondemand'] | count > 0 else '' }}"
+blackbox_exporter_address: "{{ hostvars[groups['blackbox_exporter'].0].api_address }}"
 
 ############################# bootstrap: local user configuration #########################
 

--- a/environments/common/inventory/group_vars/all/prometheus.yml
+++ b/environments/common/inventory/group_vars/all/prometheus.yml
@@ -46,5 +46,21 @@ prometheus_scrape_configs_default:
       - cpufreq
   scrape_interval: 30s
   scrape_timeout: 20s
+- job_name: slurm
+  metrics_path: /probe
+  params:
+    module: [tcp_connect]
+  static_configs:
+    - targets:
+      - "http://{{ openhpc_slurm_control_host }}:6817"
+    - targets:
+      - "http://{{ groups['login'] | first }} :6818" # FIXME: want all login and compute nodes
+  relabel_configs:
+    - source_labels: [__address__]
+      target_label: __param_target
+    - source_labels: [__param_target]
+      target_label: instance
+    - target_label: __address__
+      replacement: "{{ blackbox_exporter_address }}:9115"  # Blackbox exporter
 
 prometheus_scrape_configs: "{{ prometheus_scrape_configs_default + (openondemand_scrape_configs if groups['openondemand'] | count > 0 else []) }}"

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -56,6 +56,9 @@ filebeat
 [node_exporter]
 # All hosts to monitor for hardware and OS metrics.
 
+[blackbox_exporter]
+# Host for blackbox exporter to probe network endpoints (probably prometheus)
+
 [openhpc_tests:children]
 # For post-deploy MPI-based tests - see ansible/adhoc/test.yml
 login

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -19,6 +19,9 @@ control
 [node_exporter:children]
 cluster
 
+[blackbox_exporter:children]
+prometheus
+
 [opendistro:children]
 control
 

--- a/environments/smslabs-example/inventory/groups
+++ b/environments/smslabs-example/inventory/groups
@@ -20,6 +20,9 @@ control
 [node_exporter:children]
 cluster
 
+[blackbox_exporter:children]
+prometheus
+
 [opendistro:children]
 control
 


### PR DESCRIPTION
Add probing of slurmctld and slurmd ports using the prometheus blackbox exporter. Will allow monitoring/alerting on slurm{ctld,d} being up/reachable.

"Default" (= `everything` layout) behaviour is to put the blackbox exporter on the prometheus node, on the basis that that removes a failure point. Is that appropriate?

Note there are slurm exporters for prometheus but they seem slightly fragile/dependent on specific versions. This is anyway more at the infra layer so probably still useful.

TODO:
- [ ] Expand slurmd endpoints to all compute/login nodes.
- [ ] Label jobs appropriately.
- [ ] Create dashboard

Could also add (probably as another job) blackbox probing for e.g. DNS?