### PR TITLE
Don't link manila for /home to manila for /project in caas

### DIFF
--- a/environments/.caas/inventory/group_vars/all/cluster.yml
+++ b/environments/.caas/inventory/group_vars/all/cluster.yml
@@ -23,4 +23,4 @@ appliances_state_dir: /var/lib/state
 
 # Defaults for caas-provided extravars:
 cluster_project_manila_share: false
-cluster_home_manila_share: "{{ cluster_project_manila_share }}"
+cluster_home_manila_share: false


### PR DESCRIPTION
Enables making the use of manila for /home in CaaS clusters an explicit opt-in via azimuth-ops configuration. This is to avoid the current situation where:

1. Deploy vanilla Azimuth
2. Deploy a Slurm cluster, gets Cinder home
3. Enable the project share support in Azimuth
4. Patch the Slurm cluster - existing data in /home gets deleted
