### PR TITLE
Provide container packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+./.github/CODEOWNERS

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,4 +1,4 @@
-flavor = "vm.alaska.cpu.general.small"
+flavor = "vm.ska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
 source_image_name = "openhpc-230217-1440.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
 #source_image_name = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-230110-1629.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/14
+source_image_name = "openhpc-230214-1026.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
 #source_image_name = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-230214-1026.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
+source_image_name = "openhpc-230215-1202.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
 #source_image_name = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]

--- a/environments/arcus/builder.pkrvars.hcl
+++ b/environments/arcus/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.alaska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-230215-1202.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
+source_image_name = "openhpc-230217-1440.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
 #source_image_name = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -31,22 +31,22 @@ module "cluster" {
     vnic_type = "direct"
     key_pair = "slurm-app-ci"
     control_node = {
-        flavor: "vm.alaska.cpu.general.quarter"
+        flavor: "vm.ska.cpu.general.quarter"
         image: var.cluster_image
     }
     login_nodes = {
         login-0: {
-            flavor: "vm.alaska.cpu.general.small"
+            flavor: "vm.ska.cpu.general.small"
             image: var.cluster_image
         }
     }
     compute_types = {
         small: {
-            flavor: "vm.alaska.cpu.general.small"
+            flavor: "vm.ska.cpu.general.small"
             image: var.cluster_image
         }
         extra: {
-            flavor: "vm.alaska.cpu.general.small"
+            flavor: "vm.ska.cpu.general.small"
             image: var.cluster_image
         }
     }

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -17,7 +17,7 @@ variable "create_nodes" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-230110-1629.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/14
+    default = "openhpc-230214-1026.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
     # default = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
     # default = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
 }

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -17,7 +17,7 @@ variable "create_nodes" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-230215-1202.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
+    default = "openhpc-230217-1440.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
     # default = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
     # default = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
 }

--- a/environments/arcus/terraform/main.tf
+++ b/environments/arcus/terraform/main.tf
@@ -17,7 +17,7 @@ variable "create_nodes" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-230214-1026.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
+    default = "openhpc-230215-1202.qcow2" # https://github.com/stackhpc/slurm_image_builder/pull/15
     # default = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
     # default = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
 }

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -21,7 +21,7 @@ grafana_address: "{{ hostvars[groups['grafana'].0].api_address }}"
 
 ############################# bootstrap: local user configuration #########################
 
-# Parameters for these users replicate what gets created using image openhpc-220526-1354.qcow2 image + appliance run.
+# Parameters for these users are consistent with the "fat" image build from https://github.com/stackhpc/slurm_image_builder
 # Note RockyLinux 8.5 defines system user/groups in range 201-999
 appliances_local_users_ansible_user_name: "{{ ansible_ssh_user | default(ansible_user) }}"
 appliances_local_users_podman: # also used in environments/common/inventory/group_vars/all/podman.yml:podman_users

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -18,9 +18,15 @@ openhpc_slurmdbd_host: "{{ openhpc_slurm_control_host }}"
 openhpc_slurm_partitions:
   - name: "compute"
 openhpc_packages_default:
+  # system packages
+  - podman
+  # OpenHPC packages
   - slurm-libpmi-ohpc # to allow intel mpi to work properly
   - ohpc-gnu12-openmpi4-perf-tools # for hpctests
   - openblas-gnu12-ohpc # for hpctests (HPL)
+  # EPEL packages:
+  - apptainer
+  - podman-compose
 openhpc_packages_extra: []
 openhpc_packages: "{{ openhpc_packages_default + openhpc_packages_extra }}"
 openhpc_munge_key: "{{ vault_openhpc_mungekey | b64decode }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - src: stackhpc.nfs
     version: v22.9.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v0.17.0 # workaround for elrepo apptainer changes
+    version: v0.18.0 # requires/uses openhpc v2.6.1
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: feature/no-install

--- a/requirements.yml
+++ b/requirements.yml
@@ -17,9 +17,9 @@ roles:
     name: cloudalchemy.grafana
     version: service-state
     # No versions available
-  - src: https://github.com/stackhpc/ood-ansible.git
+  - src: https://github.com/OSC/ood-ansible.git
     name: osc.ood
-    version: shpc/releasever # based on v2.0.8
+    version: v2.0.8
 
 collections:
 - name: containers.podman


### PR DESCRIPTION
- Updates openhpc role now OpenHPC v2.6.1 released (no longer requiring old apptainer install workaround)
- Adds `apptainer` (for singularity), `podman` and `podman-compose` packages by default.
- CaaS/CI image updated: https://github.com/stackhpc/slurm_image_builder/pull/15