### PR TITLE
Use project manila share user from Azimuth

### DIFF
--- a/environments/.caas/inventory/group_vars/all/manila.yml
+++ b/environments/.caas/inventory/group_vars/all/manila.yml
@@ -8,6 +8,7 @@ caas_manila_home:
 cluster_project_manila_share_name: azimuth-project-share
 caas_manila_project:
   share_name: "{{ cluster_project_manila_share_name }}"
+  share_user: "{{ cluster_project_manila_share_user }}"
   mount_path: /project
   mount_user: root
   mount_group: root

--- a/environments/.caas/inventory/group_vars/all/manila.yml
+++ b/environments/.caas/inventory/group_vars/all/manila.yml
@@ -8,7 +8,7 @@ caas_manila_home:
 cluster_project_manila_share_name: azimuth-project-share
 caas_manila_project:
   share_name: "{{ cluster_project_manila_share_name }}"
-  share_user: "{{ cluster_project_manila_share_user }}"
+  share_user: "{{ cluster_project_manila_share_user | default(omit) }}"
   mount_path: /project
   mount_user: root
   mount_group: root

--- a/environments/.caas/inventory/group_vars/all/manila.yml
+++ b/environments/.caas/inventory/group_vars/all/manila.yml
@@ -7,7 +7,7 @@ caas_manila_home:
 
 cluster_project_manila_share_name: azimuth-project-share
 caas_manila_project:
-  share_name: "{{ cluster_project_manila_share_name }}"
+  share_name: "{{ cluster_project_manila_share_name | default(none) }}"
   share_user: "{{ cluster_project_manila_share_user | default(omit) }}"
   mount_path: /project
   mount_user: root

--- a/environments/.caas/inventory/group_vars/all/manila.yml
+++ b/environments/.caas/inventory/group_vars/all/manila.yml
@@ -7,7 +7,7 @@ caas_manila_home:
 
 cluster_project_manila_share_name: azimuth-project-share
 caas_manila_project:
-  share_name: "{{ cluster_project_manila_share_name | default(none) }}"
+  share_name: "{{ cluster_project_manila_share_name | default('azimuth-project-share') }}"
   share_user: "{{ cluster_project_manila_share_user | default(omit) }}"
   mount_path: /project
   mount_user: root

--- a/environments/.caas/ui-meta/slurm-infra.yml
+++ b/environments/.caas/ui-meta/slurm-infra.yml
@@ -52,7 +52,7 @@ parameters:
   
   - name: home_volume_size
     label: Home volume size (GB)
-    description: The size of the cloud volume or share to use for home directories.
+    description: The size of the cloud volume to use for home directories.
     kind: cloud.volume_size
     immutable: true
     options:


### PR DESCRIPTION
Changes CaaS project manila shares to use the share user provided by Azimuth (in https://github.com/stackhpc/azimuth/pull/148/files), rather assuming there is only a single access rule. Fixes cases where multiple access rules are defined on the project share.