### PR TITLE
Remove special-case for firewalld in builder

### DIFF
--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -27,13 +27,6 @@
   become: yes
   gather_facts: no
   tasks:
-    - name: Disable firewalld
-      # This is enabled on installation, which isn't what we want
-      systemd:
-        name: firewalld
-        state: stopped
-        enabled: false
-
     # - import_playbook: iam.yml
     - name: Install FreeIPA client
       import_role:

--- a/ansible/roles/firewalld/tasks/main.yml
+++ b/ansible/roles/firewalld/tasks/main.yml
@@ -1,15 +1,3 @@
 ---
 - import_tasks: install.yml
-
-- name: Apply filewalld configs
-  ansible.posix.firewalld: "{{ item }}"
-  notify: Restart filewalld
-  loop: "{{ firewalld_configs }}"
-
-- meta: flush_handlers
-
-- name: Ensure filewalld state
-  ansible.builtin.systemd:
-    name: firewalld
-    state: "{{ firewalld_state }}"
-    enabled: "{{ firewalld_enabled | default('yes' ) }}"
+- import_tasks: runtime.yml

--- a/ansible/roles/firewalld/tasks/runtime.yml
+++ b/ansible/roles/firewalld/tasks/runtime.yml
@@ -1,0 +1,12 @@
+- name: Apply filewalld configs
+  ansible.posix.firewalld: "{{ item }}"
+  notify: Restart filewalld
+  loop: "{{ firewalld_configs }}"
+
+- meta: flush_handlers
+
+- name: Ensure filewalld state
+  ansible.builtin.systemd:
+    name: firewalld
+    state: "{{ firewalld_state }}"
+    enabled: "{{ firewalld_enabled | default(true) }}"

--- a/environments/common/inventory/group_vars/builder/defaults.yml
+++ b/environments/common/inventory/group_vars/builder/defaults.yml
@@ -14,3 +14,5 @@ block_devices_configurations: [] # as volumes will not be attached to Packer bui
 mysql_state: stopped # as it tries to connect to real mysql node
 opensearch_state: stopped # avoid writing config+certs+db into image
 cuda_persistenced_state: stopped # probably don't have GPU in Packer build VMs
+firewalld_enabled: false # dnf install of firewalld enables it
+firewalld_state: stopped # dnf install of firewalld enables it


### PR DESCRIPTION
Uses extravars to ensure firewalld isn't enabled (or started) once installed, instead of a workaround in fatimage.yml. Want to minimise the differences there from site.yml to make changes easier/less error-prone.