### PR TITLE
Re-enable NetworkManager control of resolv.conf after image build

### DIFF
--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -48,7 +48,7 @@ jobs:
           . venv/bin/activate
           . environments/.stackhpc/activate
           cd packer/
-          packer init
+          packer init .
           PACKER_LOG=1 packer build -only openstack.openhpc -on-error=ask -var-file=$PKR_VAR_environment_root/builder.pkrvars.hcl openstack.pkr.hcl
 
       - name: Get created image name from manifest

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -55,7 +55,7 @@ jobs:
         id: manifest
         run: |
           . venv/bin/activate
-          IMAGE_ID=$(jq --raw-output '.builds[-1].artifact_id' packer-manifest.json)
+          IMAGE_ID=$(jq --raw-output '.builds[-1].artifact_id' packer/packer-manifest.json)
           while ! openstack image show -f value -c name $IMAGE_ID; do
             sleep 30
           done

--- a/ansible/cleanup.yml
+++ b/ansible/cleanup.yml
@@ -5,10 +5,18 @@
 - name: Remove dnf caches
   command: dnf clean all
 
+# If image build happens on a Neutron subnet with property dns_namservers defined, then cloud-init
+# disables NetworkManager's control of /etc/resolv.conf and appends nameservers itself.
+# We don't want network configuration during instance boot to depend on the configuration
+# of the network the builder was on, so we reset these aspects.
 - name: Delete /etc/resolv.conf
-  # required as if cloud-init (rather than network manager) controls this on next boot it won't be entirely overrwritten
   file:
     path: /etc/resolv.conf
+    state: absent
+
+- name: Reenable NetworkManager control of resolv.conf
+  file:
+    path: /etc/NetworkManager/conf.d/99-cloud-init.conf
     state: absent
 
 - name: Delete any injected ssh config for rocky
@@ -18,4 +26,3 @@
 
 - name: Run cloud-init cleanup
   command: cloud-init clean --logs --seed
-

--- a/ansible/cleanup.yml
+++ b/ansible/cleanup.yml
@@ -19,9 +19,9 @@
     path: /etc/NetworkManager/conf.d/99-cloud-init.conf
     state: absent
 
-- name: Delete any injected ssh config for rocky
+- name: Delete any injected ssh config for ansible_user
   file:
-    path: /home/rocky/.ssh/
+    path: "/home/{{ ansible_user }}/.ssh/"
     state: absent
 
 - name: Run cloud-init cleanup

--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -108,6 +108,7 @@
     - name: unpack prometheus binaries
       become: false
       unarchive:
+        remote_src: yes
         src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp"
         creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/prometheus"
@@ -143,6 +144,7 @@
   become: yes
   gather_facts: no
   tasks:
+    # - meta: end_here
     - name: Cleanup image
       import_tasks: cleanup.yml
 

--- a/environments/.stackhpc/builder.pkrvars.hcl
+++ b/environments/.stackhpc/builder.pkrvars.hcl
@@ -1,6 +1,6 @@
 flavor = "vm.ska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
-source_image_name = "openhpc-230221-1226-f5ba2db7.qcow2" # https://github.com/stackhpc/ansible-slurm-appliance/pull/250
+source_image_name = "openhpc-230412-1447-e3769af6.qcow2" # https://github.com/stackhpc/ansible-slurm-appliance/pull/258
 #source_image_name = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]

--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -17,7 +17,7 @@ variable "create_nodes" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-230221-1226-f5ba2db7.qcow2" # https://github.com/stackhpc/ansible-slurm-appliance/pull/250
+    default = "openhpc-230412-1447-e3769af6.qcow2" # https://github.com/stackhpc/ansible-slurm-appliance/pull/258
     # default = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
     # default = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
 }


### PR DESCRIPTION


- Fixes #257, producing a fat image which should work on OpenStack subnets with or without `dns_nameservers` defined.
- Makes cleanup of injected ssh config during build depend on `ansible_user`, rather than being hard-coded to `rocky`.
- Fixes previously-untried fat image build workflow.