### PR TITLE
Update prometheus-slurm-exporter version

### DIFF
--- a/ansible/roles/slurm_exporter/defaults/main.yml
+++ b/ansible/roles/slurm_exporter/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # see https://github.com/stackhpc/prometheus-slurm-exporter/releases - version follows upstream, release is stackhpc build
-slurm_exporter_version: '0.20'
-slurm_exporter_release: '2'
+slurm_exporter_version: '0.21'
+slurm_exporter_release: '1'
 slurm_exporter_state: started


### PR DESCRIPTION
prometheus-slurm-exporter 0.20 fails to parse GRES output for Slurm >19.05.0rc1 and just ends up in a crash loop.

Update versions to point to new RPM (https://github.com/stackhpc/prometheus-slurm-exporter/releases/tag/0.21) built from the development branch of https://github.com/stackhpc/prometheus-slurm-exporter, which has the relevant fixes in.