### PR TITLE
Allow source images to be specified by UUID or name

### DIFF
--- a/environments/.stackhpc/builder.pkrvars.hcl
+++ b/environments/.stackhpc/builder.pkrvars.hcl
@@ -1,7 +1,7 @@
 flavor = "vm.ska.cpu.general.small"
 networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
 source_image_name = "openhpc-230412-1447-e3769af6.qcow2" # https://github.com/stackhpc/ansible-slurm-appliance/pull/258
-#source_image_name = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
+fatimage_source_image_name = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
 ssh_keypair_name = "slurm-app-ci"
 security_groups = ["default", "SSH"]
 ssh_bastion_host = "128.232.222.183"

--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -31,13 +31,26 @@ variable "networks" {
   type = list(string)
 }
 
+# Must supply either source_image_name or source_image
 variable "source_image_name" {
   type = string
+  default = null
 }
 
+variable "source_image" {
+  type = string
+  default = null
+}
+
+# Must supply either fatimage_source_image_name or fatimage_source_image
 variable "fatimage_source_image_name" {
   type = string
-  default = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
+  default = null
+}
+
+variable "fatimage_source_image" {
+  type = string
+  default = null
 }
 
 variable "flavor" {
@@ -101,6 +114,7 @@ source "openstack" "openhpc" {
 build {
   source "source.openstack.openhpc" {
     name = "compute"
+    source_image = "${var.source_image}"
     source_image_name = "${var.source_image_name}" # NB: must already exist in OpenStack
     image_name = "ohpc-${source.name}-${local.timestamp}-${substr(local.git_commit, 0, 8)}.qcow2" # also provides a unique legal instance hostname (in case of parallel packer builds)
   }
@@ -123,6 +137,7 @@ build {
 # The "fat" image build with all binaries:
 build {
   source "source.openstack.openhpc" {
+    source_image = "${var.fatimage_source_image}"
     source_image_name = "${var.fatimage_source_image_name}" # NB: must already exist in OpenStack
     image_name = "${source.name}-${local.timestamp}-${substr(local.git_commit, 0, 8)}.qcow2" # similar to name from slurm_image_builder
   }


### PR DESCRIPTION
Allow Packer base images to be specified by either UUID or name. Set default values in the `.stackhpc` environment.