### PR TITLE
Add localhost to limit when building images

### DIFF
--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -159,7 +159,7 @@ build {
     groups = concat(["builder"], split("-", "${source.name}"))
     keep_inventory_file = true # for debugging
     use_proxy = false # see https://www.packer.io/docs/provisioners/ansible#troubleshooting
-    extra_arguments = ["--limit", "builder", "-i", "${var.repo_root}/packer/ansible-inventory.sh", "-vv", "-e", "@${var.repo_root}/packer/${source.name}_extravars.yml"]
+    extra_arguments = ["--limit", "builder,localhost", "-i", "${var.repo_root}/packer/ansible-inventory.sh", "-vv", "-e", "@${var.repo_root}/packer/${source.name}_extravars.yml"]
   }
 
   post-processor "manifest" {
@@ -184,7 +184,7 @@ build {
     groups = ["builder", "control", "compute", "login"]
     keep_inventory_file = true # for debugging
     use_proxy = false # see https://www.packer.io/docs/provisioners/ansible#troubleshooting
-    extra_arguments = ["--limit", "builder", "-i", "${var.repo_root}/packer/ansible-inventory.sh", "-vv", "-e", "@${var.repo_root}/packer/${source.name}_extravars.yml"]
+    extra_arguments = ["--limit", "builder,localhost", "-i", "${var.repo_root}/packer/ansible-inventory.sh", "-vv", "-e", "@${var.repo_root}/packer/${source.name}_extravars.yml"]
   }
 
   post-processor "manifest" {


### PR DESCRIPTION
Limiting to localhost and builder means that plays that run on localhost - notably those detecting hooks - are in the scope of the play. Limiting to just to just builder means that hooks are never run because they cannot be detected.