### PR TITLE
Remove the cluster_previous_image workaround

### DIFF
--- a/ansible/roles/cluster_infra/tasks/main.yml
+++ b/ansible/roles/cluster_infra/tasks/main.yml
@@ -38,25 +38,6 @@
       }
     dest: "{{ terraform_project_path }}/backend.tf"
 
-# Patching in this appliance is implemented as a switch to a new base image
-# So unless explicitly patching, we want to use the same image as last time
-# To do this, we query the previous Terraform state before updating
-- block:
-    - name: Get previous Terraform state
-      stackhpc.terraform.terraform_output:
-        binary_path: "{{ terraform_binary_path }}"
-        project_path: "{{ terraform_project_path }}"
-        backend_config: "{{ terraform_backend_config }}"
-      register: cluster_infra_terraform_output
-
-    - name: Extract image from Terraform state
-      set_fact:
-        cluster_previous_image: "{{ cluster_infra_terraform_output.outputs.cluster_image.value }}"
-      when: '"cluster_image" in cluster_infra_terraform_output.outputs'
-  when:
-    - terraform_state == "present"
-    - cluster_upgrade_system_packages is not defined or not cluster_upgrade_system_packages
-
 - name: Template Terraform files into project directory
   template:
     src: >-

--- a/ansible/roles/cluster_infra/templates/outputs.tf.j2
+++ b/ansible/roles/cluster_infra/templates/outputs.tf.j2
@@ -49,5 +49,5 @@ output "cluster_nodes" {
 
 output "cluster_image" {
   description = "The id of the image used to build the cluster nodes"
-  value       = "{{ cluster_previous_image | default(cluster_image) }}"
+  value       = "{{ cluster_image }}"
 }

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -249,7 +249,7 @@ resource "openstack_compute_keypair_v2" "cluster_keypair" {
 
 resource "openstack_compute_instance_v2" "login" {
   name      = "{{ cluster_name }}-login-0"
-  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  image_id  = "{{ cluster_image }}"
   {% if login_flavor_name is defined %}
   flavor_name = "{{ login_flavor_name }}"
   {% else %}
@@ -262,7 +262,7 @@ resource "openstack_compute_instance_v2" "login" {
 
   # root device:
   block_device {
-      uuid = "{{ cluster_previous_image | default(cluster_image) }}"
+      uuid = "{{ cluster_image }}"
       source_type  = "image"
       {% if cluster_use_root_volumes is defined and cluster_use_root_volumes %}
       volume_size = {{ cluster_root_volume_size | default("20") }}
@@ -298,7 +298,7 @@ resource "openstack_compute_instance_v2" "login" {
 
 resource "openstack_compute_instance_v2" "control" {
   name      = "{{ cluster_name }}-control-0"
-  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  image_id  = "{{ cluster_image }}"
   {% if control_flavor_name is defined %}
   flavor_name = "{{ control_flavor_name }}"
   {% else %}
@@ -311,7 +311,7 @@ resource "openstack_compute_instance_v2" "control" {
 
   # root device:
   block_device {
-      uuid = "{{ cluster_previous_image | default(cluster_image) }}"
+      uuid = "{{ cluster_image }}"
       source_type  = "image"
       {% if cluster_use_root_volumes is defined and cluster_use_root_volumes %}
       volume_size = {{ cluster_root_volume_size | default("20") }}
@@ -373,7 +373,7 @@ resource "openstack_compute_instance_v2" "{{ partition.name }}" {
   count = {{ partition.count }}
 
   name      = "{{ cluster_name }}-compute-{{ partition.name }}-${count.index}"
-  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  image_id  = "{{ cluster_image }}"
   {% if 'flavor_name' in partition %}
   flavor_name = "{{ partition.flavor_name }}"
   {% else %}
@@ -386,7 +386,7 @@ resource "openstack_compute_instance_v2" "{{ partition.name }}" {
 
   # root device:
   block_device {
-      uuid = "{{ cluster_previous_image | default(cluster_image) }}"
+      uuid = "{{ cluster_image }}"
       source_type  = "image"
       {% if cluster_use_root_volumes is defined and cluster_use_root_volumes %}
       volume_size = {{ cluster_root_volume_size | default("20") }}


### PR DESCRIPTION
The caas operator always sends the correct image via
extra_vars, so we can remove the cluster_previous_image
workaround.