### PR TITLE
Fix CI failure on podman deploy due to Ansible versions & others

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -1,6 +1,7 @@
 
 name: Test deployment and image build on OpenStack
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ It is recommended to check the following before starting:
 
 ## Installation on deployment host
 
-These instructions assume the deployment host is running Centos/Rocky 8:
+These instructions assume the deployment host is running Rocky Linux 8:
 
-    sudo yum install -y git python3
+    sudo yum install -y git python38
     git clone https://github.com/stackhpc/ansible-slurm-appliance
     cd ansible-slurm-appliance
-    python3 -m venv venv
+    /usr/bin/python3.8 -m venv venv
     . venv/bin/activate
     pip install -U pip
     pip install -r requirements.txt

--- a/ansible/roles/hpctests/library/hpl_pq.py
+++ b/ansible/roles/hpctests/library/hpl_pq.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (c) 2020, StackHPC
 # Apache 2 License

--- a/ansible/roles/hpctests/library/plot_nxnlatbw.py
+++ b/ansible/roles/hpctests/library/plot_nxnlatbw.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (c) 2020, StackHPC
 # Apache 2 License

--- a/ansible/roles/hpctests/library/read_imb_pingpong.py
+++ b/ansible/roles/hpctests/library/read_imb_pingpong.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (c) 2020, StackHPC
 # Apache 2 License

--- a/ansible/roles/hpctests/library/slurm_node_info.py
+++ b/ansible/roles/hpctests/library/slurm_node_info.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (c) 2020, StackHPC
 # Apache 2 License

--- a/ansible/roles/podman/tasks/config.yml
+++ b/ansible/roles/podman/tasks/config.yml
@@ -20,6 +20,7 @@
   user: "{{ item }}"
   with_items: "{{ podman_users }}"
   register: podman_user_info
+  become: yes
 
 - name: Define tmp directories on tmpfs
   blockinfile:

--- a/dev/setup-env.sh
+++ b/dev/setup-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-python3 -m venv venv
+/usr/bin/python3.8 -m venv venv # use `sudo yum install python38` on Rocky Linux 8 to install this
 . venv/bin/activate
 pip install -U pip
 pip install -r requirements.txt

--- a/dev/setup-env.sh
+++ b/dev/setup-env.sh
@@ -4,6 +4,7 @@ python3 -m venv venv
 . venv/bin/activate
 pip install -U pip
 pip install -r requirements.txt
+ansible --version
 # Install ansible dependencies ...
 ansible-galaxy role install -r requirements.yml -p ansible/roles
 ansible-galaxy collection install -r requirements.yml -p ansible/collections

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-220413-1545.qcow2"
+source_image_name = "openhpc-220504-0904.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]
 ssh_bastion_host = "128.232.222.183"

--- a/environments/smslabs/builder.pkrvars.hcl
+++ b/environments/smslabs/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "general.v1.tiny"
 networks = ["c245901d-6b84-4dc4-b02b-eec0fb6122b2"] # stackhpc-ci-geneve
-source_image_name = "openhpc-220413-1545.qcow2"
+source_image_name = "openhpc-220504-0904.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]
 ssh_bastion_host = "185.45.78.150"

--- a/environments/smslabs/hooks/pre.yml
+++ b/environments/smslabs/hooks/pre.yml
@@ -16,3 +16,17 @@
       register: packer_run
       async: 2700 # 45 minutes
       poll: 0
+
+- hosts: all
+  become: true
+  tags: etc_hosts
+  tasks:
+    - name: Create /etc/hosts for all nodes as DNS doesn't work
+      blockinfile:
+        path: /etc/hosts
+        create: yes
+        state: present
+        block: |
+          {% for hostname in groups['all'] %}
+          {{ hostvars[hostname]['ansible_host'] }} {{ hostname }}
+          {% endfor %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-ansible>=2.9.0
-os-client-config
-openstacksdk
-python-openstackclient
-jmespath
-passlib[bcrypt]
-cookiecutter
-vagranttoansible
-selinux # this is a shim to avoid having to use --system-site-packages, you still need sudo yum install libselinux-python3
-netaddr
+ansible==4.10.0
+os-client-config==2.1.0
+openstacksdk==0.99.0
+python-openstackclient==5.8.0
+jmespath==0.10.0
+passlib[bcrypt]==1.7.4
+cookiecutter==1.7.3
+selinux==0.2.1 # this is a shim to avoid having to use --system-site-packages, you still need sudo yum install libselinux-python3
+netaddr==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-ansible==4.10.0
-os-client-config==2.1.0
-openstacksdk==0.99.0
-python-openstackclient==5.8.0
-jmespath==0.10.0
+ansible==6.0.0
+openstacksdk
+python-openstackclient
+jmespath
 passlib[bcrypt]==1.7.4
-cookiecutter==1.7.3
-selinux==0.2.1 # this is a shim to avoid having to use --system-site-packages, you still need sudo yum install libselinux-python3
-netaddr==0.8.0
+cookiecutter
+selinux # this is a shim to avoid having to use --system-site-packages, you still need sudo yum install libselinux-python3
+netaddr


### PR DESCRIPTION
CI was failing when working on #189 with a podman permission denied error (see details below). This was due to CI's Ubuntu having python 3.8 and therefore getting a newer version of python which seems to behave differently. Fixed by:
- Using Python 3.8 on both Rocky Linux and Ubuntu, which gives ansible core 2.13.1 on both.
- Adding a missing `become: yes` to the failing task - this is a no-op anyway but fails without `become` under 2.13.1.

Subsequent discoveries:
- DNS broken on SMS-labs, not expected to be fixed soon. Fixed by templating /etc/hosts on SMS-labs
- `hpctests` modules failing due to incorrect shebang; presumably due to [change in python interpreter detection](https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery) in 2.12. Fixed by using [documented module shebang](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#python-shebang-utf-8-coding).


## Podman error details

This only occurred in CI and not when running manually on sms-labs.

Error:
```
TASK [podman : Ensure podman users exist] **************************************
task path: /home/runner/work/ansible-slurm-appliance/ansible-slurm-appliance/ansible/roles/podman/tasks/config.yml:19
[WARNING]: Using a variable for a task's 'args' is unsafe in some situations
(see
https://docs.ansible.com/ansible/devel/reference_appendices/faq.html#argsplat-
unsafe)
failed: [ci2588470616-control] (item={'name': 'podman', 'comment': 'Used for running all containers', 'home': '/var/lib/podman'}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "comment": "Used for running all containers",
        "home": "/var/lib/podman",
        "name": "podman"
    },
    "rc": 1
}
MSG:
MODULE FAILURE
See stdout/stderr for the exact error
MODULE_STDERR:
Warning: Permanently added '10.20.1.76' (ECDSA) to the list of known hosts.
Traceback (most recent call last):
  File "<stdin>", line 107, in <module>
  File "<stdin>", line 99, in _ansiballz_main
  File "<stdin>", line 48, in invoke_module
  File "/usr/lib64/python3.6/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_user_payload_1qj0p5k_/ansible_user_payload.zip/ansible/modules/user.py", line 3221, in <module>
  File "/tmp/ansible_user_payload_1qj0p5k_/ansible_user_payload.zip/ansible/modules/user.py", line 3207, in main
  File "/tmp/ansible_user_payload_1qj0p5k_/ansible_user_payload.zip/ansible/modules/user.py", line 1055, in set_password_expire
PermissionError: [Errno 13] Permission denied
```

CI was on `ansible-6.0.0` (pip version) whereas latest available on RockyLinux is 4.10. This gives ansible core versions of 2.13 and 2.11 respectively. Not sure on collection versions.