### PR TITLE
Update OpenHPC and OOD, pinning to RL8.6

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -53,6 +53,7 @@
       ansible.builtin.copy:
         dest: /etc/yum/vars/releasever
         content: "{{ releasever }}"
+      become: true
 
 - hosts: systemd
   become: yes

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -49,6 +49,10 @@
       become: true
     - name: Reset ssh connection to allow user changes to affect ansible_user
       meta: reset_connection
+    - name: Set dnf releasever
+      ansible.builtin.copy:
+        dest: /etc/yum/vars/releasever
+        content: "{{ releasever }}"
 
 - hosts: systemd
   become: yes

--- a/ansible/ci/check_sacct_hpctests.yml
+++ b/ansible/ci/check_sacct_hpctests.yml
@@ -4,11 +4,11 @@
   vars:
     sacct_stdout_expected: |- # based on CI running hpctests as the first job - NB note no trailing newline
       JobID,JobName,State
-      2,pingpong.sh,COMPLETED
-      3,pingmatrix.sh,COMPLETED
-      4,hpl-build-linux64.sh,COMPLETED
-      5_0,hpl-solo.sh,COMPLETED
-      5_1,hpl-solo.sh,COMPLETED
+      1,pingpong.sh,COMPLETED
+      2,pingmatrix.sh,COMPLETED
+      3,hpl-build-linux64.sh,COMPLETED
+      4_0,hpl-solo.sh,COMPLETED
+      4_1,hpl-solo.sh,COMPLETED
   tasks:
     - name: Get info for ended jobs
       shell:

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 hpctests_rootdir:
-hpctests_pingmatrix_modules: [gnu9 openmpi4]
-hpctests_pingpong_modules: [gnu9 openmpi4 imb]
+hpctests_pingmatrix_modules: [gnu12 openmpi4]
+hpctests_pingpong_modules: [gnu12 openmpi4 imb]
 hpctests_pingpong_plot: yes
-hpctests_hpl_modules: [gnu9 openmpi4 openblas]
+hpctests_hpl_modules: [gnu12 openmpi4 openblas]
 hpctests_outdir: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/hpctests"
 hpctests_ucx_net_devices: all
 hpctests_hpl_version: "2.3"

--- a/ansible/roles/openondemand/tasks/main.yml
+++ b/ansible/roles/openondemand/tasks/main.yml
@@ -9,7 +9,7 @@
 # if using PAM auth we need apache installed but NOT started so split the osc.ood role up:
 - include_role:
     name: osc.ood
-    tasks_from: install-rpm.yml
+    tasks_from: install-package.yml
     vars_from: Rocky.yml
     public: yes # Expose the vars from this role to the rest of the play
   # can't set vars: from a dict hence the workaround above

--- a/ansible/roles/openondemand/tasks/vnc_compute.yml
+++ b/ansible/roles/openondemand/tasks/vnc_compute.yml
@@ -14,7 +14,7 @@
   tags: install
   yum:
     name:
-      - turbovnc-2.2.7 # see https://discourse.osc.edu/t/turbovnc-seems-to-no-longer-have-the-nohttpd-option/1856/6 and https://github.com/OSC/ood_core/issues/737
+      - turbovnc-3.0.1
       - nmap-ncat
       - python3
 

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-221117-1324.qcow2"
+source_image_name = "openhpc-221118-1422.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]
 ssh_bastion_host = "128.232.222.183"

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-221027-1557.qcow2"
+source_image_name = "openhpc-221117-1324.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]
 ssh_bastion_host = "128.232.222.183"

--- a/environments/arcus/inventory/group_vars/selinux/overrides.yml
+++ b/environments/arcus/inventory/group_vars/selinux/overrides.yml
@@ -1,0 +1,1 @@
+selinux_state: disabled

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -24,7 +24,7 @@ module "cluster" {
     key_pair = "slurm-app-ci"
     control_node = {
         flavor: "vm.alaska.cpu.general.small"
-        image: "openhpc-220830-2042.qcow2"
+        image: "openhpc-221116-1159.qcow2"
     }
     login_nodes = {
         login-0: {
@@ -35,11 +35,11 @@ module "cluster" {
     compute_types = {
         small: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-220830-2042.qcow2"
+            image: "openhpc-221116-1159.qcow2"
         }
         extra: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-220830-2042.qcow2"
+            image: "openhpc-221116-1159.qcow2"
         }
     }
     compute_nodes = {

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -17,7 +17,7 @@ variable "create_nodes" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-221117-1324.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/9
+    default = "openhpc-221118-1422.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/12
 }
 
 module "cluster" {

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -14,6 +14,12 @@ variable "create_nodes" {
     default = true
 }
 
+variable "cluster_image" {
+    description = "single image for all cluster nodes - a convenience for CI"
+    type = string
+    default = "openhpc-221117-1324.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/9
+}
+
 module "cluster" {
     source = "../../skeleton/{{cookiecutter.environment}}/terraform/"
 
@@ -24,22 +30,22 @@ module "cluster" {
     key_pair = "slurm-app-ci"
     control_node = {
         flavor: "vm.alaska.cpu.general.small"
-        image: "openhpc-221116-1159.qcow2"
+        image: var.cluster_image
     }
     login_nodes = {
         login-0: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-221027-1557.qcow2"
+            image: var.cluster_image
         }
     }
     compute_types = {
         small: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-221116-1159.qcow2"
+            image: var.cluster_image
         }
         extra: {
             flavor: "vm.alaska.cpu.general.small"
-            image: "openhpc-221116-1159.qcow2"
+            image: var.cluster_image
         }
     }
     compute_nodes = {

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -4,6 +4,7 @@ ansible_user: rocky
 appliances_repository_root: "{{ lookup('env', 'APPLIANCES_REPO_ROOT') }}"
 appliances_environment_root: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}"
 #appliances_state_dir: # define an absolute path here to use for persistent state
+releasever: '8.6'
 
 # Address(ip/dns) for internal communication between services. This is
 # normally traffic you do no want to expose to users.

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -19,8 +19,8 @@ openhpc_slurm_partitions:
   - name: "compute"
 openhpc_packages_default:
   - slurm-libpmi-ohpc # to allow intel mpi to work properly
-  - ohpc-gnu9-openmpi4-perf-tools # for hpctests
-  - openblas-gnu9-ohpc # for hpctests (HPL)
+  - ohpc-gnu12-openmpi4-perf-tools # for hpctests
+  - openblas-gnu12-ohpc # for hpctests (HPL)
 openhpc_packages_extra: []
 openhpc_packages: "{{ openhpc_packages_default + openhpc_packages_extra }}"
 openhpc_munge_key: "{{ vault_openhpc_mungekey | b64decode }}"

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -7,7 +7,7 @@
 
 # openondemand_servername: '' # Must be defined when using openondemand
 
-ondemand_package: ondemand-2.0.28
+ondemand_package: ondemand-2.0.29
 
 openondemand_dashboard_links: # TODO: should really only be deployed if grafana is deployed and proxying configured
   - name: Grafana

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -7,6 +7,8 @@
 
 # openondemand_servername: '' # Must be defined when using openondemand
 
+ondemand_package: ondemand-2.0.28
+
 openondemand_dashboard_links: # TODO: should really only be deployed if grafana is deployed and proxying configured
   - name: Grafana
     app_name: grafana

--- a/environments/skeleton/{{cookiecutter.environment}}/inventory/group_vars/all/cloud_init.yml
+++ b/environments/skeleton/{{cookiecutter.environment}}/inventory/group_vars/all/cloud_init.yml
@@ -3,17 +3,19 @@
 # Note volumes MUST be defined using block_device{} inside openstack_compute_instance_v2,
 # NOT attached after boot, else the device ordering is liable to change e.g. on reboots.
 
+block_device_prefix: sd
+
 cloud_init_userdata_templates_extra:
   - module: fs_setup
     group: control
     template: |
         - label: state
           filesystem: ext4
-          device: /dev/vdb
+          device: /dev/{{ block_device_prefix }}b
           partition: auto
         - label: home
           filesystem: ext4
-          device: /dev/vdc
+          device: /dev/{{ block_device_prefix }}c
           partition: auto
   - module: mounts
     group: control

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,15 +1,13 @@
 ---
 roles:
   - src: stackhpc.nfs
-    version: v21.2.1
+    version: v22.9.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
     version: v0.16.0
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: feature/no-install
     name: cloudalchemy.node_exporter
-  - src: cloudalchemy.blackbox-exporter
-    version: 1.0.0
   - src: https://github.com/cloudalchemy/ansible-prometheus.git
     version: 4d2c8d742de39e50387e0aa6d5510b21c7451343 # need fix in preceeding commit for rocky
     name: cloudalchemy.prometheus
@@ -18,7 +16,6 @@ roles:
   - src: https://github.com/stackhpc/ansible-grafana.git
     name: cloudalchemy.grafana
     version: service-state
-  - src: jriguera.configdrive
     # No versions available
   - src: https://github.com/stackhpc/ood-ansible.git
     name: osc.ood

--- a/requirements.yml
+++ b/requirements.yml
@@ -20,9 +20,9 @@ roles:
     version: service-state
   - src: jriguera.configdrive
     # No versions available
-  - src: https://github.com/OSC/ood-ansible.git
+  - src: https://github.com/stackhpc/ood-ansible.git
     name: osc.ood
-    version: v2.0.8
+    version: shpc/releasever # based on v2.0.8
 
 collections:
 - name: containers.podman

--- a/requirements.yml
+++ b/requirements.yml
@@ -22,7 +22,7 @@ roles:
     # No versions available
   - src: https://github.com/OSC/ood-ansible.git
     name: osc.ood
-    version: v2.0.5
+    version: v2.0.8
 
 collections:
 - name: containers.podman


### PR DESCRIPTION
Major changes:

- [x] Yum/dnf releasever set to 8.6 to avoid getting RockyLinux 8.7 updates
- [x] OpenHPC now at v2.6 with Slurm 22.05.2
- [x] Updates and pins Open Ondemand 2.0.29
- [x] Disables SELinux by default
- [x] Updates turbovnc to 3.0.1 (fixes https://github.com/stackhpc/ansible-slurm-appliance/issues/198)
- [x] Updates packages/modules used for `hpctests` role (avoids dependency problems now OpenHPC v2.6 available).
- [x] Uses appropriate "fat" image in CI incorporating the above: `openhpc-221118-1422.qcow2`



