### PR TITLE
Remove bastion setup from CI

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -15,21 +15,9 @@ jobs:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
       TF_VAR_cluster_name: ci${{ github.run_id }}
+      BASTION_SSH_KEY: ${{ secrets.ARCUS_SSH_KEY }}
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup ssh
-        run: |
-          set -x
-          mkdir ~/.ssh
-          echo "${arcus_SSH_KEY}" > ~/.ssh/id_rsa
-          chmod 0600 ~/.ssh/id_rsa
-        env:
-          arcus_SSH_KEY: ${{ secrets.ARCUS_SSH_KEY }}
-
-      - name: Add bastion's ssh key to known_hosts
-        run: cat environments/.stackhpc/bastion_fingerprint >> ~/.ssh/known_hosts
-        shell: bash
       
       - name: Install ansible etc
         run: dev/setup-env.sh

--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -77,7 +77,6 @@ jobs:
         run: |
           . venv/bin/activate
           . environments/.stackhpc/activate
-          ansible all -m wait_for_connection
           ansible-playbook -v ansible/site.yml
           ansible-playbook -v ansible/ci/check_slurm.yml
 

--- a/environments/.stackhpc/hooks/pre.yml
+++ b/environments/.stackhpc/hooks/pre.yml
@@ -1,3 +1,18 @@
+- hosts: localhost
+  become: no
+  gather_facts: false
+  tasks:
+    - block: 
+      - name: Setup ssh
+        shell: |
+          set -x
+          mkdir ~/.ssh
+          echo "{{ lookup('env', 'BASTION_SSH_KEY') }}" > ~/.ssh/id_rsa
+          chmod 0600 ~/.ssh/id_rsa
+      - name: Add bastion's ssh key to known_hosts
+        shell: cat {{ appliances_environment_root }}/bastion_fingerprint >> ~/.ssh/known_hosts
+    when: "lookup('env', 'HOSTNAME') != 'steveb-deploy'"
+
 - hosts: control:!builder
   become: yes
   gather_facts: false

--- a/environments/.stackhpc/hooks/pre.yml
+++ b/environments/.stackhpc/hooks/pre.yml
@@ -13,6 +13,12 @@
         shell: cat {{ appliances_environment_root }}/bastion_fingerprint >> ~/.ssh/known_hosts
     when: "lookup('env', 'HOSTNAME') != 'steveb-deploy'"
 
+- hosts: all
+  become: no
+  gather_facts: false
+  tasks:
+    - wait_for_connection:
+
 - hosts: control:!builder
   become: yes
   gather_facts: false

--- a/environments/.stackhpc/hooks/pre.yml
+++ b/environments/.stackhpc/hooks/pre.yml
@@ -10,8 +10,9 @@
           echo "{{ lookup('env', 'BASTION_SSH_KEY') }}" > ~/.ssh/id_rsa
           chmod 0600 ~/.ssh/id_rsa
       - name: Add bastion's ssh key to known_hosts
-        shell: cat {{ appliances_environment_root }}/bastion_fingerprint >> ~/.ssh/known_hosts
-    when: "lookup('env', 'HOSTNAME') != 'steveb-deploy'"
+        shell:
+          cmd: "cat {{ appliances_environment_root }}/bastion_fingerprint >> ~/.ssh/known_hosts"
+      when: "lookup('env', 'HOSTNAME') != 'steveb-deploy'"
 
 - hosts: all
   become: no


### PR DESCRIPTION
Try doing this as an environment-specific pre-hook instead so that CI becomes more generic.

This is more to work out how to do it; production use would need:
- Secrets names changing to make them more generic, and to cope with bastion secret missing entirely.
- Thinking about whether the pre-hook should run when using the appliance locally in the CI environment (e.g. for dev/debugging)