### PR TITLE
Configuration of slurm-driven rebuild is now idempotent

### DIFF
--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -9,15 +9,6 @@
     - include_role:
         name:  geerlingguy.mysql
 
-- name: Setup slurm
-  hosts: openhpc
-  become: yes
-  tags:
-    - openhpc
-  tasks:
-    - import_role:
-        name: stackhpc.openhpc
-
 - name: Setup slurm-driven reimage
   hosts: rebuild
   become: yes
@@ -27,6 +18,15 @@
   tasks:
     - import_role:
         name: stackhpc.slurm_openstack_tools.rebuild
+
+- name: Setup slurm
+  hosts: openhpc
+  become: yes
+  tags:
+    - openhpc
+  tasks:
+    - import_role:
+        name: stackhpc.openhpc
 
 - name: Set locked memory limits on user-facing nodes
   hosts:

--- a/requirements.yml
+++ b/requirements.yml
@@ -31,5 +31,5 @@ collections:
 - name: community.grafana
 - name: https://github.com/stackhpc/ansible_collection_slurm_openstack_tools
   type: git
-  version: v0.1.0
+  version: v0.2.0
 ...


### PR DESCRIPTION
[DEV-871](https://stackhpc.atlassian.net/browse/DEV-871)

Currently configuration for rebuilding compute nodes using slurm is done by modifying slurm.conf after running the openhpc role. However this means running `ansible/slurm.yml` on an existing cluster changes slurm.conf twice which triggers a restart of all slurm daemons, even if the actual configuration hasn't changed.

v0.2 of `stackhpc/ansible_collection_slurm_openstack_tools` [added support](https://github.com/stackhpc/ansible_collection_slurm_openstack_tools/releases/tag/v0.2.0) for making this idempotent by merging the additional slurm parameters needed for rebuild configuration into the `openhpc` role's `openhpc_config` variable.

This PR uses that new slurm openstack tools version and reorders slurm.conf to take advantage of it.

Test deployment: arcus:/home/rocky/slurm-app-rebuild