### PR TITLE
change caas controller memory to >=4GB

### DIFF
--- a/environments/.caas/ui-meta/slurm-infra-fast-volume-type.yml
+++ b/environments/.caas/ui-meta/slurm-infra-fast-volume-type.yml
@@ -29,7 +29,7 @@ parameters:
     kind: cloud.size
     immutable: true
     options:
-      min_ram: 8192
+      min_ram: 4096
       min_disk: 20
 
   - name: compute_count

--- a/environments/.caas/ui-meta/slurm-infra-manila-home.yml
+++ b/environments/.caas/ui-meta/slurm-infra-manila-home.yml
@@ -32,7 +32,7 @@ parameters:
     kind: cloud.size
     immutable: true
     options:
-      min_ram: 8192
+      min_ram: 4096
       min_disk: 20
 
   - name: compute_count

--- a/environments/.caas/ui-meta/slurm-infra.yml
+++ b/environments/.caas/ui-meta/slurm-infra.yml
@@ -29,7 +29,7 @@ parameters:
     kind: cloud.size
     immutable: true
     options:
-      min_ram: 8192
+      min_ram: 4096
       min_disk: 20
 
   - name: compute_count


### PR DESCRIPTION
#378 breaks existing arcus deployments using `vm.ska.cpu.general.small`, so change to 4GB