### PR TITLE
Fatimage update

### DIFF
--- a/ansible/extras.yml
+++ b/ansible/extras.yml
@@ -1,4 +1,4 @@
-- hosts: basic_users
+- hosts: basic_users:!builder
   become: yes
   tags:
     - basic_users

--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -13,7 +13,7 @@ variable "cluster_name" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-231201-1606-1b453aff" # https://github.com/stackhpc/ansible-slurm-appliance/pull/340
+    default = "openhpc-231205-1542-059b54c3" # https://github.com/stackhpc/ansible-slurm-appliance/pull/340
     # default = "Rocky-8-GenericCloud-Base-8.8-20230518.0.x86_64.qcow2"
 }
 

--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -13,7 +13,7 @@ variable "cluster_name" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-231027-0916-893570de" # https://github.com/stackhpc/ansible-slurm-appliance/pull/324
+    default = "openhpc-231201-1606-1b453aff" # https://github.com/stackhpc/ansible-slurm-appliance/pull/340
     # default = "Rocky-8-GenericCloud-Base-8.8-20230518.0.x86_64.qcow2"
 }
 

--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -13,7 +13,7 @@ variable "cluster_name" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-231205-1542-059b54c3" # https://github.com/stackhpc/ansible-slurm-appliance/pull/340
+    default = "openhpc-231206-1648-9d6aa4e4" # https://github.com/stackhpc/ansible-slurm-appliance/pull/340
     # default = "Rocky-8-GenericCloud-Base-8.8-20230518.0.x86_64.qcow2"
 }
 

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -107,7 +107,6 @@ openondemand_apps_desktop_default:
     ---
     script:
       job_name: "ood-desktop"
-      copy_environment: true
       native:
         - <%= "--nodes=1" %>
         - <%= "--ntasks=#{num_cores}" %>

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -13,7 +13,7 @@
 # or include regex special characters.
 openondemand_host_regex: "{{ (groups['compute'] + groups['grafana']) | to_ood_regex }}"
 
-ondemand_package: ondemand-3.0.1
+ondemand_package: ondemand-3.0.3
 
 # Add grafana to dashboard links to OOD only if grafana group is available
 openondemand_dashboard_links_grafana:

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -107,6 +107,7 @@ openondemand_apps_desktop_default:
     ---
     script:
       job_name: "ood-desktop"
+      copy_environment: true
       native:
         - <%= "--nodes=1" %>
         - <%= "--ntasks=#{num_cores}" %>


### PR DESCRIPTION
- Updated fat image (now RockyLinux 8.9 with OpenHPC [v2.7](https://github.com/openhpc/ohpc/releases/tag/v2.7.GA))
- Updates Open Ondemand to [v3.0.3](https://github.com/OSC/ondemand/releases/tag/v3.0.3)
- Fixes regression where `basic_users` functionality ran in fat image build (note this did not affect any released images)