### PR TITLE
Update ondemand to v3

### DIFF
--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -45,7 +45,7 @@
         tasks_from: install.yml
 
     - name: Include distribution variables for osc.ood
-      include_vars: "{{ appliances_repository_root }}/ansible/roles/osc.ood/vars/Rocky.yml"
+      include_vars: "{{ appliances_repository_root }}/ansible/roles/osc.ood/vars/Rocky/8.yml"
     # FUTURE: install-apps.yml - this is git clones
 
     # - import_playbook: portal.yml

--- a/ansible/roles/openondemand/tasks/main.yml
+++ b/ansible/roles/openondemand/tasks/main.yml
@@ -10,7 +10,7 @@
 - include_role:
     name: osc.ood
     tasks_from: install-package.yml
-    vars_from: Rocky.yml
+    vars_from: Rocky/8.yml
     public: yes # Expose the vars from this role to the rest of the play
   # can't set vars: from a dict hence the workaround above
 

--- a/environments/.stackhpc/hooks/pre.yml
+++ b/environments/.stackhpc/hooks/pre.yml
@@ -2,6 +2,12 @@
   become: yes
   gather_facts: false
   tasks:
+    - name: Ensure CI_CLOUD is set
+      assert:
+        that: "lookup('env', 'CI_CLOUD') != ''"
+        fail_msg: "Did you forget to `export CI_CLOUD={SMS,ARCUS}` when running manually?"
+      delegate_to: localhost
+
     - name: Write CI-generated inventory and secrets for debugging
       ansible.builtin.copy:
         dest: /etc/ci-config/

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -13,7 +13,7 @@
 # or include regex special characters.
 openondemand_host_regex: "{{ (groups['compute'] + groups['grafana']) | to_ood_regex }}"
 
-ondemand_package: ondemand-2.0.29
+ondemand_package: ondemand-3.0.1
 
 openondemand_dashboard_links: # TODO: should really only be deployed if grafana is deployed and proxying configured
   - name: Grafana

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,7 +19,7 @@ roles:
     # No versions available
   - src: https://github.com/OSC/ood-ansible.git
     name: osc.ood
-    version: v3.0.2
+    version: v3.0.3
 
 collections:
 - name: containers.podman

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,7 +19,7 @@ roles:
     # No versions available
   - src: https://github.com/OSC/ood-ansible.git
     name: osc.ood
-    version: v2.0.8
+    version: v3.0.2
 
 collections:
 - name: containers.podman


### PR DESCRIPTION
Update Open Ondemand to v3.

Fixes #289 

TODO:
- [ ] Check if v3.0 [autoloading changes](https://osc.github.io/ood-documentation/latest/release-notes/v3.0-release-notes.html#autoloading-during-initialization-is-deprecated) affect our auto-population of files app 
- [ ] Check whether `_opeonondemand_unset_auth` can be removed - see linked issue above

Manual tests (will be updated as completed):
- [OK] site.yml runs OK
- [FAILED] Slurm job dashboard has info