### PR TITLE
Use RL9 for caas environment

### DIFF
--- a/ansible/extras.yml
+++ b/ansible/extras.yml
@@ -26,3 +26,13 @@
   tasks:
     - import_role:
         name: cuda
+
+- name: Persist hostkeys across rebuilds
+  # Must be after filesystems.yml (for storage)
+  # and before portal.yml (where OOD login node hostkeys are scanned)
+  hosts: persist_hostkeys:!builder
+  become: yes
+  gather_facts: no
+  tasks:
+    - import_role:
+        name: persist_hostkeys

--- a/ansible/roles/filebeat/templates/filebeat.service.j2
+++ b/ansible/roles/filebeat/templates/filebeat.service.j2
@@ -12,7 +12,7 @@ After=network-online.target
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=always
-ExecStart=/usr/bin/podman --cgroup-manager=cgroupfs run \
+ExecStart=/usr/bin/podman run \
     --network=host \
     --sdnotify=conmon \
     --cgroups=no-conmon \

--- a/ansible/roles/mysql/templates/mysql.service.j2
+++ b/ansible/roles/mysql/templates/mysql.service.j2
@@ -14,7 +14,7 @@ EnvironmentFile=/etc/sysconfig/mysqld
 # The above EnvironmentFile must define MYSQL_INITIAL_ROOT_PASSWORD
 ExecStartPre=+install -d -o {{ mysql_podman_user }} -g {{ mysql_podman_user }} -Z container_file_t {{ mysql_datadir }}
 ExecStartPre=+chown -R {{ mysql_podman_user }}:{{ mysql_podman_user }} {{ mysql_datadir }}
-ExecStart=/usr/bin/podman --cgroup-manager=cgroupfs run \
+ExecStart=/usr/bin/podman run \
     --network=host \
     --sdnotify=conmon \
     --cgroups=no-conmon \

--- a/ansible/roles/opensearch/templates/opensearch.service.j2
+++ b/ansible/roles/opensearch/templates/opensearch.service.j2
@@ -11,7 +11,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=always
 # paths below based on https://opensearch.org/docs/latest/opensearch/configuration/ and https://opensearch.org/docs/latest/security-plugin/configuration/yaml
 # see also https://opensearch.org/docs/2.0/opensearch/install/important-settings/
-ExecStart=/usr/bin/podman --cgroup-manager=cgroupfs run \
+ExecStart=/usr/bin/podman run \
     --network=host \
     --sdnotify=conmon \
     --cgroups=no-conmon \

--- a/ansible/roles/persist_hostkeys/README.md
+++ b/ansible/roles/persist_hostkeys/README.md
@@ -1,0 +1,8 @@
+# persist_hostkeys
+
+Save hostkeys to persistent storage and restore them after a rebuild/reimage.
+
+Add hosts to the `persist_hostkeys` group to enable.
+
+This role has no variables but hosts in this group must have `appliances_state_dir`
+defined as a directory they can write to on persistent storage.

--- a/ansible/roles/podman/tasks/config.yml
+++ b/ansible/roles/podman/tasks/config.yml
@@ -26,6 +26,16 @@
     value: 25000000 # set same as root. Non-root default is 20000
   become: true
 
+- name: Configure podman to use cgroupfs as the cgroup manager
+  community.general.ini_file:
+  # is actually toml but there's no module for that
+    create: false # something's unexpected if it doesn't exist now
+    path: /usr/share/containers/containers.conf
+    section: engine
+    option: cgroup_manager
+    value: '"cgroupfs"'
+  become: true
+
 - name: reset ssh connection to allow user changes to affect 'current login user'
   meta: reset_connection
 

--- a/environments/.caas/hooks/post.yml
+++ b/environments/.caas/hooks/post.yml
@@ -7,16 +7,7 @@
     - persist_hostkeys
 
 # Configure the Zenith clients that are required
-# First, ensure that podman is installed on all hosts that will run Zenith clients
-- hosts: zenith,!podman
-  tasks:
-    - import_role:
-        name: podman
-        tasks_from: prereqs.yml
-    - import_role:
-        name: podman
-        tasks_from: config.yml
-
+# Note zenith hosts are in podman group
 - hosts: grafana
   tasks:
     - name: Deploy the Zenith client for Grafana

--- a/environments/.caas/hooks/post.yml
+++ b/environments/.caas/hooks/post.yml
@@ -1,11 +1,3 @@
-- name: Persist login hostkey across rebuilds
-# Need NFS for this so can't do it before the appliance plays
-  hosts: login
-  gather_facts: no
-  become: yes
-  roles:
-    - persist_hostkeys
-
 # Configure the Zenith clients that are required
 # Note zenith hosts are in podman group
 - hosts: grafana

--- a/environments/.caas/inventory/extra_groups
+++ b/environments/.caas/inventory/extra_groups
@@ -11,3 +11,6 @@ openondemand
 [manila:children]
 login
 compute
+
+[podman:children]
+zenith

--- a/environments/.caas/inventory/extra_groups
+++ b/environments/.caas/inventory/extra_groups
@@ -14,3 +14,6 @@ compute
 
 [podman:children]
 zenith
+
+[persist_hostkeys:children]
+openondemand

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -123,3 +123,6 @@ freeipa_client
 
 [proxy]
 # Hosts to configure http/s proxies - see ansible/roles/proxy/README.md
+
+[persist_hostkeys]
+# Hosts to persist hostkeys for across reimaging. NB: Requires appliances_state_dir on hosts.

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -69,3 +69,6 @@ openhpc
 
 [manila]
 # Hosts to configure for manila fileshares
+
+[persist_hostkeys]
+# Hosts to persist hostkeys for across reimaging. NB: Requires appliances_state_dir on hosts.


### PR DESCRIPTION
- Use RockyLinux9 and hence OpenHPC v3 for `caas` environment.
- Makes the `persist_hostkeys` role now enable-able in any environment.
- Fixes a bug in `caas` environment where the OpenOndemand shell aborted after a patch which reimaged the nodes due to hostkeys changing.

Notes:
- Slurm version is unchanged at `22.05.11`.
- Some of the (default) openhpc package installs which are available via lmod in caas have changed between OpenHPC v2 and v3:
  ```
  # RL8                       | # RL9
  gnu12/12.3.0                | gnu12/12.2.0
  hwloc/2.7.2                 | hwloc/2.9.0
  libfabric/1.19.0            | libfabric/1.18.0
  openmpi4/4.1.6              | openmpi4/4.1.5
                              > pmix/4.2.6
  ucx/1.15.0                  | ucx/1.14.0

- As OHPCv3 provides pmix and builds openmpi against it, the `srun` launcher can now be used again (early OpenHPC v2.x could use it with pmi2, also see https://github.com/stackhpc/ansible-slurm-appliance/issues/190):
  ```
  module load gnu12 openmpi4 imb # note pmix does not need to be loaded
  srun --mpi=pmix IMB-MPI1 pingpong
  ```
  At this time hpctests has not been modified to make use of this.
