### PR TITLE
Don't ignore image changes in skeleton terraform lifecycle

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
@@ -141,12 +141,6 @@ resource "openstack_compute_instance_v2" "control" {
       - [LABEL=home, /exports/home, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
   EOF
 
-  lifecycle{
-    ignore_changes = [
-      image_name,
-      ]
-    }
-
 }
 
 resource "openstack_compute_instance_v2" "login" {
@@ -184,12 +178,6 @@ resource "openstack_compute_instance_v2" "login" {
     fqdn: ${var.cluster_name}-${each.key}.${var.cluster_name}.${var.cluster_domain_suffix}
   EOF
 
-  lifecycle{
-    ignore_changes = [
-      image_name,
-      ]
-    }
-
 }
 
 resource "openstack_compute_instance_v2" "compute" {
@@ -226,11 +214,5 @@ resource "openstack_compute_instance_v2" "compute" {
     #cloud-config
     fqdn: ${var.cluster_name}-${each.key}.${var.cluster_name}.${var.cluster_domain_suffix}
   EOF
-
-  lifecycle{
-    ignore_changes = [
-      image_name,
-      ]
-    }
 
 }


### PR DESCRIPTION
Allows the skeleton terraform to act on image changes. This is because:
- Now state is not in the root disk, being able to reimage with terraform is useful, especially for development.
- No one is using slurm-controlled reimage (which conflicts with terraform tracking compute node usage)
- For the control node, there are issues around lifecycle due to the root disk block device definition also referencing the image.
- For production non-Azimuth use, any change to lifecycle needs some careful consideration anyway.