### PR TITLE
Use volume-backed instances for smslabs

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/images.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/images.tf
@@ -1,0 +1,5 @@
+data "openstack_images_image_v2" "nodes" {
+  for_each = var.image_names
+  
+  name = each.value
+}

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
@@ -48,14 +48,16 @@ resource "openstack_compute_instance_v2" "control" {
     access_network = true
   }
 
-  # volume-backed instance:
-  block_device {
-    boot_index = 0
-    source_type = "image"
-    uuid = data.openstack_images_image_v2.nodes[lookup(var.image_names, "control", "default")].id
-    destination_type = "volume"
-    volume_size = data.openstack_images_image_v2.nodes[lookup(var.image_names, "control", "default")].min_disk_gb
-    delete_on_termination = true
+  dynamic "block_device" {
+    for_each = toset(true ? [1] : [])
+    content {
+      boot_index = 0
+      source_type = "image"
+      uuid = data.openstack_images_image_v2.nodes[lookup(var.image_names, "control", "default")].id
+      destination_type = "volume"
+      volume_size = data.openstack_images_image_v2.nodes[lookup(var.image_names, "control", "default")].min_disk_gb
+      delete_on_termination = true
+    }
   }
 
   metadata = {
@@ -78,14 +80,16 @@ resource "openstack_compute_instance_v2" "login" {
     access_network = true
   }
 
-  # volume-backed instance:
-  block_device {
-    boot_index = 0
-    source_type = "image"
-    uuid = data.openstack_images_image_v2.nodes[lookup(var.image_names, each.key, "default")].id
-    destination_type = "volume"
-    volume_size = data.openstack_images_image_v2.nodes[lookup(var.image_names, each.key, "default")].min_disk_gb
-    delete_on_termination = true
+  dynamic "block_device" {
+    for_each = toset(true ? [1] : [])
+    content {
+      boot_index = 0
+      source_type = "image"
+      uuid = data.openstack_images_image_v2.nodes[lookup(var.image_names, each.key, "default")].id
+      destination_type = "volume"
+      volume_size = data.openstack_images_image_v2.nodes[lookup(var.image_names, each.key, "default")].min_disk_gb
+      delete_on_termination = true
+    }
   }
 
   metadata = {
@@ -108,14 +112,16 @@ resource "openstack_compute_instance_v2" "compute" {
     access_network = true
   }
 
-  # volume-backed instance:
-  block_device {
-    boot_index = 0
-    source_type = "image"
-    uuid = data.openstack_images_image_v2.nodes[lookup(var.image_names, each.key, "default")].id
-    destination_type = "volume"
-    volume_size = data.openstack_images_image_v2.nodes[lookup(var.image_names, each.key, "default")].min_disk_gb
-    delete_on_termination = true
+  dynamic "block_device" {
+    for_each = toset(true ? [1] : [])
+    content {
+      boot_index = 0
+      source_type = "image"
+      uuid = data.openstack_images_image_v2.nodes[lookup(var.image_names, each.key, "default")].id
+      destination_type = "volume"
+      volume_size = data.openstack_images_image_v2.nodes[lookup(var.image_names, each.key, "default")].min_disk_gb
+      delete_on_termination = true
+    }
   }
 
   metadata = {

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
@@ -43,6 +43,12 @@ variable "image_names" {
     description = "Mapping defining images: key -> 'default' (must exist) or nodename suffix, value -> name of image (must exist in OpenStack)"
 }
 
+variable "volume_backed_instances" {
+    type = bool
+    description = "Whether instance root disks are on volumes or local disk"
+    default = false
+}
+
 variable "environment_root" {
     type = string
     description = "Path to environment root, automatically set by activate script"

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
@@ -18,19 +18,19 @@ variable "key_pair" {
     description = "Name of an existing keypair in OpenStack"
 }
 
-variable "control_node" {
-    type = map
-    description = "Mapping {flavor: flavor_name, image: image_name_or_id }"
+variable "control_node_flavor" {
+    type = string
+    description = "Name of flavor for control node"
 }
 
-variable "login_nodes" {
-  type = map
-  description = "Mapping defining login nodes: key -> (str) nodename suffix, value -> mapping  {flavor: flavor_name, image: image_name_or_id }"
+variable "login_node_flavors" {
+  type = map(string)
+  description = "Mapping defining login nodes: key -> nodename suffix, value -> flavor name"
 }
 
 variable "compute_types" {
-    type = map
-    description = "Mapping defining types of compute nodes: key -> (str) name of type, value -> mapping {flavor: flavor_name, image: image_name_or_id }"
+    type = map(string)
+    description = "Mapping defining *types* of compute nodes: key -> name of type, value -> flavor name"
 }
 
 variable "compute_nodes" {
@@ -38,10 +38,9 @@ variable "compute_nodes" {
     description = "Mapping of compute nodename suffix -> key in compute_types"
 }
 
-variable "compute_images" {
+variable "image_names" {
     type = map(string)
-    default = {}
-    description = "Mapping to override compute images from compute_types: key ->(str) node name, value -> (str) image name"
+    description = "Mapping defining images: key -> 'default' (must exist) or nodename suffix, value -> name of image (must exist in OpenStack)"
 }
 
 variable "environment_root" {

--- a/environments/smslabs/terraform/main.tf
+++ b/environments/smslabs/terraform/main.tf
@@ -19,21 +19,15 @@ module "cluster" {
         "SSH", # enable ansible, as bastion does not have same default security group as nodes
     ]
     key_pair = "slurm-app-ci"
-    control_node = {
-        flavor: "general.v1.small"
-        image: "openhpc-220526-1354.qcow2"
+    image_names = {
+        default = "openhpc-220526-1354.raw"
     }
-    login_nodes = {
-        login-0: {
-          flavor: "general.v1.small"
-          image: "openhpc-220526-1354.qcow2"
-        }
+    control_node_flavor = "general.v1.small"
+    login_node_flavors = {
+        login-0: "general.v1.small"
     }
     compute_types = {
-        small: {
-            flavor: "general.v1.small"
-            image: "openhpc-220526-1354.qcow2"
-        }
+        small: "general.v1.small"
     }
     compute_nodes = {
         compute-0: "small"

--- a/environments/smslabs/terraform/main.tf
+++ b/environments/smslabs/terraform/main.tf
@@ -22,6 +22,7 @@ module "cluster" {
     image_names = {
         default = "openhpc-220526-1354.raw"
     }
+    volume_backed_instances = true
     control_node_flavor = "general.v1.small"
     login_node_flavors = {
         login-0: "general.v1.small"


### PR DESCRIPTION
Currently CI on smslabs is flaky due to a lack of disk capacity for VMs. This PR adds a variable to the skeleton terraform `volume_backed_instances` which is set to `true` in `smslabs` to use volume-backed instances.

However this also requires the use of `raw`-format images (otherwise glance times out when launching >1 instance). So the image also needs to be converted from the arcus-built `qcow2` image.