### PR TITLE
Reduce CI resources

### DIFF
--- a/ansible/ci/check_slurm.yml
+++ b/ansible/ci/check_slurm.yml
@@ -22,4 +22,3 @@
       vars:
         expected_sinfo:
           - "{{ openhpc_cluster_name }}-compute-[0-1] small* up 60-00:00:00 2 idle"
-          - "{{ openhpc_cluster_name }}-compute-[2-3] extra up 60-00:00:00 2 idle"

--- a/environments/.stackhpc/terraform/ARCUS.tfvars
+++ b/environments/.stackhpc/terraform/ARCUS.tfvars
@@ -1,5 +1,5 @@
 cluster_net = "portal-internal"
 cluster_subnet = "portal-internal"
 vnic_type = "normal"
-control_node_flavor = "vm.ska.cpu.general.quarter"
+control_node_flavor = "vm.ska.cpu.general.eighth"
 other_node_flavor = "vm.ska.cpu.general.small"

--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -63,16 +63,10 @@ module "cluster" {
             flavor: var.other_node_flavor
             image: var.cluster_image
         }
-        extra: {
-            flavor: var.other_node_flavor
-            image: var.cluster_image
-        }
     }
     compute_nodes = {
         compute-0: "small"
         compute-1: "small"
-        compute-2: "extra"
-        compute-3: "extra"
     }
     volume_backed_instances = var.volume_backed_instances
     


### PR DESCRIPTION
Downsize to 2x compute / single partition and smaller control node. Still shows 15 of 20 Gi mem free at idle.

Hoping to reduce contention for CI resources.