### PR TITLE
Fix minimum caas controller memory

### DIFF
--- a/environments/.caas/ui-meta/slurm-infra-fast-volume-type.yml
+++ b/environments/.caas/ui-meta/slurm-infra-fast-volume-type.yml
@@ -29,7 +29,7 @@ parameters:
     kind: cloud.size
     immutable: true
     options:
-      min_ram: 2048
+      min_ram: 8192
       min_disk: 20
 
   - name: compute_count

--- a/environments/.caas/ui-meta/slurm-infra-manila-home.yml
+++ b/environments/.caas/ui-meta/slurm-infra-manila-home.yml
@@ -32,7 +32,7 @@ parameters:
     kind: cloud.size
     immutable: true
     options:
-      min_ram: 2048
+      min_ram: 8192
       min_disk: 20
 
   - name: compute_count

--- a/environments/.caas/ui-meta/slurm-infra.yml
+++ b/environments/.caas/ui-meta/slurm-infra.yml
@@ -29,7 +29,7 @@ parameters:
     kind: cloud.size
     immutable: true
     options:
-      min_ram: 2048
+      min_ram: 8192
       min_disk: 20
 
   - name: compute_count


### PR DESCRIPTION
One deployment ran out of memory on a 2GB Slurm control node; experience from leafcloud CI showed although a 4GB instance worked it only had ~100Mi free during deployment.