### PR TITLE
DO NOT MERGE: Update openhpc role for slurm.conf changes

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - src: stackhpc.nfs
     version: v22.9.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v0.20.0 # Allow multiple empty partitions by @sjpb in #156
+    version: feat/update-slurmconf # NON-FUNCTIONAL changes to slurm.conf
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: feature/no-install


### PR DESCRIPTION
**NB:** This should NOT currently be merged, it is just using the Slurm CI to check non-functional changes in https://github.com/stackhpc/ansible-role-openhpc/pull/161.