### PR TITLE
Make pingpong plotting independent of role path

### DIFF
--- a/ansible/adhoc/hpctests.yml
+++ b/ansible/adhoc/hpctests.yml
@@ -4,7 +4,7 @@
 
 ---
 
-- hosts: login[0] # TODO: might want to make which node is used selectable?
+- hosts: hpctests[0] # TODO: might want to make which node is used selectable?
   become: false
   gather_facts: false
   tasks:

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -35,6 +35,7 @@ Role Variables
 The following variables should not generally be changed:
 - `hpctests_pingmatrix_modules`: Optional. List of modules to load for pingmatrix test. Defaults are suitable for OpenHPC 2.x cluster using the required packages.
 - `hpctests_pingpong_modules`: As above but for pingpong test.
+- `hpctests_pingpong_plot`: Whether to plot pingpong results. Default `yes`.
 - `hpctests_hpl_modules`: As above but for hpl tests.
 - `hpctests_hpl_version`: Version of HPL
 

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -2,6 +2,7 @@
 hpctests_rootdir:
 hpctests_pingmatrix_modules: [gnu9 openmpi4]
 hpctests_pingpong_modules: [gnu9 openmpi4 imb]
+hpctests_pingpong_plot: yes
 hpctests_hpl_modules: [gnu9 openmpi4 openblas]
 hpctests_outdir: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/hpctests"
 hpctests_ucx_net_devices: all

--- a/ansible/roles/hpctests/tasks/pingpong.yml
+++ b/ansible/roles/hpctests/tasks/pingpong.yml
@@ -52,6 +52,7 @@
     creates: "{{ _pingpong_local_output | dirname }}/latency.png"
   register: _pingpong_plot
   delegate_to: localhost
+  when: hpctests_pingpong_plot | bool
   
 - debug:
     msg: |
@@ -61,5 +62,7 @@
       Zero-size msg latency: {{ hpctests_pingpong_out['columns']['latency'][0] }} us
       Max bandwidth: {{ hpctests_pingpong_out['columns']['bandwidth'] | max }} Mbytes/s ({{ (hpctests_pingpong_out['columns']['bandwidth'] | max) / 125.0 }} Gbit/s)
 
+      {% if hpctests_pingpong_plot %}
       See plot on localhost:
       {{ _pingpong_plot.stdout }}
+      {% endif %}

--- a/ansible/roles/hpctests/tasks/pingpong.yml
+++ b/ansible/roles/hpctests/tasks/pingpong.yml
@@ -48,7 +48,7 @@
 
 - name: Plot image
   shell:
-    cmd: "python {{lookup('env', 'APPLIANCES_REPO_ROOT') }}/ansible/roles/hpctests/files/plot_imb_pingpong.py {{ _pingpong_local_output }}"
+    cmd: "python {{ role_path }}/files/plot_imb_pingpong.py {{ _pingpong_local_output }}"
     creates: "{{ _pingpong_local_output | dirname }}/latency.png"
   register: _pingpong_plot
   delegate_to: localhost

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -13,8 +13,9 @@ login
 control
 compute
 
-[hpctests]
+[hpctests:children]
 # Login group to use for running mpi-based testing.
+login
 
 [cluster:children]
 # All nodes in the appliance - add e.g. service nodes not running Slurm here.

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -13,6 +13,9 @@ login
 control
 compute
 
+[hpctests]
+# Login group to use for running mpi-based testing.
+
 [cluster:children]
 # All nodes in the appliance - add e.g. service nodes not running Slurm here.
 openhpc

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -1,6 +1,9 @@
 [nfs:children]
 openhpc
 
+[hpctests:children]
+login
+
 [mysql:children]
 control
 

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -1,9 +1,6 @@
 [nfs:children]
 openhpc
 
-[hpctests:children]
-login
-
 [mysql:children]
 control
 


### PR DESCRIPTION
Removes use of `APPLIANCES_REPO_ROOT` which is not available in CaaS appliance.