### PR TITLE
Fix SMS ssh

### DIFF
--- a/environments/.stackhpc/ansible.cfg
+++ b/environments/.stackhpc/ansible.cfg
@@ -11,6 +11,5 @@ roles_path = ../../ansible/roles
 filter_plugins = ../../ansible/filter_plugins
 
 [ssh_connection]
-#ssh_args = -o ControlMaster=auto -o ControlPersist=240s -o PreferredAuthentications=publickey -o UserKnownHostsFile=/dev/null
-ssh_args = -o PreferredAuthentications=publickey -o UserKnownHostsFile=/dev/null
+ssh_args = -o ControlMaster=auto -o ControlPath=~/.ssh/%r@%h-%p -o ControlPersist=240s -o PreferredAuthentications=publickey -o UserKnownHostsFile=/dev/null
 pipelining = True


### PR DESCRIPTION
ControlPath was missing from the original smslabs SSH config.


TODO: change environments/skeleton/{{cookiecutter.environment}}/ansible.cfg as well