### PR TITLE
Make etc_hosts role more flexible

### DIFF
--- a/ansible/roles/etc_hosts/README.md
+++ b/ansible/roles/etc_hosts/README.md
@@ -2,10 +2,10 @@
 
 Hosts in the `etc_hosts` groups have `/etc/hosts` created with entries of the format `IP_address canonical_hostname [alias]`.
 
-By default, an entry is created for each host in this group, using `ansible_host` as the IP_address and `inventory_hostname` as the canonical hostname. This may need overriding for multi-homed hosts.
+By default, an entry is created for each host in this group, using `ansible_host` as the IP_address and `inventory_hostname` as the canonical hostname. This may need overriding for multi-homed hosts or hosts with multiple aliases.
 
 # Variables
 
 - `etc_hosts_template`: Template file to use. Default is the in-role template.
-- `etc_hosts_hosts`: Hosts to create an entry for in `/etc/hosts`. Default is hosts in the group `etc_hosts`. NB: this is different from the hosts on which `/etc/hosts` is created, which is always the hosts in the `etc_hosts` group. This allows additional hosts to be added to `/etc/hosts` by defining them in inventory and referencing them in this variable.
 - `etc_hosts_hostvars`: A list of variable names, used (in the order supplied) to create the entry for each host. Default is `['ansible_host', 'inventory_hostname']`
+- `etc_hosts_extra_hosts`: String (possibly multi-line) defining additional hosts to add to `/etc/hosts`. Default is empty string.

--- a/ansible/roles/etc_hosts/README.md
+++ b/ansible/roles/etc_hosts/README.md
@@ -1,7 +1,11 @@
 # etc_hosts
 
-Hosts in the `etc_hosts` groups have `/etc/hosts` created. The generated file defines all hosts in this group using `ansible_host` as the IP address and `inventory_hostname` as the canonical hostname. This may need overriding for multi-homed hosts. See `environments/common/inventory/group_vars/all/cloud_init.yml` for configuration.
+Hosts in the `etc_hosts` groups have `/etc/hosts` created with entries of the format `IP_address canonical_hostname [alias]`.
 
-# Variables:
+By default, an entry is created for each host in this group, using `ansible_host` as the IP_address and `inventory_hostname` as the canonical hostname. This may need overriding for multi-homed hosts.
 
-- `etc_hosts_template`: Template file to use. Default uses in-role template.
+# Variables
+
+- `etc_hosts_template`: Template file to use. Default is the in-role template.
+- `etc_hosts_hosts`: Hosts to create an entry for in `/etc/hosts`. Default is hosts in the group `etc_hosts`. NB: this is different from the hosts on which `/etc/hosts` is created, which is always the hosts in the `etc_hosts` group. This allows additional hosts to be added to `/etc/hosts` by defining them in inventory and referencing them in this variable.
+- `etc_hosts_hostvars`: A list of variable names, used (in the order supplied) to create the entry for each host. Default is `['ansible_host', 'inventory_hostname']`

--- a/ansible/roles/etc_hosts/defaults/main.yml
+++ b/ansible/roles/etc_hosts/defaults/main.yml
@@ -1,5 +1,4 @@
 etc_hosts_template: hosts.j2
-etc_hosts_hosts: "{{ groups['etc_hosts'] }}"
 etc_hosts_hostvars:
   - ansible_host
   - inventory_hostname

--- a/ansible/roles/etc_hosts/defaults/main.yml
+++ b/ansible/roles/etc_hosts/defaults/main.yml
@@ -1,1 +1,5 @@
 etc_hosts_template: hosts.j2
+etc_hosts_hosts: "{{ groups['etc_hosts'] }}"
+etc_hosts_hostvars:
+  - ansible_host
+  - inventory_hostname

--- a/ansible/roles/etc_hosts/defaults/main.yml
+++ b/ansible/roles/etc_hosts/defaults/main.yml
@@ -3,3 +3,4 @@ etc_hosts_hosts: "{{ groups['etc_hosts'] }}"
 etc_hosts_hostvars:
   - ansible_host
   - inventory_hostname
+etc_hosts_extra_hosts: ''

--- a/ansible/roles/etc_hosts/templates/hosts.j2
+++ b/ansible/roles/etc_hosts/templates/hosts.j2
@@ -1,6 +1,9 @@
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
-{% for inventory_hostname in etc_hosts_hosts | sort -%}
+{% for inventory_hostname in groups['etc_hosts'] | sort -%}
 {{ hostvars[inventory_hostname] | json_query('['  + ( etc_hosts_hostvars | join(', ') ) + ']' ) | join(' ')}}
 {% endfor %}
+{% if etc_hosts_extra_hosts != '' %}
+{{ etc_hosts_extra_hosts }}
+{% endif %}

--- a/ansible/roles/etc_hosts/templates/hosts.j2
+++ b/ansible/roles/etc_hosts/templates/hosts.j2
@@ -1,6 +1,6 @@
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
-{% for hostname in groups['etc_hosts'] | sort -%}
-{{ hostvars[hostname]['ansible_host'] }} {{ hostname }}
-{% endfor -%}
+{% for inventory_hostname in etc_hosts_hosts | sort -%}
+{{ hostvars[inventory_hostname] | json_query('['  + ( etc_hosts_hostvars | join(', ') ) + ']' ) | join(' ')}}
+{% endfor %}


### PR DESCRIPTION
The `etc_hosts` role now supports:
- Using non-default hostvars to define the IP, name etc for each host's entry.
- Adding entries for hosts other than those in `etc_hosts` group.