### PR TITLE
Fix packer build defaults

### DIFF
--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -42,6 +42,7 @@ variable "ssh_keypair_name" {
 
 variable "security_groups" {
   type = list(string)
+  default = []
 }
 
 variable "image_visibility" {
@@ -51,10 +52,12 @@ variable "image_visibility" {
 
 variable "ssh_bastion_host" {
   type = string
+  default = ""
 }
 
 variable "ssh_bastion_username" {
   type = string
+  default = ""
 }
 
 variable "ssh_bastion_private_key_file" {


### PR DESCRIPTION
The packer build contains some variables used to proxy through a jumphost - this is unlikely to be needed for real site deployments but is required for CI. This PR adds defaults so that the packer build works when these aren't set.

This is a cherry pick from NREL