### PR TITLE
Provide /etc/hosts templating via cloud-init

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -68,11 +68,11 @@ jobs:
           . venv/bin/activate
           . environments/${{ matrix.cloud }}/activate
           ansible-playbook ansible/adhoc/generate-passwords.yml
-          echo test_user_password: "$TEST_USER_PASSWORD" > $APPLIANCES_ENVIRONMENT_ROOT/inventory/group_vars/all/test_user.yml
+          echo vault_testuser_password: "$TESTUSER_PASSWORD" > $APPLIANCES_ENVIRONMENT_ROOT/inventory/group_vars/all/test_user.yml
           ansible-playbook ansible/adhoc/template-cloud-init.yml
         env:
           ANSIBLE_FORCE_COLOR: True
-          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+          TESTUSER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
 
       - name: Provision servers
         id: provision_servers
@@ -154,24 +154,24 @@ jobs:
             --server-response \
             --no-check-certificate \
             --http-user=testuser \
-            --http-password=${TEST_USER_PASSWORD} https://${openondemand_servername} \
+            --http-password=${TESTUSER_PASSWORD} https://${openondemand_servername} \
             2>&1)
           (echo $statuscode | grep "200 OK") || (echo $statuscode  && exit 1)
         env:
-          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+          TESTUSER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
 
       - name: Build packer images
         run: |
           . venv/bin/activate
           . environments/${{ matrix.cloud }}/activate
           ansible-playbook ansible/adhoc/generate-passwords.yml
-          echo test_user_password: "$TEST_USER_PASSWORD" > $APPLIANCES_ENVIRONMENT_ROOT/inventory/group_vars/all/test_user.yml
+          echo vault_testuser_password: "$TESTUSER_PASSWORD" > $APPLIANCES_ENVIRONMENT_ROOT/inventory/group_vars/all/test_user.yml
           cd packer/
           PACKER_LOG=1 packer build -on-error=ask -var-file=$PKR_VAR_environment_root/builder.pkrvars.hcl openstack.pkr.hcl
         env:
           OS_CLOUD: openstack
           ANSIBLE_FORCE_COLOR: True
-          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+          TESTUSER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
 
       - name: Test reimage of nodes
         run: |

--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -14,7 +14,7 @@ jobs:
         cloud:
           - "arcus"   # Arcus OpenStack in rcp-cloud-portal-demo project, with RoCE
       fail-fast: false # as want clouds to continue independently
-    concurrency: ${{ matrix.cloud }}
+    concurrency: ${{ github.ref }} # to branch/PR
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -52,8 +52,30 @@ jobs:
           smslabs_CLOUDS_YAML: ${{ secrets.CLOUDS_YAML }}
           arcus_CLOUDS_YAML: ${{ secrets.ARCUS_CLOUDS_YAML }}
       
-      - name: Provision infrastructure
-        id: provision
+      - name: Provision ports, inventory and other infrastructure apart from nodes
+        id: provision_ports
+        run: |
+          . venv/bin/activate
+          . environments/${{ matrix.cloud }}/activate
+          cd $APPLIANCES_ENVIRONMENT_ROOT/terraform
+          TF_VAR_create_nodes=false terraform apply -auto-approve
+        env:
+          OS_CLOUD: openstack
+          TF_VAR_cluster_name: ci${{ github.run_id }}
+      
+      - name: Setup environment-specific inventory/terraform inputs
+        run: |
+          . venv/bin/activate
+          . environments/${{ matrix.cloud }}/activate
+          ansible-playbook ansible/adhoc/generate-passwords.yml
+          echo test_user_password: "$TEST_USER_PASSWORD" > $APPLIANCES_ENVIRONMENT_ROOT/inventory/group_vars/all/test_user.yml
+          ansible-playbook ansible/adhoc/template-cloud-init.yml
+        env:
+          ANSIBLE_FORCE_COLOR: True
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+
+      - name: Provision servers
+        id: provision_servers
         run: |
           . venv/bin/activate
           . environments/${{ matrix.cloud }}/activate
@@ -62,7 +84,7 @@ jobs:
         env:
           OS_CLOUD: openstack
           TF_VAR_cluster_name: ci${{ github.run_id }}
-      
+
       - name: Get server provisioning failure messages
         id: provision_failure
         run: |
@@ -70,12 +92,12 @@ jobs:
           . environments/${{ matrix.cloud }}/activate
           cd $APPLIANCES_ENVIRONMENT_ROOT/terraform
           TF_FAIL_MSGS="$(../../skeleton/\{\{cookiecutter.environment\}\}/terraform/getfaults.py  $PWD)"
-          echo $TF_FAIL_MSGS
+          echo TF failure messages: $TF_FAIL_MSGS
           echo "::set-output name=messages::${TF_FAIL_MSGS}"
         env:
           OS_CLOUD: openstack
           TF_VAR_cluster_name: ci${{ github.run_id }}
-        if: always() && steps.provision.outcome == 'failure'
+        if: always() && steps.provision_servers.outcome == 'failure'
         
       - name: Delete infrastructure if failed due to lack of hosts
         run: |
@@ -86,20 +108,17 @@ jobs:
         env:
           OS_CLOUD: openstack
           TF_VAR_cluster_name: ci${{ github.run_id }}
-        if: ${{ always() && steps.provision.outcome == 'failure' && contains('not enough hosts available', steps.provision_failure.messages) }}
+        if: ${{ always() && steps.provision_servers.outcome == 'failure' && contains(steps.provision_failure.messages, 'not enough hosts available') }}
 
       - name: Directly configure cluster
         run: |
           . venv/bin/activate
           . environments/${{ matrix.cloud }}/activate
           ansible all -m wait_for_connection
-          ansible-playbook ansible/adhoc/generate-passwords.yml
-          echo test_user_password: "$TEST_USER_PASSWORD" > $APPLIANCES_ENVIRONMENT_ROOT/inventory/group_vars/basic_users/defaults.yml
           ansible-playbook -vv ansible/site.yml
         env:
           OS_CLOUD: openstack
           ANSIBLE_FORCE_COLOR: True
-          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
 
       - name: Run MPI-based tests
         run: |
@@ -145,7 +164,8 @@ jobs:
         run: |
           . venv/bin/activate
           . environments/${{ matrix.cloud }}/activate
-          echo test_user_password: "$TEST_USER_PASSWORD" > $APPLIANCES_ENVIRONMENT_ROOT/inventory/group_vars/basic_users/defaults.yml
+          ansible-playbook ansible/adhoc/generate-passwords.yml
+          echo test_user_password: "$TEST_USER_PASSWORD" > $APPLIANCES_ENVIRONMENT_ROOT/inventory/group_vars/all/test_user.yml
           cd packer/
           PACKER_LOG=1 packer build -on-error=ask -var-file=$PKR_VAR_environment_root/builder.pkrvars.hcl openstack.pkr.hcl
         env:

--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -26,6 +26,10 @@ roles/*
 !roles/slurm_exporter/**
 !roles/firewalld/
 !roles/firewalld/**
+!roles/etc_hosts/
+!roles/etc_hosts/**
+!roles/cloud_init/
+!roles/cloud_init/**
 !roles/mysql/
 !roles/mysql/**
 !roles/systemd/

--- a/ansible/adhoc/template-cloud-init.yml
+++ b/ansible/adhoc/template-cloud-init.yml
@@ -1,0 +1,9 @@
+- hosts: cloud_init
+  become: no
+  gather_facts: no
+  tasks:
+    - name: Template out cloud-init userdata
+      import_role:
+        name: cloud_init
+        tasks_from: template.yml
+      delegate_to: localhost

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -13,6 +13,19 @@
           to update these variable names. ** NB: The actual secrets will not be changed.**
       when: "'secrets_openhpc_' in (hostvars[inventory_hostname] | join)"
 
+- hosts: etc_hosts
+  gather_facts: false
+  tags: etc_hosts
+  become: yes
+  tasks:
+    - name: Template /etc/hosts
+      copy:
+        content: "{{ etc_hosts_template }}"
+        dest: /etc/hosts
+        owner: root
+        group: root
+        mode: u=rw,og=r
+
 - hosts: cluster
   gather_facts: false
   tasks:

--- a/ansible/roles/cloud_init/README.md
+++ b/ansible/roles/cloud_init/README.md
@@ -1,0 +1,31 @@
+# cloud_init
+
+Create cloud init userdata for instance groups.
+
+# Requirements
+Image and cloud environment supporting cloud-init.
+
+# Role Variables
+
+- `cloud_init_output_path`: Required. Path to output userdata files to.
+- `cloud_init_userdata_templates`: Optional list. Each element is a dict with keys/values as follows:
+    - `module`: Required str. Name of cloud_init [module](https://cloudinit.readthedocs.io/en/latest/topics/modules.html)
+    - `group`: Optional str. Name of inventory group to which this config applies - if omitted it applies. This allows defining `cloud_init_userdata_templates` for group `all`.
+    - `template`: Jinja template for cloud_init module [configuration](https://cloudinit.readthedocs.io/en/latest/topics/modules.html).
+
+  Elements may repeat `module`; the resulting userdata cloud-config file will will contain configuration from all applicable (by group) elements for that module.
+  
+  Note that the appliance [constructs](../../../environments/common/inventory/group_vars/all/cloud_init.yml) `cloud_init_userdata_templates` from `cloud_init_userdata_templates_default` and `cloud_init_userdata_templates_extra` to 
+  allow easier customisation in specific environments.
+
+# Dependencies
+None.
+
+# Example Playbook
+See `ansible/adhoc/rebuild.yml`.
+
+# License
+Apache 2.0
+
+# Author Information
+steveb@stackhpc.com

--- a/ansible/roles/cloud_init/README.md
+++ b/ansible/roles/cloud_init/README.md
@@ -10,7 +10,7 @@ Image and cloud environment supporting cloud-init.
 - `cloud_init_output_path`: Required. Path to output userdata files to.
 - `cloud_init_userdata_templates`: Optional list. Each element is a dict with keys/values as follows:
     - `module`: Required str. Name of cloud_init [module](https://cloudinit.readthedocs.io/en/latest/topics/modules.html)
-    - `group`: Optional str. Name of inventory group to which this config applies - if omitted it applies. This allows defining `cloud_init_userdata_templates` for group `all`.
+    - `group`: Optional str. Name of inventory group to which this config applies - if no group is specified then it applies to all groups. This allows defining `cloud_init_userdata_templates` for group `all`.
     - `template`: Jinja template for cloud_init module [configuration](https://cloudinit.readthedocs.io/en/latest/topics/modules.html).
 
   Elements may repeat `module`; the resulting userdata cloud-config file will will contain configuration from all applicable (by group) elements for that module.

--- a/ansible/roles/cloud_init/defaults/main.yml
+++ b/ansible/roles/cloud_init/defaults/main.yml
@@ -1,0 +1,2 @@
+#cloud_init_output_path: 
+cloud_init_userdata_templates: []

--- a/ansible/roles/cloud_init/tasks/template.yml
+++ b/ansible/roles/cloud_init/tasks/template.yml
@@ -1,0 +1,5 @@
+
+- name: Template out cloud-init userdata
+  ansible.builtin.template:
+    src: userdata.yml.j2
+    dest: "{{ cloud_init_output_path }}/{{ inventory_hostname }}.userdata.yml"

--- a/ansible/roles/cloud_init/templates/userdata.yml.j2
+++ b/ansible/roles/cloud_init/templates/userdata.yml.j2
@@ -1,0 +1,13 @@
+#cloud-config
+disable_ec2_metadata: true
+
+{% for module, tmpls in cloud_init_userdata_templates | groupby(attribute='module') %}
+{% for tmpl in tmpls %}
+{% if not 'group' in tmpl or tmpl.group in group_names %}
+{% if loop.first %}
+{{ module }}:
+{% endif %}
+{{ tmpl.template }}
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/ansible/roles/etc_hosts/README.md
+++ b/ansible/roles/etc_hosts/README.md
@@ -1,0 +1,5 @@
+# etc_hosts
+
+This role provides documentation only.
+
+Hosts in the `etc_hosts` groups get `/etc/hosts` created via `cloud-init`. The generated file defines all hosts in this group using `ansible_host` as the IP address and `inventory_hostname` as the canonical hostname. This may need overriding for multi-homed hosts. See `environments/common/inventory/group_vars/all/cloud_init.yml` for configuration.

--- a/environments/arcus/.gitignore
+++ b/environments/arcus/.gitignore
@@ -1,3 +1,8 @@
 partitions.yml
 secrets.yml
 hosts
+terraform.tfvars
+.terraform.lock.hcl
+logs/
+hpctests/
+inventory/group_vars/all/test_user.yml

--- a/environments/arcus/hooks/pre.yml
+++ b/environments/arcus/hooks/pre.yml
@@ -1,17 +1,3 @@
-- hosts: all # NB: As this doesn't exclude `builder` /etc/hosts is baked into images, which should let `openstack server rebuild` work
-  become: true
-  tags: etc_hosts
-  tasks:
-    - name: Create /etc/hosts for all nodes as DNS doesn't work
-      blockinfile:
-        path: /etc/hosts
-        create: yes
-        state: present
-        block: |
-          {% for hostname in groups['all'] %}
-          {{ hostvars[hostname]['ansible_host'] }} {{ hostname }}
-          {% endfor %}
-
 - hosts: control
   become: yes
   gather_facts: false
@@ -28,4 +14,4 @@
       loop:
         - "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/inventory/hosts"
         - "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/inventory/group_vars/all/secrets.yml"
-        - "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/inventory/group_vars/basic_users/defaults.yml"
+        - "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/inventory/group_vars/all/test_user.yml"

--- a/environments/arcus/inventory/extra_groups
+++ b/environments/arcus/inventory/extra_groups
@@ -4,3 +4,6 @@ cluster
 [rebuild:children]
 control
 compute
+
+[etc_hosts:children]
+cluster

--- a/environments/arcus/inventory/group_vars/all/basic_users.yml
+++ b/environments/arcus/inventory/group_vars/all/basic_users.yml
@@ -1,0 +1,7 @@
+# has to be defined on 'all' group so localhost can template out for cloud-init
+testuser_password: "{{ lookup('env', 'TESTUSER_PASSWORD') | default(vault_testuser_password, true) }}"
+
+basic_users_users:
+  - name: testuser # can't use rocky as $HOME isn't shared!
+    password: "{{ testuser_password | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}" # idempotent
+    uid: 1005

--- a/environments/arcus/inventory/group_vars/all/cloud_init.yml
+++ b/environments/arcus/inventory/group_vars/all/cloud_init.yml
@@ -1,0 +1,1 @@
+../../../../skeleton/{{cookiecutter.environment}}/inventory/group_vars/all/cloud_init.yml

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -8,6 +8,12 @@ variable "cluster_name" {
     description = "Name for cluster, used as prefix for resources - set by environment var in CI"
 }
 
+variable "create_nodes" {
+    description = "Whether to create nodes (servers) or just ports and other infra"
+    type = bool # can't use bool as want to pass from command-line
+    default = true
+}
+
 module "cluster" {
     source = "../../skeleton/{{cookiecutter.environment}}/terraform/"
 
@@ -36,6 +42,7 @@ module "cluster" {
         compute-0: "small"
         compute-1: "small"
     }
+    create_nodes = var.create_nodes
     
     environment_root = var.environment_root
 }

--- a/environments/common/inventory/group_vars/all/cloud_init.yml
+++ b/environments/common/inventory/group_vars/all/cloud_init.yml
@@ -1,5 +1,13 @@
 cloud_init_output_path: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/cloud_init"
 
+etc_hosts_template: |
+  127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+  ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+  {% for hostname in groups['etc_hosts'] | sort -%}
+  {{ hostvars[hostname]['ansible_host'] }} {{ hostname }}
+  {% endfor -%}
+
 cloud_init_userdata_etchosts:
   module: write_files
   group: etc_hosts
@@ -10,12 +18,7 @@ cloud_init_userdata_etchosts:
         permissions: "0644"
         owner: root:root
         content: |
-            127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
-            ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
-
-            {% for hostname in groups['etc_hosts'] | sort -%}
-            {{ hostvars[hostname]['ansible_host'] }} {{ hostname }}
-            {% endfor -%}
+          {{ etc_hosts_template | indent(width=6, first=false) }}
 
 cloud_init_userdata_templates_default: # provides indirection so environments could copy parts of default without having to rewrite the entire thing
   - "{{ cloud_init_userdata_etchosts }}"

--- a/environments/common/inventory/group_vars/all/cloud_init.yml
+++ b/environments/common/inventory/group_vars/all/cloud_init.yml
@@ -1,0 +1,24 @@
+cloud_init_output_path: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/cloud_init"
+
+cloud_init_userdata_etchosts:
+  module: write_files
+  group: etc_hosts
+  template: |-
+    # etc_hosts group:
+      - path: /etc/hosts
+        encoding: text/plain
+        permissions: "0644"
+        owner: root:root
+        content: |
+            127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+            ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+            {% for hostname in groups['etc_hosts'] | sort -%}
+            {{ hostvars[hostname]['ansible_host'] }} {{ hostname }}
+            {% endfor -%}
+
+cloud_init_userdata_templates_default: # provides indirection so environments could copy parts of default without having to rewrite the entire thing
+  - "{{ cloud_init_userdata_etchosts }}"
+
+cloud_init_userdata_templates_extra: []
+cloud_init_userdata_templates: "{{ cloud_init_userdata_templates_default + cloud_init_userdata_templates_extra }}"

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -90,6 +90,13 @@ fail2ban
 [openondemand_jupyter]
 # Subset of compute to run a Jupyter Notebook servers on via Open Ondemand
 
+[etc_hosts]
+# Hosts to manage /etc/hosts e.g. if no internal DNS. See ansible/roles/etc_hosts/README.md
+
+[cloud_init:children]
+# Hosts to template out cloud_init data for
+etc_hosts
+
 [systemd:children]
 # Hosts to make systemd unit adjustments on
 opendistro

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -54,3 +54,6 @@ compute
 [openondemand_jupyter:children]
 # Subset of compute to run a Jupyter Notebook servers on via Open Ondemand
 compute
+
+[etc_hosts]
+# Hosts to manage /etc/hosts e.g. if no internal DNS. See ansible/roles/etc_hosts/README.md

--- a/environments/skeleton/{{cookiecutter.environment}}/inventory/group_vars/all/cloud_init.yml
+++ b/environments/skeleton/{{cookiecutter.environment}}/inventory/group_vars/all/cloud_init.yml
@@ -1,0 +1,22 @@
+# This provides cloud_init templates to manage and mount the Terraform-provided
+# volumes on the control node for `appliances_state_dir` and $HOME.
+# Note volumes MUST be defined using block_device{} inside openstack_compute_instance_v2,
+# NOT attached after boot, else the device ordering is liable to change e.g. on reboots.
+
+cloud_init_userdata_templates_extra:
+  - module: fs_setup
+    group: control
+    template: |
+        - label: state
+          filesystem: ext4
+          device: /dev/vdb
+          partition: auto
+        - label: home
+          filesystem: ext4
+          device: /dev/vdc
+          partition: auto
+  - module: mounts
+    group: control
+    template: |
+        - [LABEL=state, /var/lib/state]
+        - [LABEL=home, /exports/home, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/inventory.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/inventory.tf
@@ -1,11 +1,11 @@
 resource "local_file" "hosts" {
   content  = templatefile("${path.module}/inventory.tpl",
                           {
-                            "cluster_name": var.cluster_name
-                            "control": openstack_compute_instance_v2.control,
-                            "state_dir": var.state_dir
-                            "logins": openstack_compute_instance_v2.login,
-                            "computes": openstack_compute_instance_v2.compute,
+                            "cluster_name": var.cluster_name,
+                            "control": openstack_networking_port_v2.control,
+                            "state_dir": var.state_dir,
+                            "logins": openstack_networking_port_v2.login,
+                            "computes": openstack_networking_port_v2.compute,
                             "compute_types": var.compute_types,
                             "compute_nodes": var.compute_nodes,
                             "subnet": data.openstack_networking_subnet_v2.cluster_subnet,

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/inventory.tpl
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/inventory.tpl
@@ -3,7 +3,7 @@ ansible_user=rocky
 openhpc_cluster_name=${cluster_name}
 
 [control]
-${control.name} ansible_host=${[for n in control.network: n.fixed_ip_v4 if n.access_network][0]} server_networks='${jsonencode({for net in control.network: net.name => [ net.fixed_ip_v4 ] })}'
+${control.name} ansible_host=${control.all_fixed_ips[0]}
 
 [control:vars]
 # NB needs to be set on group not host otherwise it is ignored in packer build!
@@ -11,12 +11,12 @@ appliances_state_dir=${state_dir}
 
 [login]
 %{ for login in logins ~}
-${login.name} ansible_host=${[for n in login.network: n.fixed_ip_v4 if n.access_network][0]} server_networks='${jsonencode({for net in login.network: net.name => [ net.fixed_ip_v4 ] })}'
+${login.name} ansible_host=${login.all_fixed_ips[0]}
 %{ endfor ~}
 
 [compute]
 %{ for compute in computes ~}
-${compute.name} ansible_host=${[for n in compute.network: n.fixed_ip_v4 if n.access_network][0]} server_networks='${jsonencode({for net in compute.network: net.name => [ net.fixed_ip_v4 ] })}'
+${compute.name} ansible_host=${compute.all_fixed_ips[0]}
 %{ endfor ~}
 
 # Define groups for slurm parititions:

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
@@ -114,6 +114,7 @@ resource "openstack_compute_instance_v2" "control" {
   lifecycle{
     ignore_changes = [
       image_name,
+      user_data,
       ]
     }
 
@@ -142,6 +143,7 @@ resource "openstack_compute_instance_v2" "login" {
   lifecycle{
     ignore_changes = [
       image_name,
+      user_data,
       ]
     }
 
@@ -170,6 +172,7 @@ resource "openstack_compute_instance_v2" "compute" {
   lifecycle{
     ignore_changes = [
       image_name,
+      user_data,
       ]
     }
 

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
@@ -96,3 +96,9 @@ variable "nonlogin_security_groups" {
         "default",  # allow all in-cluster services
     ]
 }
+
+variable "create_nodes" {
+    description = "Whether to create nodes (servers) or just ports and other infra"
+    type = bool # can't use bool as want to pass from command-line
+    default = true
+}


### PR DESCRIPTION
As title says, by:
- Adding a new `cloud_init` role and adhoc command which can generate cloud_init userdata files from jinja template fragments
- Defining a group `etc_hosts` for which such /etc/hosts userdata templates will be generated, and populating it in the `arcus` CI environment.
- Changing the cookiecutter TF and arcus CI workflow/environment so that:
  - First TF apply creates ports etc. but not instances
  - Cloud-init userdata is templated using the port addresses to define /etc/hosts
  - Second TF apply creates instances using that userdata

Note that:
- The `ansible/bootstrap.yml` playbook also templates /etc/hosts. This should be a no-change if it has been written by cloud-init but it permits adding nodes to an existing cluster.
- No special handing of rebuilding/reimaging instances is done; userdata is kept on rebuild unless specifically changed or cleared, so all rebuild routes should "just work".

The userdata templating probably looks overly-complex, but it does need to support assembling group/host-dependent userdata with defaults + environment-specific additions/overrides:
- The cookiecutter (and therefore Arcus) environments were already using userdata ("hard-coded" in the terraform directory) to manage the volume format/mounts.
- A subsequent PR for generic images will create more userdata fragments to push config into compute and login nodes.