### PR TITLE
Make OOD role vars public when the role is imported

### DIFF
--- a/ansible/roles/openondemand/tasks/main.yml
+++ b/ansible/roles/openondemand/tasks/main.yml
@@ -11,6 +11,7 @@
     name: osc.ood
     tasks_from: install-rpm.yml
     vars_from: Rocky.yml
+    public: yes # Expose the vars from this role to the rest of the play
   # can't set vars: from a dict hence the workaround above
 
 - include_tasks:
@@ -23,13 +24,14 @@
 # The configure.yml playbook needs vars from Rocky (for nginx) and main if using OIDC auth. However vars_from doensn't take a list.
 # include_vars doens't interpolate from role vars, so we use that for main.yml which only requires things we override in the appliance inventory
 # and use vars_from for Rocky which requires interpolation from role vars.
-- include_vars:
-    file: roles/osc.ood/vars/main.yml
+#- include_vars:
+#    file: roles/osc.ood/vars/main.yml
 
 - include_role:
     name: osc.ood
     tasks_from: configure.yml
-    vars_from: Rocky.yml
+    vars_from: main.yml
+    public: yes
 
 - include_role:
     name: osc.ood


### PR DESCRIPTION
Using relative paths in `include_vars` doesn't work when AWX is in charge of where galaxy roles are put.

The search path for `roles/osc.ood/vars/main.yml` on AWX is:

```
/runner/project/vendor/stackhpc/ansible-slurm-appliance/ansible/roles/openondemand/vars/roles/osc.ood/vars/main.yml
/runner/project/vendor/stackhpc/ansible-slurm-appliance/ansible/roles/openondemand/roles/osc.ood/vars/main.yml
/runner/project/vendor/stackhpc/ansible-slurm-appliance/ansible/roles/openondemand/tasks/vars/roles/osc.ood/vars/main.yml
/runner/project/vendor/stackhpc/ansible-slurm-appliance/ansible/roles/openondemand/tasks/roles/osc.ood/vars/main.yml
/runner/project/vendor/stackhpc/ansible-slurm-appliance/ansible/vars/roles/osc.ood/vars/main.yml
/runner/project/vendor/stackhpc/ansible-slurm-appliance/ansible/roles/osc.ood/vars/main.yml
```

but the downloaded roles live in `/runner/project/requirements_roles`.

This fix exposes `osc.ood` vars to the rest of the play when each `include_role` happens, exposing both `Rocky.yml` and `main.yml` using the `public: yes` [parameter](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_role_module.html#parameter-public). 