### PR TITLE
Bump image to openhpc-220526-1354.qcow2 (RL8.6)

### DIFF
--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-220413-1545.qcow2"
+source_image_name = "openhpc-220526-1354.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]
 ssh_bastion_host = "128.232.222.183"

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -18,18 +18,18 @@ module "cluster" {
     key_pair = "slurm-app-ci"
     control_node = {
         flavor: "vm.alaska.cpu.general.small"
-        image: "openhpc-220504-0904.qcow2"
+        image: "openhpc-220526-1354.qcow2"
     }
     login_nodes = {
         login-0: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-220504-0904.qcow2"
+            image: "openhpc-220526-1354.qcow2"
         }
     }
     compute_types = {
         small: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-220504-0904.qcow2"
+            image: "openhpc-220526-1354.qcow2"
         }
     }
     compute_nodes = {


### PR DESCRIPTION
Bumps image to `openhpc-220526-1354.qcow2`
- Image built on arcus and available in s3
- RockyLinux 8.6.
- 