### PR TITLE
Fix failure when setting basic_users state: absent

### DIFF
--- a/ansible/roles/basic_users/library/terminate_user_sessions.py
+++ b/ansible/roles/basic_users/library/terminate_user_sessions.py
@@ -56,13 +56,11 @@ def run_module():
 
     _, sessions_stdout, _ = module.run_command("loginctl --no-legend list-sessions", check_rc=True)
     for line in sessions_stdout.splitlines():
-        try:
-            session, uid, user = line.split()
-        except ValueError:
-            raise ValueError('failed to split "%s"' % line)
-            
+        session_info = line.split()
+        user = session_info[1]
+        session_id = session_info[0]
         if user == module.params['user']:
-            _, sessions_stdout, _ = module.run_command("loginctl terminate-session %s" % session, check_rc=True)
+            _, sessions_stdout, _ = module.run_command("loginctl terminate-session %s" % session_id, check_rc=True)
             result['changed'] = True
         
     # successful module exit:


### PR DESCRIPTION
At some point loginctl format changed to include extra fields, some of which may be empty. Luckily we only care about the first two so don't have to parse this properly.

```shell
[rocky@demo-login-0 ~]$ loginctl list-sessions
SESSION  UID USER  SEAT TTY   IDLE SINCE
   1789 1000 rocky      pts/0 no        
   1796 1000 rocky      n/a   no        
   1797 1006 lab0       pts/1 no  
```