### PR TITLE
Add debug logging options for opensearch & filebeat

### DIFF
--- a/ansible/roles/filebeat/defaults/main.yml
+++ b/ansible/roles/filebeat/defaults/main.yml
@@ -3,3 +3,4 @@
 #filebeat_config_path: undefined # REQUIRED. Path to filebeat.yml configuration file template
 filebeat_podman_user: "{{ ansible_user }}" # User that runs the filebeat container
 filebeat_version: 7.12.1 # latest usable with opensearch - see https://opensearch.org/docs/2.4/tools/index/#compatibility-matrix-for-beats
+filebeat_debug: false

--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -9,3 +9,4 @@ opensearch_data_path: /usr/share/opensearch/data
 opensearch_state: started # will be restarted if required
 opensearch_systemd_service_enabled: true
 opensearch_certs_duration: "{{ 365 * 10 }}" # days validity for self-signed certs
+opensearch_debug: false

--- a/ansible/roles/opensearch/templates/opensearch.yml.j2
+++ b/ansible/roles/opensearch/templates/opensearch.yml.j2
@@ -32,3 +32,5 @@ plugins.security.system_indices.enabled: true
 
 # Fake version for filebeat: https://opensearch.org/docs/2.4/tools/index/#agents-and-ingestion-tools
 compatibility.override_main_response_version: true
+
+{% if opensearch_debug | default(false) | bool %}logger.level: debug{% endif %}

--- a/environments/common/files/filebeat/filebeat.yml
+++ b/environments/common/files/filebeat/filebeat.yml
@@ -54,3 +54,5 @@ output.elasticsearch:
   ssl.verification_mode: none
   username: "admin"
   password: "{{ vault_elasticsearch_admin_password }}"
+
+{% if filebeat_debug | default(false) | bool %}logging.level: debug{% endif %}


### PR DESCRIPTION
Set variables `opensearch_debug` and `filebeat_debug` to enable debug-level logging for these containerised services.