### PR TITLE
Always skip updating grafana

### DIFF
--- a/environments/common/inventory/group_vars/all/update.yml
+++ b/environments/common/inventory/group_vars/all/update.yml
@@ -4,7 +4,8 @@ update_enable: false
 # These variables define the packages updates and are passed to ansible's yum module parameters with the same names: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_module.html
 update_name: '*'
 update_state: latest
-update_exclude: omit
+update_exclude:
+  - grafana
 update_disablerepo: omit
 # Log changes during update here on localhost:
 update_log_path:  "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/logs/{{ inventory_hostname }}-updates.log"

--- a/environments/common/inventory/group_vars/builder/defaults.yml
+++ b/environments/common/inventory/group_vars/builder/defaults.yml
@@ -6,8 +6,6 @@ openhpc_slurm_service_started: false
 nfs_client_mnt_state: present
 openhpc_rebuild_reconfigure: false
 update_enable: true
-update_exclude:
-  - grafana
 block_devices_partition_state: skip
 block_devices_filesystem_state: skip
 block_devices_mount_state: present


### PR DESCRIPTION
Grafana is supposed to be pinned at a version. `update_exclude` was set appropriately for the packer builds (tested in CI) but not for a direct update (not tested in CI, but done in Azimuth CaaS deployments).