### PR TITLE
Ensure pip is up to date in websockify venv

### DIFF
--- a/ansible/roles/openondemand/tasks/vnc_compute.yml
+++ b/ansible/roles/openondemand/tasks/vnc_compute.yml
@@ -29,6 +29,7 @@
     name: pip
     virtualenv: /opt/websockify
     virtualenv_command: python3 -m venv
+    state: latest
   tags: install
 
 - name: Install websockify package in venv


### PR DESCRIPTION
I'm hitting the following error while trying to install the latest version of the CaaS Slurm appliance, which seems to be occurring in the "Install websockify package in venv" task in this repo:
```
Traceback (most recent call last):
      File \"<string>\", line 1, in <module>
      File \"/tmp/pip-build-wpwhfgb4/cryptography/setup.py\", line 18, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'
    
    ----------------------------------------

:stderr: Command \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-wpwhfgb4/cryptography/
You are using pip version 9.0.3, however version 23.2.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
", "invocation": {"module_args": {"name": ["websockify"], "virtualenv": "/opt/websockify", "virtualenv_command": "python3 -m venv", "state": "present", "virtualenv_site_packages": false, "editable": false, "version": null, "requirements": null, "virtualenv_python": null, "extra_args": null, "chdir": null, "executable": null, "umask": null}}, "_ansible_no_log": null, "changed": false}, "start": "2023-08-25T15:36:18.592459", "end": "2023-08-25T15:36:27.771264", "duration": 9.178805, "ignore_errors": null, "event_loop": null, "uuid": "6b55e258-0464-44da-b86e-dc09c4650d26"}}
```
Will test this fix then update PR with outcome.