### PR TITLE
Fix issues when using GenericCloud image

### DIFF
--- a/ansible/roles/openondemand/tasks/vnc_compute.yml
+++ b/ansible/roles/openondemand/tasks/vnc_compute.yml
@@ -12,38 +12,46 @@
 
 - name: Install VNC-related packages
   tags: install
-  yum:
+  dnf:
     name:
       - turbovnc-3.0.1
       - nmap-ncat
-      - python3
+      - python3.9
 
 - name: Install Xfce desktop
   tags: install
   yum:
     name: '@Xfce'
   
+# - name: Ensure python3.9 installed
+#   dnf:
+#     name: python39
+#   tags: install
+
 - name: Install websockify venv
   # Requires separate step so that the upgraded pip is used to install packages
   pip:
     name: pip
-    virtualenv: /opt/websockify
-    virtualenv_command: python3 -m venv
+    state: latest
+    virtualenv: /opt/websockify-py39
+    virtualenv_command: python3.9 -m venv
   tags: install
 
 - name: Install websockify package in venv
   pip:
     name: websockify
-    virtualenv: /opt/websockify
+    virtualenv: /opt/websockify-py39
     virtualenv_command: python3 -m venv
   tags: install
 
 - name: Symlink websockify to where Open Ondemand expects
-  file:
-    src: /opt/websockify/bin/websockify
-    dest: /opt/websockify/run
-    state: link
-
+  file: "{{ item }}"
+  loop:
+    - path: /opt/websockify
+      state: directory
+    - src: /opt/websockify-py39/bin/websockify
+      dest: /opt/websockify/run
+      state: link
 - name: Disable screensaver # as users might not have passwords
   yum:
     name: xfce4-screensaver

--- a/environments/.stackhpc/ARCUS.pkrvars.hcl
+++ b/environments/.stackhpc/ARCUS.pkrvars.hcl
@@ -1,5 +1,8 @@
 flavor = "vm.ska.cpu.general.small"
-networks = ["a262aabd-e6bf-4440-a155-13dbc1b5db0e"] # WCDC-iLab-60
+use_blockstorage_volume = true
+volume_size = 10 # GB
+image_disk_format = "qcow2"
+networks = ["4b6b2722-ee5b-40ec-8e52-a6610e14cc51"] # portal-internal (DNS broken on ilab-60)
 source_image_name = "openhpc-230804-1754-80b8d714" # https://github.com/stackhpc/ansible-slurm-appliance/pull/298
 fatimage_source_image_name = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
 ssh_keypair_name = "slurm-app-ci"

--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -13,7 +13,7 @@ variable "cluster_name" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-230811-1548-a49164d1" # https://github.com/stackhpc/ansible-slurm-appliance/pull/301
+    default = "openhpc-230922-0940-434e190f" # https://github.com/stackhpc/ansible-slurm-appliance/pull/313
     # default = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
     # default = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
 }

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -48,7 +48,6 @@ appliances_local_users_default:
         shell: /sbin/nologin
         uid: 202
         system: true
-      enable: "{{ 'control' in group_names }}"
     
     - group:
         name: prometheus


### PR DESCRIPTION
- Upgrade to python3.9 and latest pip for Open Ondemand websockify venv to fix error caused by pip changes:
       
       [openondemand : Install websockify package in venv] ... ModuleNotFoundError: No module named 'setuptools_rust'

   Note the venv path is changed to avoid any potential upgrade issues.
- Ensure `slurm` user is pre-installed on all nodes to avoid potential for uid/gid clash.

- Provides new image `openhpc-230922-0940-434e190f`, requiring 10GB root disk.

- Arcus packer build now uses volume-backed instances to achieve this.