### PR TITLE
Fix accidently not using configless mode

### DIFF
--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -25,6 +25,12 @@
     - rebuild
     - openhpc
   tasks:
+    - assert:
+        that: "'enable_configless' in openhpc_config.SlurmctldParameters | default([])"
+        fail_msg: |
+          'enable_configless' not found in openhpc_config.SlurmctldParameters - is variable openhpc_config overridden?
+          Additional slurm.conf parameters should be provided using variable openhpc_config_extra.
+        success_msg: Checked Slurm will be configured for configless operation
     - import_role:
         name: stackhpc.slurm_openstack_tools.rebuild
 

--- a/environments/smslabs-example/inventory/group_vars/openhpc/overrides.yml
+++ b/environments/smslabs-example/inventory/group_vars/openhpc/overrides.yml
@@ -1,4 +1,4 @@
-openhpc_config:
+openhpc_config_extra:
   SlurmctldDebug: debug
   SlurmdDebug: debug
 openhpc_slurm_partitions:


### PR DESCRIPTION
The smslabs (CI) environment overrode `openhpc_config` which override the appliance default of configless. We always want to operate in this mode, so this PR a) fixes the problem in that environment, b) checks that the environment hasn't turned it off.
