### PR TITLE
By default scrape all the node exporter bits

### DIFF
--- a/environments/common/inventory/group_vars/all/prometheus.yml
+++ b/environments/common/inventory/group_vars/all/prometheus.yml
@@ -40,13 +40,6 @@ prometheus_scrape_configs_default:
     regex:         '(.*):.*'
     target_label:  'instance'
     replacement:   '${1}'
-  params:
-    collect[]:
-      - netdev
-      - cpu
-      - meminfo
-      - infiniband
-      - cpufreq
   scrape_interval: 30s
   scrape_timeout: 20s
 


### PR DESCRIPTION
Currently we are using the reduced set of scrapes we had when polling node exporter every second, this makes the storage bits of the dashboard empty. Instead we really should scrape everything by default, I think.