### PR TITLE
Disable screen locking on OOD desktop sessions

### DIFF
--- a/ansible/roles/openondemand/README.md
+++ b/ansible/roles/openondemand/README.md
@@ -60,6 +60,7 @@ This role enables SSL on the Open Ondemand server, using the following self-sign
     - `app_name`: Optional. Unique name for app appended to `/var/www/ood/apps/sys/`. Default is `name`, useful if that is not unique or not suitable as a path component.
 - `openondemand_dashboard_support_url`: Optional. URL or email etc to show as support contact under Help in dashboard. Default `(undefined)`.
 - `openondemand_desktop_partition`: Optional. Name of Slurm partition to use for remote desktops. Requires a corresponding group named "openondemand_desktop" and entry in openhpc_slurm_partitions.
+- `openondemand_desktop_screensaver`: Optional. Whether to enable screen locking/screensaver. **NB:** Users must have passwords if this is enabled. Bool, default `false`.
 - `openondemand_filesapp_paths`: List of paths (in addition to $HOME, which is always added) to include shortcuts to within the Files dashboard app.
 - `openondemand_jupyter_partition`: Required. Name of Slurm partition to use for Jupyter Notebook servers. Requires a corresponding group named "openondemand_jupyter" and entry in openhpc_slurm_partitions.
 

--- a/ansible/roles/openondemand/defaults/main.yml
+++ b/ansible/roles/openondemand/defaults/main.yml
@@ -20,6 +20,7 @@ openondemand_ssl_cert_key: /etc/pki/tls/private/localhost.key
 openondemand_dashboard_docs_url: (undefined)
 openondemand_dashboard_support_url: (undefined)
 openondemand_desktop_partition: ''
+openondemand_desktop_screensaver: false
 openondemand_filesapp_paths: []
 openondemand_jupyter_partition: ''
 openondemand_dashboard_links: []

--- a/ansible/roles/openondemand/tasks/vnc_compute.yml
+++ b/ansible/roles/openondemand/tasks/vnc_compute.yml
@@ -45,6 +45,7 @@
     state: link
 
 - name: Disable screensaver # as users might not have passwords
-  file:
-    path: /etc/xdg/autostart/xfce4-screensaver.desktop 
+  yum:
+    name: xfce4-screensaver
     state: absent
+  when: not (openondemand_desktop_screensaver | bool)


### PR DESCRIPTION
Fixes #167 . Note this also makes the disabling optional.