### PR TITLE
Fix freeipa server referer errors

### DIFF
--- a/ansible/roles/freeipa/tasks/server.yml
+++ b/ansible/roles/freeipa/tasks/server.yml
@@ -32,8 +32,11 @@
 
 - name: Disable redirects to hard-coded domain
   # see https://pagure.io/freeipa/issue/7479
-  replace: path=/etc/httpd/conf.d/ipa-rewrite.conf regexp='{{ item.regexp }}' replace='{{ item.replace }}'
-  with_items:
+  replace:
+    path: /etc/httpd/conf.d/ipa-rewrite.conf
+    regexp: '{{ item.regexp }}'
+    replace: '{{ item.replace }}'
+  loop:
     # RewriteRule ^/$ https://${FQDN}/ipa/ui [L,NC,R=301] - irrelevant if using --no-ui-redirect
     - regexp: '^(RewriteRule \^/\$) (https://.*)(/ipa/ui.*)$'
       replace: '\1 \3'
@@ -47,17 +50,17 @@
       replace: '#\1'
   register: _replace_freeipa_rewrites
 
-- name: Deactivate HTTP RefererError
-  replace:
-    path: '/usr/lib/python3.6/site-packages/ipaserver/rpcserver.py'
-    regexp: '{{ item }}'
-    replace: '\1pass  # \2'
-  with_items:
-    - "^([ ]*)(return self.marshal\\(result, RefererError\\(referer)"
-  register: _replace_rpcserver_referrer
+- name: Get freeipa server facts
+  setup:
+
+- name: Fix HTTP_REFERER
+  ansible.builtin.lineinfile:
+    path: /etc/httpd/conf.d/ipa-rewrite.conf
+    line: "RequestHeader set Referer https://{{ ansible_nodename }}/ipa/ui"
+  register: _http_referer
 
 - name: Reload apache configuration
   service:
     name: httpd
     state: reloaded
-  when: _replace_freeipa_rewrites.changed or _replace_rpcserver_referrer.changed
+  when: _replace_freeipa_rewrites.changed or _http_referer.changed


### PR DESCRIPTION
Latest freeipa server has additional checks for HTTP_REFERER which means the current workaround isn't sufficient. This PR uses mod_headers to add the correct HTTP_REFERER instead, which is a more-robust/cleaner solution.