### PR TITLE
Pin grafana to 8.4.6-1 ...

### DIFF
--- a/environments/common/inventory/group_vars/all/grafana.yml
+++ b/environments/common/inventory/group_vars/all/grafana.yml
@@ -2,6 +2,7 @@
 
 # See: https://github.com/cloudalchemy/ansible-grafana
 # for variable definitions.
+grafana_version: 8.4.6-1
 
 # need to copy some role defaults here so we can use in inventory:
 grafana_port: 3000


### PR DESCRIPTION
8.4.7-1 appears to ignore admin username/password in grafana.ini, which causes

    TASK [grafana-datasources : Ensure datasources exist (via API)]

to fail with:

    Unauthorized to perform action 'POST' on 'http://<control-hostname>:3000/api/user/using/1'


Note this is the only cloudalchemy role which defaults to `latest` for the version:
- prometheus is pinned to 2.27.0 by [cloudalchemy.prometheus](https://github.com/cloudalchemy/ansible-prometheus)
- node_exporter is pinned to 1.1.2 by [cloudlachemy.node_exporter](https://github.com/cloudalchemy/ansible-node-exporter)
- alertmanager is pinned to 0.21.0
- blackbox exporter is pinned to 0.18.0