### PR TITLE
Fix issue with templating hostvars

### DIFF
--- a/ansible/filter_plugins/utils.py
+++ b/ansible/filter_plugins/utils.py
@@ -9,22 +9,10 @@ import jinja2
 from ansible.module_utils.six import string_types
 import os.path
 
-def _get_hostvar(context, var_name, inventory_hostname=None):
-    if inventory_hostname is None:
-        namespace = context
-    else:
-        if inventory_hostname not in context['hostvars']:
-            raise AnsibleFilterError(
-                "Inventory hostname '%s' not in hostvars" % inventory_hostname)
-        namespace = context["hostvars"][inventory_hostname]
-    return namespace.get(var_name)
-
-@jinja2.contextfilter
-def prometheus_node_exporter_targets(context, hosts):
+def prometheus_node_exporter_targets(hosts, env):
     result = []
     per_env = defaultdict(list)
     for host in hosts:
-        env = _get_hostvar(context, "env", host) or "ungrouped"
         per_env[env].append(host)
     for env, hosts in per_env.items():
         target = {

--- a/environments/common/inventory/group_vars/all/prometheus.yml
+++ b/environments/common/inventory/group_vars/all/prometheus.yml
@@ -13,8 +13,10 @@ prometheus_alert_rules_files:
 
 prometheus_alert_rules: []
 
+# Can set a hostvar 'env' to an arbitrary string to group prometheus targets, e.g. rack.
+# env: location-1
 prometheus_targets:
-  node: "{{ groups.get('node_exporter', []) | reject('equalto', 'localhost') | prometheus_node_exporter_targets }}"
+  node: "{{ groups.get('node_exporter', []) | reject('equalto', 'localhost') | prometheus_node_exporter_targets(env | default('ungrouped')) }}"
 
 prometheus_scrape_configs:
 - job_name: "prometheus"


### PR DESCRIPTION
Currently, this fails:

    ansible all -m debug -a msg="{{ hostvars[inventory_hostname] }}"

whereas this succeeds:

    ansible all -m debug -a msg="{{ <any hostvar> }}"

Turns out this is because of the use of `context['hostvars']` in [this helper](https://github.com/stackhpc/ansible-slurm-appliance/blob/main/ansible/filter_plugins/utils.py#L12) called from the `prometheus_node_exporter_targets` filter [source](https://github.com/stackhpc/ansible-slurm-appliance/blob/main/ansible/filter_plugins/utils.py#L23) used in [environments/common/group_vars/all/prometheus](https://github.com/stackhpc/ansible-slurm-appliance/blob/c7274e91758f8cc10909185acb52185935768653/environments/common/inventory/group_vars/all/prometheus.yml#L16).

The difference is the first one calls for resolving hostvars in the jinja template whereas the second doesn't - presumably this somehow trips up the context as it is required "too early".

The fix is just to pass in the `env` var directly, instead of getting it from hostvars. Results in simpler code too.