### PR TITLE
Add hpctests_pre_cmd option

### DIFF
--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -33,6 +33,7 @@ Role Variables
 - `hpctests_hpl_arch`: Optional, default 'linux64'. Arbitrary architecture name for HPL build. HPL is compiled on the first compute node of those selected (see `hpctests_nodes`), so this can be used to create different builds for different types of compute node.
 
 The following variables should not generally be changed:
+- `hpctests_pre_cmd`: Optional. Command(s) to include in sbatch templates before module load commands.
 - `hpctests_pingmatrix_modules`: Optional. List of modules to load for pingmatrix test. Defaults are suitable for OpenHPC 2.x cluster using the required packages.
 - `hpctests_pingpong_modules`: As above but for pingpong test.
 - `hpctests_pingpong_plot`: Whether to plot pingpong results. Default `yes`.

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 hpctests_rootdir:
+hpctests_pre_cmd: ''
 hpctests_pingmatrix_modules: [gnu12 openmpi4]
 hpctests_pingpong_modules: [gnu12 openmpi4 imb]
 hpctests_pingpong_plot: yes

--- a/ansible/roles/hpctests/templates/hpl-build.sh.j2
+++ b/ansible/roles/hpctests/templates/hpl-build.sh.j2
@@ -8,7 +8,7 @@
 {%if hpctests_nodes is defined %}#SBATCH --nodelist={{ hpctests_computes.stdout_lines[0] }}{% endif %}
 
 echo HPL arch: {{ hpctests_hpl_arch }}
-
+{{ hpctests_pre_cmd }}
 module load {{ hpctests_hpl_modules | join(' ' ) }}
 make arch={{ hpctests_hpl_arch }} clean_arch_all
 make arch={{ hpctests_hpl_arch }}

--- a/ansible/roles/hpctests/templates/hpl-solo.sh.j2
+++ b/ansible/roles/hpctests/templates/hpl-solo.sh.j2
@@ -15,6 +15,6 @@ echo SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST
 echo SLURM_JOB_ID: $SLURM_JOB_ID
 echo UCX_NET_DEVICES: $UCX_NET_DEVICES
 echo HPL arch: {{ hpctests_hpl_arch }}
-
+{{ hpctests_pre_cmd }}
 module load {{ hpctests_hpl_modules | join(' ' ) }}
 mpirun ./xhpl-{{ hpctests_hpl_arch }}

--- a/ansible/roles/hpctests/templates/pingmatrix.sh.j2
+++ b/ansible/roles/hpctests/templates/pingmatrix.sh.j2
@@ -12,6 +12,7 @@ export UCX_NET_DEVICES={{ hpctests_ucx_net_devices }}
 echo SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST
 echo SLURM_JOB_ID: $SLURM_JOB_ID
 echo UCX_NET_DEVICES: $UCX_NET_DEVICES
+{{ hpctests_pre_cmd }}
 module load {{ hpctests_pingmatrix_modules | join(' ' ) }}
 
 mpicc -o nxnlatbw mpi_nxnlatbw.c

--- a/ansible/roles/hpctests/templates/pingpong.sh.j2
+++ b/ansible/roles/hpctests/templates/pingpong.sh.j2
@@ -12,6 +12,7 @@ export UCX_NET_DEVICES={{ hpctests_ucx_net_devices }}
 echo SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST
 echo SLURM_JOB_ID: $SLURM_JOB_ID
 echo UCX_NET_DEVICES: $UCX_NET_DEVICES
+{{ hpctests_pre_cmd }}
 module load {{ hpctests_pingpong_modules | join(' ' ) }}
 
 #srun --mpi=pmi2 IMB-MPI1 pingpong # doesn't work in ohpc v2.1


### PR DESCRIPTION
Allow adding a command to hpctests sbatch templates before module load, to enable working around situations where paths or module paths are customised.