### PR TITLE
Fix everything layout for OOD groups

### DIFF
--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -39,14 +39,14 @@ cluster
 [basic_users]
 # Add `openhpc` group to add Slurm users via creation of users on each node.
 
-[openondemand]
+[openondemand:children]
 # Host to run Open Ondemand server on - subset of login
 login
 
-[openondemand_desktop]
+[openondemand_desktop:children]
 # Subset of compute to run a interactive desktops on via Open Ondemand
 compute
 
-[openondemand_jupyter]
+[openondemand_jupyter:children]
 # Subset of compute to run a Jupyter Notebook servers on via Open Ondemand
 compute


### PR DESCRIPTION
The open ondemand groups in the everything layout are wrong, giving an ansible warning that there are both hosts and groups called `login` and `compute`.

Not spotted before as we don't use a the everything layout (which is used by cookiecutter) in the smslabs - perhaps we should.