### PR TITLE
Use new TurboVNC repofile

### DIFF
--- a/ansible/roles/openondemand/tasks/vnc_compute.yml
+++ b/ansible/roles/openondemand/tasks/vnc_compute.yml
@@ -2,7 +2,7 @@
 - name: Enable TurboVNC repo
   tags: install
   get_url:
-    url: https://turbovnc.org/pmwiki/uploads/Downloads/TurboVNC.repo
+    url: https://raw.githubusercontent.com/TurboVNC/repo/main/TurboVNC.repo
     dest: /etc/yum.repos.d/TurboVNC.repo
 
 - name: Install EPEL


### PR DESCRIPTION
TurboVNC repofile has moved. See https://github.com/TurboVNC/turbovnc/issues/387 and the [current install instructions](https://turbovnc.org/Downloads/YUM).