### PR TITLE
update stackhpc.openhpc now nodename padding fixed

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - src: stackhpc.nfs
     version: v21.2.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v0.13.0
+    version: v0.16.0
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: feature/no-install


### PR DESCRIPTION
Bump `stackhpc.openhpc` role version for [Fix slurm.conf inventory filtering for nodenames with padding](https://github.com/stackhpc/ansible-role-openhpc/pull/143)