### PR TITLE
Fix testuser password in CI image build

### DIFF
--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -48,6 +48,8 @@ jobs:
           cd packer/
           packer init .
           PACKER_LOG=1 packer build -only openstack.openhpc -on-error=${{ vars.PACKER_ON_ERROR }} -var-file=$PKR_VAR_environment_root/${{ vars.CI_CLOUD }}.pkrvars.hcl openstack.pkr.hcl
+        env:
+          TESTUSER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
 
       - name: Get created image name from manifest
         id: manifest


### PR DESCRIPTION
Image build workflow got broken during transition to allowing CI to run on both Arcus and SMS.