### PR TITLE
Fix openondemand_servername default

### DIFF
--- a/environments/common/inventory/group_vars/all/grafana.yml
+++ b/environments/common/inventory/group_vars/all/grafana.yml
@@ -14,7 +14,7 @@ grafana_api_url: "http://{{ grafana_api_address }}:{{ grafana_port }}"
 # Configure external address, with external URL depending on whether we are using Open Ondemand as a proxy
 grafana_address: "{{ hostvars[groups['grafana'].0].api_address }}"
 grafana_url_direct: "http://{{ grafana_address }}:{{ grafana_port }}"
-grafana_url_openondemand_proxy: "https://{{ openondemand_servername }}/node/{{ groups['grafana'].0 }}/{{ grafana_port }}"
+grafana_url_openondemand_proxy: "https://{{ openondemand_servername | default('') }}/node/{{ groups['grafana'].0 }}/{{ grafana_port }}"
 grafana_url: "{{ grafana_url_openondemand_proxy if groups['openondemand'] | count > 0 else grafana_url_direct }}"
 grafana_serve_from_sub_path: "{{ groups['openondemand'] | count > 0 }}"
 

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -5,7 +5,7 @@
 
 # NB: Variables prefixed ood_ are all from https://github.com/OSC/ood-ansible
 
-openondemand_servername: '' # Must be changed when using openondemand, but allows templating when openondemand group is empty
+# openondemand_servername: '' # Must be defined when using openondemand
 
 openondemand_dashboard_links: # TODO: should really only be deployed if grafana is deployed and proxying configured
   - name: Grafana


### PR DESCRIPTION
Currently `openondemand_servername` is set to `''` in `common/all/group_vars` to permit templating on grafana host even when openondemand is not configured.

However setting it here means it can't[^1] be overriden by the `[all:vars]` section in an environment's (TF-templated) `inventory/hosts` file, which is the natural place to define it given it a) depends on infrastructure, at least when it is a FIP rather than a fully-qualified hostname and b) needs to be defined on at least the ood and grafana hosts.  

This PR removes it from group_vars/all and fixes templating to cope with the fact it may be undefined.

[^1]: The relevant [precedence rules](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) are items 3. and 4.