### PR TITLE
Make nvidia-driver install idempotent

### DIFF
--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -2,6 +2,8 @@
 
 Install NVIDIA CUDA. The CUDA binaries are added to the PATH for all users, and the [NVIDIA persistence daemon](https://docs.nvidia.com/deploy/driver-persistence/index.html#persistence-daemon) is enabled.
 
+To avoid unwanted package updates which break functionality, on first use this role enables the dkms-flavour `nvidia-driver` DNF module stream which has the current highest version number. The `latest-dkms` stream is not enabled, and subsequent runs of the role will *not* switch which stream is enabled even if later version streams become available. If an upgrade of the `nvidia-driver` module is required, the currently-enabled stream and all packages should be manually removed.
+
 ## Prerequisites
 
 Requires OFED to be installed to provide required kernel-* packages.

--- a/ansible/roles/cuda/tasks/main.yml
+++ b/ansible/roles/cuda/tasks/main.yml
@@ -17,22 +17,40 @@
     dest: "/etc/yum.repos.d/cuda-{{ cuda_distro }}.repo"
     url: "{{ cuda_repo }}"
 
-- name: Enable nvidia driver module
-  ansible.builtin.command: dnf module enable -y nvidia-driver:latest-dkms
-  register: nvidiadriver_enable
-  changed_when: "'Nothing to do' not in nvidiadriver_enable.stdout"
+- name: Check if nvidia driver module is enabled
+  shell:
+    cmd: dnf module list --enabled nvidia-driver
+  changed_when: false
+  failed_when: false
+  register: _cuda_driver_module_enabled
 
-- name: Install nvidia driver module
-  ansible.builtin.command: dnf module install -y nvidia-driver:latest-dkms
-  register: nvidiadriver_install
-  changed_when: "'Nothing to do' not in nvidiadriver_install.stdout"
+- name: List nvidia driver dnf module stream versions
+  shell:
+    cmd: dnf module list nvidia-driver | grep -oP "\d+-dkms" | sort -V
+  # Output of interest from command is something like (some whitespace removed):
+  # "nvidia-driver 418-dkms   default [d], fm, ks    Nvidia driver for 418-dkms branch "
+  changed_when: false
+  register: _cuda_driver_module_streams
+  when: "'No matching Modules to list' in _cuda_driver_module_enabled.stderr"
+
+- name: Enable nvidia driver module
+  ansible.builtin.command: "dnf module enable -y nvidia-driver:{{ _cuda_driver_module_streams.stdout_lines | last }}"
+  register: _cuda_driver_module_enable
+  when: "'No matching Modules to list' in _cuda_driver_module_enabled.stderr"
+  changed_when: "'Nothing to do' not in _cuda_driver_module_enable.stdout"
+
+- name: Install nvidia drivers # TODO: make removal possible?
+  ansible.builtin.command: dnf module install -y nvidia-driver
+  register: _cuda_driver_install
+  when: "'No matching Modules to list' in _cuda_driver_module_enabled.stderr"
+  changed_when: "'Nothing to do' not in _cuda_driver_install.stdout"
 
 - name: Install cuda packages
   ansible.builtin.dnf:
     name: "{{ cuda_packages }}"
   register: cuda_package_install
 
-- name: Add latest cuda binaries to path
+- name: Add cuda binaries to path
   lineinfile:
     path: /etc/profile.d/sh.local
     line: 'export PATH=$PATH:$(ls -1d /usr/local/cuda-* | sort -V | tail -1)/bin'


### PR DESCRIPTION
Makes the install of the `nvidia-driver` module by the CUDA role idempotent, so that the module's packages are not updated by rerunning the role.

If using the `nvidia-driver:latest-dkms` module stream, running `dnf module install nvidia-driver` will update drivers if more recent ones become available. This is in contrast to non-modular `dnf install $package_name` behaviour, where installed packages are *not* updated by rerunning the command.

This PR changes the role to check if a nvidia-driver module is enabled, and only if not, search for the highest-numbered dkms-variant module stream and enable that.