### PR TITLE
Require user SSH key to be available in ui-meta

### DIFF
--- a/environments/.caas/ui-meta/slurm-infra-fast-volume-type.yml
+++ b/environments/.caas/ui-meta/slurm-infra-fast-volume-type.yml
@@ -5,6 +5,8 @@ description: >-
   OnDemand web interface, and custom monitoring.
 logo: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Slurm_logo.svg/158px-Slurm_logo.svg.png
 
+requires_ssh_key: true
+
 parameters:
   - name: cluster_floating_ip
     label: External IP

--- a/environments/.caas/ui-meta/slurm-infra-manila-home.yml
+++ b/environments/.caas/ui-meta/slurm-infra-manila-home.yml
@@ -9,6 +9,8 @@ description: >-
   when the platform is deleted.
 logo: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Slurm_logo.svg/158px-Slurm_logo.svg.png
 
+requires_ssh_key: true
+
 parameters:
   - name: cluster_floating_ip
     label: External IP

--- a/environments/.caas/ui-meta/slurm-infra.yml
+++ b/environments/.caas/ui-meta/slurm-infra.yml
@@ -5,6 +5,8 @@ description: >-
   OnDemand web interface, and custom monitoring.
 logo: https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Slurm_logo.svg/158px-Slurm_logo.svg.png
 
+requires_ssh_key: true
+
 parameters:
   - name: cluster_floating_ip
     label: External IP


### PR DESCRIPTION
explanation by @sjpb:
- AWX driver defaulted this true. CaaS operator defaults it to false.
- Hit on new cloud. Hadn't been hit as users/CI user always had a key defined.