### PR TITLE
Fix filebeat service reload

### DIFF
--- a/ansible/roles/filebeat/tasks/install.yml
+++ b/ansible/roles/filebeat/tasks/install.yml
@@ -15,3 +15,4 @@
 - name: Reload filebeat unit file
   command: systemctl daemon-reload
   when: _filebeat_unit.changed
+  become: true


### PR DESCRIPTION
Change in PR #351 missed the required privilege escalation on systemd daemon-reload after filebeat service file changes.

Fixes #371.