### PR TITLE
Allow openondemand group to not exist and validation to still run

### DIFF
--- a/ansible/validate.yml
+++ b/ansible/validate.yml
@@ -59,7 +59,9 @@
     - import_role:
         name: openondemand
         tasks_from: validate.yml
-      when: groups['openondemand'] | length > 0
+      when: 
+        - "'openondemand' in groups"
+        - groups['openondemand'] | length > 0
       tags:
         - openondemand
         - openondemand_server

--- a/ansible/validate.yml
+++ b/ansible/validate.yml
@@ -59,6 +59,13 @@
     - import_role:
         name: openondemand
         tasks_from: validate.yml
+      # This set of tasks will run if there are grafana hosts configured. 
+      # It is a valid configuration to have a grafana group with hosts 
+      # when *not* deploying openondemand. This would mean that openondemand
+      # vars validated in the below task are not set in a way that passes
+      # this set of validation tasks. To ensure that this validation does
+      # not fail with a valid config, only run these tasks when the
+      # openondemand group both exists *and* contains hosts.
       when: 
         - "'openondemand' in groups"
         - groups['openondemand'] | length > 0


### PR DESCRIPTION
The `validate.yml` playbook fails with a keyerror when an `openondemand` group doesn't exist. This adds a further check to ensure that the group does exist before checking to see if it contains any hosts.

Tested and working with Azimuth clusters.