### PR TITLE
Bump CI image to one without authorized ssh keys for rocky

### DIFF
--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-220830-2042.qcow2"
+source_image_name = "openhpc-221027-1557.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]
 ssh_bastion_host = "128.232.222.183"

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -24,22 +24,22 @@ module "cluster" {
     key_pair = "slurm-app-ci"
     control_node = {
         flavor: "vm.alaska.cpu.general.small"
-        image: "openhpc-220830-2042.qcow2"
+        image: "openhpc-221027-1557.qcow2"
     }
     login_nodes = {
         login-0: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-220830-2042.qcow2"
+            image: "openhpc-221027-1557.qcow2"
         }
     }
     compute_types = {
         small: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-220830-2042.qcow2"
+            image: "openhpc-221027-1557.qcow2"
         }
         extra: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-220830-2042.qcow2"
+            image: "openhpc-221027-1557.qcow2"
         }
     }
     compute_nodes = {


### PR DESCRIPTION
Changes image to `openhpc-221027-1557.qcow2` built by https://github.com/stackhpc/slurm_image_builder/commit/b13a88542963cf6cc2e3802de4c89178efc28ceb