### PR TITLE
Fix RL8.6 and EPEL repo changes

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -44,11 +44,6 @@
       become: true
     - name: Reset ssh connection to allow user changes to affect ansible_user
       meta: reset_connection
-    - name: Set dnf releasever
-      ansible.builtin.copy:
-        dest: /etc/yum/vars/releasever
-        content: "{{ releasever }}"
-      become: true
 
 - hosts: systemd
   become: yes

--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -19,16 +19,6 @@
     - import_role:
         name: stackhpc.slurm_openstack_tools.rebuild
 
-- name: Workaround https://github.com/openhpc/ohpc/issues/1644
-  hosts: compute
-  become: yes
-  gather_facts: no
-  tasks:
-    - name: Install old apptainer version to unbreak ohpc-base-compute package
-      dnf:
-        name: https://github.com/apptainer/apptainer/releases/download/v1.1.3/apptainer-1.1.3-1.x86_64.rpm
-        disable_gpg_check: true
-
 - name: Setup slurm
   hosts: openhpc
   become: yes

--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -19,6 +19,16 @@
     - import_role:
         name: stackhpc.slurm_openstack_tools.rebuild
 
+- name: Workaround https://github.com/openhpc/ohpc/issues/1644
+  hosts: compute
+  become: yes
+  gather_facts: no
+  tasks:
+    - name: Install old apptainer version to unbreak ohpc-base-compute package
+      dnf:
+        name: https://github.com/apptainer/apptainer/releases/download/v1.1.3/apptainer-1.1.3-1.x86_64.rpm
+        disable_gpg_check: true
+
 - name: Setup slurm
   hosts: openhpc
   become: yes

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-230104-1319.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
+source_image_name = "openhpc-230105-1647.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
 #source_image_name = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-230105-1647.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
+source_image_name = "openhpc-230106-1107.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
 #source_image_name = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,7 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-221118-1422.qcow2"
+source_image_name = "openhpc-230104-1319.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
+#source_image_name = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]
 ssh_bastion_host = "128.232.222.183"

--- a/environments/arcus/inventory/group_vars/all/cloud_init.yml
+++ b/environments/arcus/inventory/group_vars/all/cloud_init.yml
@@ -1,1 +1,0 @@
-../../../../skeleton/{{cookiecutter.environment}}/inventory/group_vars/all/cloud_init.yml

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -17,7 +17,8 @@ variable "create_nodes" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-221118-1422.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/12
+    default = "openhpc-230104-1319.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
+    # default = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
 }
 
 module "cluster" {

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -17,7 +17,7 @@ variable "create_nodes" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-230104-1319.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
+    default = "openhpc-230105-1647.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
     # default = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
 }
 

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -17,8 +17,9 @@ variable "create_nodes" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-230105-1647.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
+    default = "openhpc-230106-1107.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/13
     # default = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
+    # default = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
 }
 
 module "cluster" {

--- a/environments/common/inventory/group_vars/all/update.yml
+++ b/environments/common/inventory/group_vars/all/update.yml
@@ -6,6 +6,7 @@ update_name: '*'
 update_state: latest
 update_exclude:
   - grafana
+  - apptainer # see https://github.com/stackhpc/ansible-slurm-appliance/pull/245
 update_disablerepo: omit
 # Log changes during update here on localhost:
 update_log_path:  "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/logs/{{ inventory_hostname }}-updates.log"

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - src: stackhpc.nfs
     version: v22.9.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v0.16.0
+    version: v0.17.0 # workaround for elrepo apptainer changes
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: feature/no-install


### PR DESCRIPTION
- Remove releasever pinning (pinning to 8.6 no longer works as packages have been moved to Vault)
- Bumps the "fat" image appropriately (https://github.com/stackhpc/slurm_image_builder/pull/13)
- Adds an older apptainer package from github release, to workaround https://github.com/openhpc/ohpc/issues/1644 (EPEL package changes break dependencies for ohpc-base-compute package).