### PR TITLE
fix grafana dashboards for grafana admin user

### DIFF
--- a/ansible/roles/openondemand/defaults/main.yml
+++ b/ansible/roles/openondemand/defaults/main.yml
@@ -53,6 +53,7 @@ openondemand_auth_defaults:
     httpd_auth: # ood_portal.yml.j2
       - 'AuthType openid-connect'
       - 'Require valid-user'
+      - 'ProxyPreserveHost On' # see under https://grafana.com/blog/2022/02/08/grafana-7.5.15-and-8.3.5-released-with-moderate-severity-security-fixes/
     user_map_cmd: /opt/ood/ood_auth_map/bin/ood_auth_map.mapfile
     user_map_match: none
   
@@ -64,6 +65,7 @@ openondemand_auth_defaults:
       - 'AuthBasicProvider PAM'
       - 'AuthPAMService ood'
       - 'Require valid-user'
+      - 'ProxyPreserveHost On' # see under https://grafana.com/blog/2022/02/08/grafana-7.5.15-and-8.3.5-released-with-moderate-severity-security-fixes/
     user_map_cmd: null
     user_map_match: '.*'
 


### PR DESCRIPTION
[DEV-918](https://stackhpc.atlassian.net/browse/DEV-918)

When logging in as grafana admin user, dashboards show `origin not allowed` for elasticsearch datasource. This did not used to be a problem so presumably has arisen when bumping grafana versions previously.

Using the fix for proxying described [under CSRF here](https://grafana.com/blog/2022/02/08/grafana-7.5.15-and-8.3.5-released-with-moderate-severity-security-fixes/) fixes this, although it's not clear entirely why it was only a problem for the admin user.

Note the proxying fix is done in the OOD `httpd_auth` config - the name of this variable isn't entirely appropriate but that is the only one OOD provides for affecting the proxy config.

Tested in `arcus` environment using both the normal `basic_user`-deployed `testuser` and the grafana admin user.