### PR TITLE
Bump grafana to 8.5.1

### DIFF
--- a/ansible/roles/firewalld/handlers/main.yml
+++ b/ansible/roles/firewalld/handlers/main.yml
@@ -3,4 +3,4 @@
   service:
     name: firewalld
     state: restarted
-  when: "{{ firewalld_state != 'stopped' }}"
+  when: firewalld_state != 'stopped'

--- a/environments/common/inventory/group_vars/all/grafana.yml
+++ b/environments/common/inventory/group_vars/all/grafana.yml
@@ -2,7 +2,7 @@
 
 # See: https://github.com/cloudalchemy/ansible-grafana
 # for variable definitions.
-grafana_version: 8.4.6-1
+grafana_version: 8.5.1
 
 # need to copy some role defaults here so we can use in inventory:
 grafana_port: 3000

--- a/environments/smslabs/terraform/variables.tf
+++ b/environments/smslabs/terraform/variables.tf
@@ -26,7 +26,7 @@ variable "control_node" {
     description = "Mapping {flavor: flavor_name, image: image_name_or_id }"
     default = {
         flavor: "general.v1.tiny"
-        image: "openhpc-220413-1545.qcow2"
+        image: "openhpc-220429-1537.qcow2"
     }
 }
 
@@ -36,7 +36,7 @@ variable "login_nodes" {
   default = {
       login-0: {
         flavor: "general.v1.tiny"
-        image: "openhpc-220413-1545.qcow2"
+        image: "openhpc-220429-1537.qcow2"
       }
     }
 }
@@ -47,7 +47,7 @@ variable "compute_types" {
     default = {
       small: {
           flavor: "general.v1.tiny"
-          image: "openhpc-220413-1545.qcow2"
+          image: "openhpc-220429-1537.qcow2"
       }
     }
 }

--- a/environments/smslabs/terraform/variables.tf
+++ b/environments/smslabs/terraform/variables.tf
@@ -26,7 +26,7 @@ variable "control_node" {
     description = "Mapping {flavor: flavor_name, image: image_name_or_id }"
     default = {
         flavor: "general.v1.tiny"
-        image: "openhpc-220429-1537.qcow2"
+        image: "openhpc-220504-0904.qcow2"
     }
 }
 
@@ -36,7 +36,7 @@ variable "login_nodes" {
   default = {
       login-0: {
         flavor: "general.v1.tiny"
-        image: "openhpc-220429-1537.qcow2"
+        image: "openhpc-220504-0904.qcow2"
       }
     }
 }
@@ -47,7 +47,7 @@ variable "compute_types" {
     default = {
       small: {
           flavor: "general.v1.tiny"
-          image: "openhpc-220429-1537.qcow2"
+          image: "openhpc-220504-0904.qcow2"
       }
     }
 }


### PR DESCRIPTION
Updates grafana to 8.5.1. This has been tested (with direct configuration) as fixing #172. Note the base image is updated as well - see https://github.com/stackhpc/slurm_image_builder/releases/tag/untagged-cc9bc550ae9e67e808c6