### PR TITLE
Use environment hooks when building "fat" image

### DIFF
--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -1,6 +1,20 @@
 # Builder version of site.yml just installing binaries
 
+- name: Run pre.yml hook
+  vars:
+    appliances_environment_root: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}"
+    hook_path: "{{ appliances_environment_root }}/hooks/pre.yml"
+  import_playbook: "{{ hook_path if hook_path | exists else 'noop.yml' }}"
+  when: hook_path | exists
+
 - import_playbook: bootstrap.yml
+
+- name: Run post-bootstrap.yml hook
+  vars:
+    appliances_environment_root: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}"
+    hook_path: "{{ appliances_environment_root }}/hooks/post-bootstrap.yml"
+  import_playbook: "{{ hook_path if hook_path | exists else 'noop.yml' }}"
+  when: hook_path | exists
 
 - hosts: builder
   become: yes
@@ -118,6 +132,17 @@
 
     # - import_playbook: iam.yml - nothing to do
 
+- name: Run post.yml hook
+  vars:
+    appliances_environment_root: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}"
+    hook_path: "{{ appliances_environment_root }}/hooks/post.yml"
+  import_playbook: "{{ hook_path if hook_path | exists else 'noop.yml' }}"
+  when: hook_path | exists
+
+- hosts: builder
+  become: yes
+  gather_facts: no
+  tasks:
     - name: Cleanup image
       import_tasks: cleanup.yml
 

--- a/environments/.stackhpc/hooks/pre.yml
+++ b/environments/.stackhpc/hooks/pre.yml
@@ -1,4 +1,4 @@
-- hosts: control
+- hosts: control:!builder
   become: yes
   gather_facts: false
   tasks:

--- a/packer/README.md
+++ b/packer/README.md
@@ -39,7 +39,7 @@ Building an environment-specific compute node image will[^1] require a cluster t
 - Build images using the variable definition file:
 
         cd packer
-        PACKER_LOG=1 /usr/bin/packer build -except openstack.fatimage --on-error=ask -var-file=$PKR_VAR_environment_root/builder.pkrvars.hcl openstack.pkr.hcl
+        PACKER_LOG=1 /usr/bin/packer build -except openstack.openhpc --on-error=ask -var-file=$PKR_VAR_environment_root/builder.pkrvars.hcl openstack.pkr.hcl
 
   Note the builder VMs are added to the `builder` group to differentiate them from "real" nodes - see developer notes below.
 


### PR DESCRIPTION
This allows for customisation of the "fat" image pipeline by running environment-specific hooks. This is useful for cases where deployments want to build their own fat image, and have some specific requirements.

If hooks need to be prevented from running during *any* build, use e.g.:
```yaml
- hosts: compute:!builder 
```

If hooks should only run in the environment-specific compute image build, not the fat image build, use e.g.:
```yaml
- hosts: compute:!control:!login
```
(as the fat image build host is in all 3 groups)
