### PR TITLE
DO NOT MERGE: PoC for RL9

### DIFF
--- a/ansible/roles/mysql/tasks/install.yml
+++ b/ansible/roles/mysql/tasks/install.yml
@@ -1,6 +1,13 @@
-- name: Install python mysql client
+- name: Install pip
+  dnf:
+    name: python3-pip
+
+- name: Install python mysql client and dependencies
+  # TODO: FIXME: doing this in the system python doesn't seem right
   pip:
-    name: pymysql
+    name:
+      - pymysql
+      - cryptography # avoids error "'cryptography' package is required for sha256_password or caching_sha2_password auth methods"
     state: present
 
 - name: Create systemd mysql container unit file

--- a/ansible/roles/mysql/templates/mysql.service.j2
+++ b/ansible/roles/mysql/templates/mysql.service.j2
@@ -14,6 +14,7 @@ EnvironmentFile=/etc/sysconfig/mysqld
 # The above EnvironmentFile must define MYSQL_INITIAL_ROOT_PASSWORD
 ExecStartPre=+install -d -o {{ mysql_podman_user }} -g {{ mysql_podman_user }} -Z container_file_t {{ mysql_datadir }}
 ExecStartPre=+chown -R {{ mysql_podman_user }}:{{ mysql_podman_user }} {{ mysql_datadir }}
+ExecStartPre=/usr/bin/podman pull docker.io/library/mysql:{{ mysql_tag }}
 ExecStart=/usr/bin/podman run \
     --network=host \
     --sdnotify=conmon \
@@ -26,7 +27,7 @@ ExecStart=/usr/bin/podman run \
     --volume {{ mysql_datadir }}:/var/lib/mysql:U \
     --publish 3306:3306 \
     --env MYSQL_ROOT_PASSWORD=${MYSQL_INITIAL_ROOT_PASSWORD} \
-    mysql:{{ mysql_tag }}{%- for opt in mysql_mysqld_options %} \
+    docker.io/library/mysql:{{ mysql_tag }}{%- for opt in mysql_mysqld_options %} \
     --{{ opt }}{% endfor %}
 
 ExecStop=/usr/bin/podman stop --ignore mysql -t 10

--- a/ansible/roles/opensearch/tasks/runtime.yml
+++ b/ansible/roles/opensearch/tasks/runtime.yml
@@ -76,7 +76,7 @@
 
 - name: Pull container
   containers.podman.podman_image:
-    name: "opensearchproject/opensearch:{{ opensearch_version }}"
+    name: "docker.io/opensearchproject/opensearch:{{ opensearch_version }}"
   become_user: "{{ opensearch_podman_user }}"
 
 - name: Flush handlers

--- a/ansible/roles/opensearch/templates/opensearch.service.j2
+++ b/ansible/roles/opensearch/templates/opensearch.service.j2
@@ -29,7 +29,7 @@ ExecStart=/usr/bin/podman run \
     --env bootstrap.memory_lock=true \
     --env "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" \
     --env DISABLE_INSTALL_DEMO_CONFIG=true \
-    opensearchproject/opensearch:{{ opensearch_version }}
+    docker.io/opensearchproject/opensearch:{{ opensearch_version }}
 ExecStop=/usr/bin/podman stop --ignore opensearch -t 10
 # note for some reason this returns status=143 which makes systemd show the unit as failed, not stopped
 ExecStopPost=/usr/bin/podman rm --ignore -f opensearch

--- a/ansible/roles/podman/tasks/config.yml
+++ b/ansible/roles/podman/tasks/config.yml
@@ -35,51 +35,61 @@
   register: podman_user_info
   become: yes
 
-- name: Define tmp directories on tmpfs
-  blockinfile:
-    path: /etc/tmpfiles.d/podman.conf
-    create: yes
-    block: |
-      d {{ podman_tmp_dir_root }}/{{ item.name }}/libpod/tmp 0755 {{ item.name }} {{ item.name }}
-      Z {{ podman_tmp_dir_root }}/{{ item.name }}            0755 {{ item.name }} {{ item.name }}
-  become: yes
-  loop: "{{ podman_users }}"
-  register: podman_tmp_dirs
+# - name: Define tmp directories on tmpfs
+#   blockinfile:
+#     path: /etc/tmpfiles.d/podman.conf
+#     create: yes
+#     block: |
+#       d {{ podman_tmp_dir_root }}/{{ item.name }}/libpod/tmp 0755 {{ item.name }} {{ item.name }}
+#       Z {{ podman_tmp_dir_root }}/{{ item.name }}            0755 {{ item.name }} {{ item.name }}
+#   become: yes
+#   loop: "{{ podman_users }}"
+#   register: podman_tmp_dirs
 
-- name: Create tmp directories
-  command: systemd-tmpfiles --create
-  become: true
-  when: podman_tmp_dirs.results | selectattr('changed') | list | length > 0 # when: any changed
+# - name: Create tmp directories
+#   command: systemd-tmpfiles --create
+#   become: true
+#   when: podman_tmp_dirs.results | selectattr('changed') | list | length > 0 # when: any changed
 
-- name: Create podman configuration directories
-  file:
-    path: "{{ item.home }}/.config/containers/"
-    state: directory
-    owner: "{{ item.name }}"
-    group: "{{ item.name }}"
-  become: yes
-  loop: "{{ podman_user_info.results }}"
+# - name: Create podman configuration directories
+#   file:
+#     path: "{{ item.home }}/.config/containers/"
+#     state: directory
+#     owner: "{{ item.name }}"
+#     group: "{{ item.name }}"
+#   become: yes
+#   loop: "{{ podman_user_info.results }}"
 
-- name: Set podman to use temp directories
-  community.general.ini_file:
-    path: "{{ item.home }}/.config/containers/containers.conf"
-    section: engine
-    option: tmp_dir
-    value: '"{{ podman_tmp_dir_root }}/{{ item.name }}/libpod/tmp"'
-    owner: "{{ item.name }}"
-    group: "{{ item.name }}"
-    create: yes
-  loop: "{{ podman_user_info.results }}"
-  become: yes
-  register: podman_tmp
+# - name: Set podman to use temp directories
+#   community.general.ini_file:
+#     path: "{{ item.home }}/.config/containers/containers.conf"
+#     section: engine
+#     option: tmp_dir
+#     value: '"{{ podman_tmp_dir_root }}/{{ item.name }}/libpod/tmp"'
+#     owner: "{{ item.name }}"
+#     group: "{{ item.name }}"
+#     create: yes
+#   loop: "{{ podman_user_info.results }}"
+#   become: yes
+#   register: podman_tmp
 
-- name: Reset podman database
-  # otherwise old config overrides!
-  command:
-    cmd: podman system reset --force
-  become: yes
-  become_user: "{{ item.item.name }}"
-  when: item.changed
-  loop: "{{ podman_tmp.results }}"
-  loop_control:
-    label: "{{ item.item.name }}"
+# - name: Enable user lingering
+#   # Avoids error "The cgroupv2 manager is set to systemd but there is no systemd user session available"
+#   command:
+#     cmd: "touch /var/lib/systemd/linger/{{ item.item.name }}"
+#     creates: "/var/lib/systemd/linger/{{ item.item.name }}"
+#   loop: "{{ podman_tmp.results }}"
+#   loop_control:
+#     label: "{{ item.item.name }}"
+#   become: yes
+
+# - name: Reset podman database
+#   # otherwise old config overrides!
+#   command:
+#     cmd: podman system reset --force
+#   become: yes
+#   become_user: "{{ item.item.name }}"
+#   when: item.changed
+#   loop: "{{ podman_tmp.results }}"
+#   loop_control:
+#     label: "{{ item.item.name }}"

--- a/environments/.stackhpc/hooks/post-bootstrap.yml
+++ b/environments/.stackhpc/hooks/post-bootstrap.yml
@@ -1,0 +1,18 @@
+- hosts: podman:!builder
+  become: yes
+  gather_facts: false
+  tags: podman
+  tasks:
+    - name: Configure container registry mirror to avoid docker.io ratelimits
+      copy:
+        dest: /etc/containers/registries.conf.d/003-arcus-mirror.conf
+        content: |
+          [[registry]]
+          location="docker.io/library/"
+          prefix="docker.io/library/"
+
+          [[registry.mirror]]
+          location = "{{ podman_registry_address }}"
+          insecure = true
+      when: "ci_cloud == 'ARCUS'"
+

--- a/environments/.stackhpc/hooks/pre.yml
+++ b/environments/.stackhpc/hooks/pre.yml
@@ -10,25 +10,8 @@
         mode: 0400
         owner: root
         group: root
-      no_log: true
+      # no_log: true
       loop:
         - "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/inventory/hosts"
         - "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/inventory/group_vars/all/secrets.yml"
         - "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}/inventory/group_vars/all/test_user.yml"
-
-- hosts: all:!builder
-  become: yes
-  gather_facts: false
-  tags: podman
-  tasks:
-    - name: Configure container image registry for unqualified searches to avoid docker.io ratelimits
-      copy:
-        dest: /etc/containers/registries.conf.d/003-arcus-unqualfied-overrides.conf
-        content: |
-          unqualified-search-registries = ['{{ podman_registry_address  | split('/') | first }}', 'registry.access.redhat.com', 'registry.redhat.io', 'docker.io']
-
-          [[registry]]
-          prefix = "{{ podman_registry_address }}"
-          location = "{{ podman_registry_address }}"
-          insecure = true
-      when: "ci_cloud == 'ARCUS'"

--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -13,9 +13,10 @@ variable "cluster_name" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-231020-1357-b5d8b056" # https://github.com/stackhpc/ansible-slurm-appliance/pull/320
+    # default = "openhpc-231020-1357-b5d8b056" # https://github.com/stackhpc/ansible-slurm-appliance/pull/320
     # default = "Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2"
     # default = "Rocky-8-GenericCloud-8.6.20220702.0.x86_64.qcow2"
+    default = "Rocky-9-GenericCloud-Base-9.2-20230513.0.x86_64.qcow2"
 }
 
 variable "cluster_net" {}
@@ -67,8 +68,8 @@ module "cluster" {
     compute_nodes = {
         compute-0: "small"
         compute-1: "small"
-        compute-2: "extra"
-        compute-3: "extra"
+        # compute-2: "extra"
+        # compute-3: "extra"
     }
     volume_backed_instances = var.volume_backed_instances
     

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -17,9 +17,6 @@ openhpc_slurm_control_host: "{{ hostvars[groups['control'].0].api_address }}"
 openhpc_slurmdbd_host: "{{ openhpc_slurm_control_host }}"
 openhpc_slurm_partitions:
   - name: "compute"
-openhpc_pre_packages_default:
-  # EPEL packages:
-  - apptainer # has to be installed before ohpc-base-compute else singularity-ce gets installed which clashes
 openhpc_packages_default:
   # system packages
   - podman
@@ -30,9 +27,7 @@ openhpc_packages_default:
   # EPEL packages:
   - apptainer
   - podman-compose
-openhpc_pre_packages_extra: []
 openhpc_packages_extra: []
-openhpc_pre_packages: "{{ openhpc_pre_packages_default + openhpc_pre_packages_extra }}"
 openhpc_packages: "{{ openhpc_packages_default + openhpc_packages_extra }}"
 openhpc_munge_key: "{{ vault_openhpc_mungekey | b64decode }}"
 openhpc_login_only_nodes: login

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -17,6 +17,9 @@ openhpc_slurm_control_host: "{{ hostvars[groups['control'].0].api_address }}"
 openhpc_slurmdbd_host: "{{ openhpc_slurm_control_host }}"
 openhpc_slurm_partitions:
   - name: "compute"
+openhpc_pre_packages_default:
+  # EPEL packages:
+  - apptainer # has to be installed before ohpc-base-compute else singularity-ce gets installed which clashes
 openhpc_packages_default:
   # system packages
   - podman
@@ -27,7 +30,9 @@ openhpc_packages_default:
   # EPEL packages:
   - apptainer
   - podman-compose
+openhpc_pre_packages_extra: []
 openhpc_packages_extra: []
+openhpc_pre_packages: "{{ openhpc_pre_packages_default + openhpc_pre_packages_extra }}"
 openhpc_packages: "{{ openhpc_packages_default + openhpc_packages_extra }}"
 openhpc_munge_key: "{{ vault_openhpc_mungekey | b64decode }}"
 openhpc_login_only_nodes: login

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - src: stackhpc.nfs
     version: v22.9.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v0.20.0 # Allow multiple empty partitions by @sjpb in #156
+    version: rl9
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: feature/no-install


### PR DESCRIPTION
This mostly works, but it is not production-ready. Key things:
- podman now won't allow you (by default at least) to use unqualified image names. Fixed by changing to fully-qualified names (and fixing the arcus registry to mirror docker.io)
- couldn't reset the podman database after adding the tmp directory config (see roles/podman/config.yml) - fixed by simply not doing these tasks, I haven't convinced myself this is OK. The original code was specifying `tmp_dir`, which is documented in [containers.conf](https://github.com/containers/common/blob/main/docs/containers.conf.5.md) as having to be on a tmpfs, but that isn't mentioned in [podman docs](https://docs.podman.io/en/stable/markdown/podman.1.html#tmpdir-path). The [rootless tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md) doesn't mention it but states that "$XDG_RUNTIME_DIRdefaults on most systems to /run/user/$UID", which doesn't exist (with the containers up) for the `podman` user (and woudn't be a tmpfs).

  `podman info` shows
  ```
    graphRoot: /var/lib/podman/.local/share/containers/storage
  ...
    runRoot: /tmp/containers-user-1001/containers
  ```
both of which are mounted on `/`

- podman systemd units complain:
  ```
  time="2023-10-13T13:57:06Z" level=warning msg="The cgroupv2 manager is set to systemd but there is no systemd user session available"
  time="2023-10-13T13:57:06Z" level=warning msg="For using systemd, you may need to login using an user session"
  time="2023-10-13T13:57:06Z" level=warning msg="Alternatively, you can enable lingering with: `loginctl enable-linger 1001` (possibly as root)"
  time="2023-10-13T13:57:06Z" level=warning msg="Falling back to --cgroup-manager=cgroupfs"
  time="2023-10-13T13:57:06Z" level=error msg="unlinkat /run/podman/libpod/tmp: permission denied"
  ```

- the openhpc role has its own PR: https://github.com/stackhpc/ansible-role-openhpc/pull/164. There is some incomplete stuff here (e.g. this PR won't work on RL8) but it also needs the "generic slurm" PR merging so we can define cgroups.conf properly which appears to be necessary. Really I'd like to move the plugin defaults to use cgroups too, but this doens't work in a container (although see OpenHPC slack for a possible workaround).
- monitoring.yml fails b/c there's no `prometheus-slurm-exporter` build for RL9. This is our repo, so it'd presumably be an easy fix.
