### PR TITLE
Install out of tree openstack builder plugin

### DIFF
--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -7,6 +7,10 @@ packer {
       version = ">= 0.3.2"
       source = "github.com/ethanmdavidson/git"
     }
+    openstack = {
+      version = ">= 1.0.0"
+      source  = "github.com/hashicorp/openstack"
+    }
   }
 }
 


### PR DESCRIPTION
Hashicorp OpenStack builder plugin is now out-of-tree and doesn't get shipped with Packer by default. List it as an explicit dependency.