### PR TITLE
Fix removal of packer bundled ansible plugin

### DIFF
--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -13,7 +13,7 @@ variable "cluster_name" {
 variable "cluster_image" {
     description = "single image for all cluster nodes - a convenience for CI"
     type = string
-    default = "openhpc-231208-1207-b69af6e2" # https://github.com/stackhpc/ansible-slurm-appliance/pull/341
+    default = "openhpc-240102-1025-e533fd70" # https://github.com/stackhpc/ansible-slurm-appliance/pull/346
     # default = "Rocky-8-GenericCloud-Base-8.9-20231119.0.x86_64.qcow2"
 }
 

--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -11,6 +11,10 @@ packer {
       version = ">= 1.0.0"
       source  = "github.com/hashicorp/openstack"
     }
+    ansible = {
+      version = ">= 1.1.1"
+      source  = "github.com/hashicorp/ansible"
+    }
   }
 }
 


### PR DESCRIPTION
Fixes packer builds using packer >= v1.10. In earlier versions ansible plugin was bundled with the packer binary but in https://github.com/hashicorp/packer/releases/tag/v1.10.0 this was removed. This PR adds this as an explicit plugin.