### PR TITLE
remove unnecessary fail2ban_cluster_subnet from environments

### DIFF
--- a/environments/smslabs/inventory/group_vars/fail2ban/overrides.yml
+++ b/environments/smslabs/inventory/group_vars/fail2ban/overrides.yml
@@ -1,1 +1,0 @@
-fail2ban_cluster_subnet: "{{ cluster_subnet_cidr }}"

--- a/environments/smslabs/terraform/inventory.tpl
+++ b/environments/smslabs/terraform/inventory.tpl
@@ -1,7 +1,6 @@
 [all:vars]
 ansible_user=rocky
 openhpc_cluster_name=${cluster_name}
-cluster_subnet_cidr=${subnet.cidr}
 
 [control]
 ${control.name} ansible_host=${[for n in control.network: n.fixed_ip_v4 if n.access_network][0]} server_networks='${jsonencode({for net in control.network: net.name => [ net.fixed_ip_v4 ] })}'

--- a/environments/vagrant-example/inventory/group_vars/fail2ban/overrides.yml
+++ b/environments/vagrant-example/inventory/group_vars/fail2ban/overrides.yml
@@ -1,1 +1,0 @@
-fail2ban_cluster_subnet: 192.168.0.0/16 # see `private_network` in environments/vagrant-example/vagrant/Vagrantfile


### PR DESCRIPTION
Earlier versions of fail2ban config required definition of `fail2ban_cluster_subnet` - final PR doesn't so can remove from environments.