### PR TITLE
Fix SELinux errors when using PAM auth for OOD 

### DIFF
--- a/ansible/roles/openondemand/tasks/pam_auth.yml
+++ b/ansible/roles/openondemand/tasks/pam_auth.yml
@@ -21,4 +21,11 @@
     mode: 0640
     group: apache
 
+- name: Allow httpd access to PAM in SELinux
+  ansible.posix.seboolean:
+    name: httpd_mod_auth_pam
+    state: yes
+    persistent: yes
+  when: ansible_facts.selinux.status == 'enabled'
+
 # TODO: do we need to restart OOD here??


### PR DESCRIPTION
As per docs for [mod_authnz_pam](https://github.com/adelton/mod_authnz_pam) this sets the SElinux boolean `httpd_mod_auth_pam` to prevent errors when apache accesses PAM.

This appeared to be causing log spam + slow OOD dashboard response.