### PR TITLE
Add support for Spectrum Scale / GFPS

### DIFF
--- a/ansible/filesystems.yml
+++ b/ansible/filesystems.yml
@@ -16,3 +16,28 @@
   tasks:
     - include_role:
         name: stackhpc.nfs
+
+- name: Setup SpectrumScale
+  hosts: spectrum_scale
+  become: yes
+  gather_facts: yes
+  tags:
+    - spectrum_scale
+  collections:
+    - ibm.spectrum_scale
+  vars:
+    ansible_distribution: RedHat # Rocky not officially supported
+  tasks:
+    - include_role:
+        name: ibm.spectrum_scale.core_prepare
+    - include_role:
+        name: ibm.spectrum_scale.core_install
+    - include_role:
+        name: ibm.spectrum_scale.core_configure
+      when: "'builder' not in group_names"
+    - include_role:
+        name: ibm.spectrum_scale.remotemount_configure
+      when: "'builder' not in group_names"
+    - include_role:
+        name: ibm.spectrum_scale.core_verify
+      when: "'builder' not in group_names"

--- a/ansible/filesystems.yml
+++ b/ansible/filesystems.yml
@@ -37,7 +37,9 @@
       when: "'builder' not in group_names"
     - include_role:
         name: ibm.spectrum_scale.remotemount_configure
-      when: "'builder' not in group_names"
+      when:
+        - "'builder' not in group_names"
+        - "scale_remotemount_filesystem_name | length > 0"
     - include_role:
         name: ibm.spectrum_scale.core_verify
       when: "'builder' not in group_names"

--- a/environments/common/inventory/group_vars/all/spectrum_scale.yml
+++ b/environments/common/inventory/group_vars/all/spectrum_scale.yml
@@ -1,0 +1,35 @@
+# The ibm.spectrum_scale roles are used to configure hosts in the `spectrum_scale` group as a GPFS cluster
+# without local storage but mounting remote GPFS filesystem(s).
+#
+# NB: group_vars are mostly prefixed scale_.
+# See ansible/collections/ansible_collections/ibm/spectrum_scale/roles/docs/VARIABLES.md for definitions
+
+# --- Installation ---
+scale_install_localpkg_path: "{{ undef('scale_install_localpkg_path is required') }}"
+# e.g.: "{{ lookup('env', 'APPLIANCES_REPO_ROOT') }}/Spectrum_Scale_Erasure_Code-5.1.6.1-x86_64-Linux-install"
+# Fix issues with spectrum_scale/roles/core_install/tasks/upgrade.yml when using _localpkg_path:
+scale_install_needsupdate: false
+scale_install_updated: false
+
+# --- Node preparation ---
+scale_prepare_enable_ssh_login: true
+scale_prepare_restrict_ssh_address: false
+scale_prepare_disable_ssh_hostkeycheck: false
+scale_prepare_exchange_keys: true
+scale_prepare_disable_firewall: false # might need changing if node is in both login (->fail2ban->firewalld) and spectrum_scale groups
+
+# --- Remote mount configuration ---
+# See roles/remotemount_configure/README.md for definitions
+# scale_remotemount_debug: true
+scale_remotemount_storage_gui_username: "{{ undef('scale_remotemount_storage_gui_username is required') }}"
+scale_remotemount_storage_gui_password: "{{ undef('scale_remotemount_storage_gui_password is required') }}"
+scale_remotemount_storage_gui_hostname: "{{ undef('scale_remotemount_storage_gui_hostname is required') }}"
+scale_remotemount_client_no_gui: true
+
+# Define the remote filesystems and local mountpoints:
+scale_remotemount_filesystem_name: "{{ undef('scale_remotemount_filesystem_name is required') }}"
+# At a minimum this is e.g.:
+# - scale_reotemount_client_filesystem_name: scratch
+#   scale_remotemount_client_remotemount_path: /gpfs/scratch
+#   scale_remotemount_storage_filesystem_name: tdc_scratch
+# See examples in roles/remotemount_configure/README.md for full options

--- a/environments/common/inventory/group_vars/all/spectrum_scale.yml
+++ b/environments/common/inventory/group_vars/all/spectrum_scale.yml
@@ -21,15 +21,22 @@ scale_prepare_disable_firewall: false # might need changing if node is in both l
 # --- Remote mount configuration ---
 # See roles/remotemount_configure/README.md for definitions
 # scale_remotemount_debug: true
+
+scale_remotemount_filesystem_name: [] # default will not perform any configuration for remote mounts
+# This defines the remote filesystems and local mountpoints. A minimal example is:
+# - scale_reotemount_client_filesystem_name: scratch
+#   scale_remotemount_client_remotemount_path: /gpfs/scratch
+#   scale_remotemount_storage_filesystem_name: tdc_scratch
+# See further examples in roles/remotemount_configure/README.md for full options
+#
+# **NB:** The IBM roles cannot manage all changes to scale_remotemount_filesystem_name once filesystems have been mounted.
+# To reset the configuration, run the following as root on any spectrum_scale node before re-running ansible:
+#   # Unmount all remote GPFS filesystems:
+#   [root@compute-0 cloud-user]# /usr/lpp/mmfs/bin/mmumount all_remote -N all
+#   # Delete all local information about the remote filesystems:
+#   [root@compute-0 cloud-user]# /usr/lpp/mmfs/bin/mmremotefs delete all
+
 scale_remotemount_storage_gui_username: "{{ undef('scale_remotemount_storage_gui_username is required') }}"
 scale_remotemount_storage_gui_password: "{{ undef('scale_remotemount_storage_gui_password is required') }}"
 scale_remotemount_storage_gui_hostname: "{{ undef('scale_remotemount_storage_gui_hostname is required') }}"
 scale_remotemount_client_no_gui: true
-
-# Define the remote filesystems and local mountpoints:
-scale_remotemount_filesystem_name: "{{ undef('scale_remotemount_filesystem_name is required') }}"
-# At a minimum this is e.g.:
-# - scale_reotemount_client_filesystem_name: scratch
-#   scale_remotemount_client_remotemount_path: /gpfs/scratch
-#   scale_remotemount_storage_filesystem_name: tdc_scratch
-# See examples in roles/remotemount_configure/README.md for full options

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -109,3 +109,6 @@ prometheus
 
 [proxy]
 # Hosts to configure http/s proxies - see ansible/roles/proxy/README.md
+
+[spectrum_scale]
+# Hosts to install IMB Spectrum Scale (GPFS) on - see environments/common/inventory/group_vars/all/spectrum_scale.yml

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -63,3 +63,6 @@ openhpc
 
 [proxy]
 # Hosts to configure http/s proxies - see ansible/roles/proxy/README.md
+
+[spectrum_scale]
+# Hosts to install IMB Spectrum Scale (GPFS) on - see environments/common/inventory/group_vars/all/spectrum_scale.yml

--- a/requirements.yml
+++ b/requirements.yml
@@ -27,4 +27,7 @@ collections:
 - name: https://github.com/stackhpc/ansible_collection_slurm_openstack_tools
   type: git
   version: v0.2.0
+- name: https://github.com/stackhpc/ibm-spectrum-scale-install-infra.git
+  type: git
+  version: fix/new-ansible
 ...


### PR DESCRIPTION
Define hosts in group `spectrum_scale` to enable. Uses IBM roles. See `environments/common/inventory/group_vars/all/spectrum_scale.yml`.

By default this assumes the Spectrum Scale cluster clreated does not have its own storage and instead mounts filesystem(s) from a remote GPFS cluster ([docs](https://www.ibm.com/docs/en/storage-scale/5.1.6?topic=administering-accessing-remote-gpfs-file-system)).

Note that if Slurm-controlled reimaging of compute nodes in the `spectrum_scale` group is not supported. Such nodes will require `ansible/filesystems.yml` (at a minimum) to be run to configure Spectrum Scale after a rebuild.