### PR TITLE
Add image upload CI workflow

### DIFF
--- a/.github/workflows/image_upload.yml
+++ b/.github/workflows/image_upload.yml
@@ -1,0 +1,53 @@
+name: Upload CI-tested image to Arcus S3
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Test deployment and reimage on OpenStack
+    types:
+      - complete
+    branches:
+      - main # only want to run after merge has successfully passed CI
+jobs:
+  image_upload:
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    concurrency: ${{ github.ref }} # to branch/PR
+    env:
+      ANSIBLE_FORCE_COLOR: True
+      OS_CLOUD: openstack
+      CI_CLOUD: ${{ vars.CI_CLOUD }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Record which cloud CI is running on
+        run: |
+          echo CI_CLOUD: ${{ vars.CI_CLOUD }}
+
+      - name: Add bastion's ssh key to known_hosts
+        run: cat environments/.stackhpc/bastion_fingerprints >> ~/.ssh/known_hosts
+        shell: bash
+
+      - name: Install ansible etc
+        run: dev/setup-env.sh
+
+      - name: Write clouds.yaml
+        run: |
+          mkdir -p ~/.config/openstack/
+          echo "${{ secrets[format('{0}_CLOUDS_YAML', vars.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
+        shell: bash
+
+      - name: Write s3cmd configuration
+        run: |
+          echo "${{ secrets['ARCUS_S3CFG'] }}" > ~/.s3cfg
+        shell: bash
+
+      - name: Install s3cmd
+        run: |
+          sudo apt-get --yes install s3cmd
+
+      - name: Upload latest image if missing
+        run: |
+          . venv/bin/activate
+          . environments/.stackhpc/activate
+          ansible-playbook -v ansible/ci/upload_image.yml

--- a/ansible/ci/upload_image.yml
+++ b/ansible/ci/upload_image.yml
@@ -19,6 +19,6 @@
         command: "openstack image save --file {{ ci_image }} {{ ci_image }}"
       
       - name: Upload image to s3
-        command: "s3cmd put {{ ci_image }} s3://openhpc-images "
+        command: "s3cmd put {{ ci_image }}.qcow2 s3://openhpc-images "
       
       when: "ci_image not in s3_ls.stdout"

--- a/ansible/ci/upload_image.yml
+++ b/ansible/ci/upload_image.yml
@@ -1,0 +1,24 @@
+- hosts: localhost
+  gather_facts: no
+  become: no
+  tasks:
+    - name: List images in Arcus S3 release bucket
+      command: s3cmd ls s3://openhpc-images
+      register: s3_ls
+
+    - name: Get current CI terraform image name
+      set_fact:
+        ci_image: "{{ lookup('file', appliances_environment_root + '/terraform/main.tf') | regex_search('openhpc-[0-9a-z-]+') }}"
+
+    - name: Show extracted current CI terraform image name
+      debug:
+        msg: "Current image from terraform main.tf: {{ ci_image }}"
+
+    - block:
+      - name: Download image to local storage
+        command: "openstack image save --file {{ ci_image }} {{ ci_image }}"
+      
+      - name: Upload image to s3
+        command: "s3cmd put {{ ci_image }} s3://openhpc-images "
+      
+      when: "ci_image not in s3_ls.stdout"


### PR DESCRIPTION
Allows images built on either CI cloud to be uploaded to Arcus S3. Either triggered manually, or via successful completion of main CI run after merging a PR to `main` branch.

TODO: add secrets to repo before merging