### PR TITLE
Add CI for OOD

### DIFF
--- a/.github/workflows/smslabs.yml
+++ b/.github/workflows/smslabs.yml
@@ -101,8 +101,9 @@ jobs:
           source $APPLIANCES_ENVIRONMENT_ROOT/vars.txt
           
           # setup ssh proxying:
-          sudo apt-get --yes --force-yes install proxychains
-          ssh -fN -D 8080 ${bastion_user}@${bastion_ip}
+          sudo apt-get --yes install proxychains
+          echo running "ssh -fN -D 8080 ${bastion_user}@${bastion_ip}"
+          ssh -v -fN -D 8080 ${bastion_user}@${bastion_ip}
           
           # check OOD server returns 200:
           statuscode=$(PROXYCHAINS_SOCKS5=8080 proxychains wget \

--- a/.github/workflows/smslabs.yml
+++ b/.github/workflows/smslabs.yml
@@ -102,11 +102,12 @@ jobs:
           
           # setup ssh proxying:
           sudo apt-get --yes install proxychains
-          echo running "ssh -fN -D 8080 ${bastion_user}@${bastion_ip}"
-          ssh -v -fN -D 8080 ${bastion_user}@${bastion_ip}
-          
+          echo proxychains installed
+          ssh -v -fN -D 9050 ${bastion_user}@${bastion_ip}
+          echo port 9050 forwarded
+
           # check OOD server returns 200:
-          statuscode=$(PROXYCHAINS_SOCKS5=8080 proxychains wget \
+          statuscode=$(proxychains wget \
             --quiet \
             --spider \
             --server-response \

--- a/.github/workflows/smslabs.yml
+++ b/.github/workflows/smslabs.yml
@@ -116,6 +116,8 @@ jobs:
             --http-password=${TEST_USER_PASSWORD} https://${openondemand_servername} \
             2>&1)
           (echo $statuscode | grep "200 OK") || (echo $statuscode  && exit 1)
+        env:
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
 
       - name: Run MPI-based tests
         run: |

--- a/.github/workflows/smslabs.yml
+++ b/.github/workflows/smslabs.yml
@@ -101,11 +101,11 @@ jobs:
           source $APPLIANCES_ENVIRONMENT_ROOT/vars.txt
           
           # setup ssh proxying:
-          sudo apt install proxychains
+          sudo apt-get --yes --force-yes install proxychains
           ssh -fN -D 8080 ${bastion_user}@${bastion_ip}
           
           # check OOD server returns 200:
-          statuscode=$(PROXYCHAINS_SOCKS5=8080 wget \
+          statuscode=$(PROXYCHAINS_SOCKS5=8080 proxychains wget \
             --quiet \
             --spider \
             --server-response \

--- a/.github/workflows/smslabs.yml
+++ b/.github/workflows/smslabs.yml
@@ -54,33 +54,6 @@ jobs:
           OS_CLOUD: openstack
           TF_VAR_cluster_name: ci${{ github.run_id }}
       
-      - name: Confirm Open Ondemand is up (via SOCKS proxy)
-        run: |
-          . venv/bin/activate
-          . environments/smslabs-example/activate
-          
-          # load ansible variables into shell:
-          ansible-playbook ansible/ci/output_vars.yml \
-            -e output_vars_hosts=openondemand \
-            -e output_vars_path=$APPLIANCES_ENVIRONMENT_ROOT/vars.txt \
-            -e output_vars_items=bastion_ip,bastion_user,openondemand_servername
-          source $APPLIANCES_ENVIRONMENT_ROOT/vars.txt
-          
-          # setup ssh proxying:
-          sudo apt install proxychains
-          ssh -fN -D 8080 ${bastion_user}@${bastion_ip}
-
-          # check OOD server returns 200:
-          statuscode=$(PROXYCHAINS_SOCKS5=8080 wget \
-            --quiet
-            --spider
-            --server-response
-            --no-check-certificate \
-            --http-user=testuser \
-            --http-password=${TEST_USER_PASSWORD} https://${openondemand_servername} \
-            2>&1)
-          (echo $statuscode | grep "200 OK") || (echo $statuscode  && exit 1)
-
       - name: Get server provisioning failure messages
         id: provision_failure
         run: |
@@ -115,6 +88,33 @@ jobs:
           ANSIBLE_FORCE_COLOR: True
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
       
+      - name: Confirm Open Ondemand is up (via SOCKS proxy)
+        run: |
+          . venv/bin/activate
+          . environments/smslabs-example/activate
+          
+          # load ansible variables into shell:
+          ansible-playbook ansible/ci/output_vars.yml \
+            -e output_vars_hosts=openondemand \
+            -e output_vars_path=$APPLIANCES_ENVIRONMENT_ROOT/vars.txt \
+            -e output_vars_items=bastion_ip,bastion_user,openondemand_servername
+          source $APPLIANCES_ENVIRONMENT_ROOT/vars.txt
+          
+          # setup ssh proxying:
+          sudo apt install proxychains
+          ssh -fN -D 8080 ${bastion_user}@${bastion_ip}
+          
+          # check OOD server returns 200:
+          statuscode=$(PROXYCHAINS_SOCKS5=8080 wget \
+            --quiet \
+            --spider \
+            --server-response \
+            --no-check-certificate \
+            --http-user=testuser \
+            --http-password=${TEST_USER_PASSWORD} https://${openondemand_servername} \
+            2>&1)
+          (echo $statuscode | grep "200 OK") || (echo $statuscode  && exit 1)
+
       - name: Run MPI-based tests
         run: |
           . venv/bin/activate

--- a/.github/workflows/smslabs.yml
+++ b/.github/workflows/smslabs.yml
@@ -54,6 +54,33 @@ jobs:
           OS_CLOUD: openstack
           TF_VAR_cluster_name: ci${{ github.run_id }}
       
+      - name: Confirm Open Ondemand is up (via SOCKS proxy)
+        run: |
+          . venv/bin/activate
+          . environments/smslabs-example/activate
+          
+          # load ansible variables into shell:
+          ansible-playbook ansible/ci/output_vars.yml \
+            -e output_vars_hosts=openondemand \
+            -e output_vars_path=$APPLIANCES_ENVIRONMENT_ROOT/vars.txt \
+            -e output_vars_items=bastion_ip,bastion_user,openondemand_servername
+          source $APPLIANCES_ENVIRONMENT_ROOT/vars.txt
+          
+          # setup ssh proxying:
+          sudo apt install proxychains
+          ssh -fN -D 8080 ${bastion_user}@${bastion_ip}
+
+          # check OOD server returns 200:
+          statuscode=$(PROXYCHAINS_SOCKS4=8080 wget \
+            --quiet
+            --spider
+            --server-response
+            --no-check-certificate \
+            --http-user=testuser \
+            --http-password=${TEST_USER_PASSWORD} https://${openondemand_servername} \
+            2>&1)
+          (echo $statuscode | grep "200 OK") || echo $statuscode
+
       - name: Get server provisioning failure messages
         id: provision_failure
         run: |

--- a/.github/workflows/smslabs.yml
+++ b/.github/workflows/smslabs.yml
@@ -79,7 +79,7 @@ jobs:
             --http-user=testuser \
             --http-password=${TEST_USER_PASSWORD} https://${openondemand_servername} \
             2>&1)
-          (echo $statuscode | grep "200 OK") || echo $statuscode
+          (echo $statuscode | grep "200 OK") || (echo $statuscode  && exit 1)
 
       - name: Get server provisioning failure messages
         id: provision_failure

--- a/ansible/ci/output_vars.yml
+++ b/ansible/ci/output_vars.yml
@@ -1,0 +1,12 @@
+# Output specific hostvars to a file in a form which can be sourced by bash
+# NB: obviously the keys and values for the hostvars need to be suitable bash variables
+- hosts: "{{ output_vars_hosts }}"
+  gather_facts: no
+  tasks:
+    - copy:
+        dest: "{{ output_vars_path }}"
+        content: |
+          {% for item in output_vars_items.split(',') %}
+          export {{output_vars_prefix | default('') }}{{ item }}={{ lookup('vars', item) }}
+          {% endfor %}
+      delegate_to: localhost

--- a/environments/smslabs-example/inventory/group_vars/all/bastion.yml
+++ b/environments/smslabs-example/inventory/group_vars/all/bastion.yml
@@ -1,1 +1,3 @@
-ansible_ssh_common_args: '-o ProxyCommand="ssh slurm-app-ci@185.45.78.150 -W %h:%p"'
+bastion_user: slurm-app-ci
+bastion_ip: 185.45.78.150
+ansible_ssh_common_args: '-o ProxyCommand="ssh {{ bastion_user }}@{{ bastion_ip }} -W %h:%p"'

--- a/environments/smslabs-example/terraform/nodes.tf
+++ b/environments/smslabs-example/terraform/nodes.tf
@@ -24,7 +24,7 @@ resource "openstack_compute_instance_v2" "login" {
   flavor_name = each.value.flavor
   key_pair = var.key_pair
   config_drive = true
-  security_groups = ["default", "ssh"]
+  security_groups = ["default", "ssh", "HTTPS"]
 
   network {
     uuid = data.openstack_networking_subnet_v2.cluster_subnet.network_id


### PR DESCRIPTION
Open Ondemand is already setup in the `smslabs-example` environment in the `ood` branch. This adds a task to check the OOD server returns 200. Bit complicated due to this requiring a SOCKS proxy to get to.

NB: relies on both:
- #101 
- #155 