### PR TITLE
Fix query type in the Slurm jobs Grafana dashboard

### DIFF
--- a/ansible/roles/grafana-dashboards/files/slurm-jobs.json
+++ b/ansible/roles/grafana-dashboards/files/slurm-jobs.json
@@ -150,7 +150,7 @@
             }
           ],
           "query": "*",
-          "queryType": "randomWalk",
+          "queryType": "lucene",
           "refId": "A",
           "timeField": "@timestamp"
         }


### PR DESCRIPTION
Set the query type to "lucene" to fix the `Slurm jobs` dashboard.

The original query causes a `SIGSEGV: segmentation violation` in versions above 2.6.2 of the OpenSearch plugin due to this change:
https://github.com/grafana/opensearch-datasource/commit/24fcd47ea212f058ecf8227554c2d16a93f60a57#diff-804a5756e358074cb0ba27b1932cca77d39b90694fc1d4d122f46348c8653259

This then makes Grafana return a 500 error with the `TypeError: pa[t] is undefined` message.

CC: https://github.com/stackhpc/ansible-slurm-appliance/pull/292