### PR TITLE
Workaround turbovnc repo bug

### DIFF
--- a/ansible/portal.yml
+++ b/ansible/portal.yml
@@ -16,9 +16,17 @@
   become: yes
   gather_facts: yes
   tasks:
+    # Temporary workaround for https://github.com/TurboVNC/turbovnc/issues/387
+    # Assumes that if the repo exists, host is using a fat image, in which case
+    # vnc_compute.yml has already run
+    - name: Check for TurboVNC repo
+      stat:
+        path: /etc/yum.repos.d/TurboVNC.repo
+      register: _turbovnc_repo
     - import_role:
         name: openondemand
         tasks_from: vnc_compute.yml
+      when: not _turbovnc_repo.stat.exists
 
 - hosts: openondemand_jupyter
   tags:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,5 +1,7 @@
 ---
 
+- import_playbook: turbovnc_bug.yml
+
 - name: Run pre.yml hook
   vars:
     # hostvars not available here, so have to recalculate environment root:

--- a/ansible/turbovnc_bug.yml
+++ b/ansible/turbovnc_bug.yml
@@ -1,0 +1,19 @@
+# Temporary workaround for https://github.com/TurboVNC/turbovnc/issues/387
+
+- hosts: all
+  become: yes
+  gather_facts: no
+  tasks:
+    - name: Check for TurboVNC repo
+      stat:
+        path: /etc/yum.repos.d/TurboVNC.repo
+      register: _turbovnc_repo
+    - name: Disable TurboVNC repo
+      community.general.ini_file:
+        path: /etc/yum.repos.d/TurboVNC.repo
+        section: TurboVNC
+        option: enabled
+        value: '0'
+        no_extra_spaces: true
+        create: false
+      when: _turbovnc_repo.stat.exists


### PR DESCRIPTION
Temporary workaround for https://github.com/TurboVNC/turbovnc/issues/387:
- Disable turbovnc repo, if present, very early to allow other dnf uses to succeed.
- Assumes that if the repo exists, host is using the fat image in which case vnc_compute.yml was run during image build and can be skipped.

Note that `dnf clean all` didn't fix the issue.
    