### PR TITLE
Fix containerised services with persistent state

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -74,6 +74,20 @@
     - import_role:
         name: fail2ban
 
+- name: Setup podman
+  hosts: podman
+  tags: podman
+  tasks:
+    - import_role:
+        name: podman
+        tasks_from: prereqs.yml
+      tags: prereqs
+
+    - import_role:
+        name: podman
+        tasks_from: config.yml
+      tags: config
+
 - hosts: update
   gather_facts: false
   become: yes

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -1,20 +1,6 @@
 # ---
 # # NOTE: Requires slurmdbd
 
-- name: Setup podman
-  hosts: podman
-  tags: podman
-  tasks:
-    - import_role:
-        name: podman
-        tasks_from: prereqs.yml
-      tags: prereqs
-
-    - import_role:
-        name: podman
-        tasks_from: config.yml
-      tags: config
-
 - name: Setup elasticsearch
   hosts: opendistro
   tags: opendistro

--- a/ansible/roles/mysql/tasks/configure.yml
+++ b/ansible/roles/mysql/tasks/configure.yml
@@ -24,7 +24,7 @@
     # no_log: true # TODO: FIXME
     register: _mysql_info
     until: "'version' in _mysql_info"
-    retries: 60
+    retries: 90
     delay: 2
 
   - name: Ensure mysql databases created

--- a/ansible/roles/mysql/templates/mysql.service.j2
+++ b/ansible/roles/mysql/templates/mysql.service.j2
@@ -13,6 +13,7 @@ Restart=always
 EnvironmentFile=/etc/sysconfig/mysqld
 # The above EnvironmentFile must define MYSQL_INITIAL_ROOT_PASSWORD
 ExecStartPre=+install -d -o {{ mysql_podman_user }} -g {{ mysql_podman_user }} -Z container_file_t {{ mysql_datadir }}
+ExecStartPre=+chown -R {{ mysql_podman_user }}:{{ mysql_podman_user }} {{ mysql_datadir }}
 ExecStart=/usr/bin/podman run \
     --network slirp4netns:cidr={{ podman_cidr }} \
     --sdnotify=conmon --cgroups=no-conmon \

--- a/ansible/roles/opendistro/templates/opendistro.service.j2
+++ b/ansible/roles/opendistro/templates/opendistro.service.j2
@@ -10,6 +10,7 @@ After=network-online.target
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=always
 ExecStartPre=+install -d -o {{ opendistro_podman_user }} -g {{ opendistro_podman_user }} -Z container_file_t {{ opendistro_data_path }}
+ExecStartPre=+chown -R {{ opendistro_podman_user }}:{{ opendistro_podman_user }} {{ opendistro_data_path }}
 ExecStart=/usr/bin/podman run \
     --network slirp4netns:cidr={{ podman_cidr }} \
     --sdnotify=conmon --cgroups=no-conmon \


### PR DESCRIPTION
mysql failed to start after reimaging control node in CI for another PR with:

```
Sep 26 15:20:53 ci3128353938-control podman[7546]: Error: failed to chown recursively host path: lchown /var/lib/state/mysql/#ib_16384_0.dblwr: operation not permitted
```

Relevant bits of service unitfile at the time:
```
ExecStartPre=+install -d -o {{ mysql_podman_user }} -g {{ mysql_podman_user }} -Z container_file_t {{ mysql_datadir }}
ExecStart=/usr/bin/podman run \
...
    --user mysql \
    --volume {{ mysql_datadir }}:/var/lib/mysql:U \
...
User={{ mysql_podman_user }}
```

Note that:
- podman is running rootless, as user `mysql_podman_user` = `podman`. So `root` in container is `podman` on host
- the container user is `mysql`
- the `U` flag is passed to the volume mount to recursively chown the host dir to the container user

Looking at host permissions showed:
```
[root@ci3128353938-control rocky]# id podman
uid=1001(podman) gid=1001(podman) groups=1001(podman)
[root@ci3128353938-control rocky]# ls -l /var/lib/state/mysql/
total 88284
-rw-r-----. 1 232070 232070       56 Sep 26 14:20  auto.cnf
...
-rw-r--r--. 1 232070 232070     1112 Sep 26 14:21  client-cert.pem
-rw-------. 1 232070 232070     1676 Sep 26 14:21  client-key.pem
-rw-r-----. 1 232070 232070   589824 Sep 26 15:15 '#ib_16384_0.dblwr'
-rw-r-----. 1 232070 232070  8978432 Sep 26 14:20 '#ib_16384_1.dblwr'
...
```

I ran the `install` command from the `ExecStartPre` directly, and it is a no-op in this case - doesn't fail, but doesn't change permissions (NB `install` is used rather than `mkdir -p` as the latter only sets owner/group/mode on the LAST directory).

So I suspect that under some circumstances the in-container user after a reimage is not the same it was before the reimage. I investigated the `--uidmap` etc options but it was hard to understand if these could guarantee the in-container UID/GID, for a rootless case.

So this adds a `chown -R` to ExecStart (as root, using `+`) to ensure that the `podman` user owns the directory before starting the container (which then chown it to the in-container `mysql` user.

Also does the same for opendistro, which is the only other container with persistent storage.

---

Also the `mysql` role requires the `podman` role so the latter has been moved earlier (probably works in CI due to using the "fat" image which has podman already installed).
