### PR TITLE
Give caas azimuth user sudo

### DIFF
--- a/ansible/roles/basic_users/README.md
+++ b/ansible/roles/basic_users/README.md
@@ -19,7 +19,7 @@ Role Variables
 `basic_users_users`: Required. A list of mappings defining information for each user. In general, mapping keys/values are passed through as parameters to [ansible.builtin.user](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html) and default values are as given there. However:
 - `create_home`, `generate_ssh_key` and `ssh_key_comment` are set automatically and should not be overriden.
 - `uid` should be set, so that the UID/GID is consistent across the cluster (which Slurm requires).
-- `shell` may be set if required, but will be overriden with `/sbin/nologin` on `control` nodes to prevent user login.
+- `shell` if *not* set will be `/sbin/nologin` on the `control` node and the default shell on other users. Explicitly setting this defines the shell for all nodes.
 - An additional key `public_key` may optionally be specified to define a key to log into the cluster.
 - Any other keys may present for other purposes (i.e. not used by this role).
 

--- a/ansible/roles/basic_users/README.md
+++ b/ansible/roles/basic_users/README.md
@@ -21,6 +21,7 @@ Role Variables
 - `uid` should be set, so that the UID/GID is consistent across the cluster (which Slurm requires).
 - `shell` if *not* set will be `/sbin/nologin` on the `control` node and the default shell on other users. Explicitly setting this defines the shell for all nodes.
 - An additional key `public_key` may optionally be specified to define a key to log into the cluster.
+- An additional key `sudo` may optionally be specified giving a string (possibly multiline) defining sudo rules to be templated.
 - Any other keys may present for other purposes (i.e. not used by this role).
 
 Dependencies

--- a/ansible/roles/basic_users/tasks/main.yml
+++ b/ansible/roles/basic_users/tasks/main.yml
@@ -44,9 +44,10 @@
   run_once: true
 
 - name: Write sudo rules
-  copy:
-    dest: /etc/sudoers.d/80-{{ item.name}}-user
-    content: "{{ item.sudo }}"
+  blockinfile:
+    path: /etc/sudoers.d/80-{{ item.name}}-user
+    block: "{{ item.sudo }}"
+    create: true
   loop: "{{ basic_users_users }}"
   loop_control:
     label: "{{ item.name }}"

--- a/ansible/roles/basic_users/tasks/main.yml
+++ b/ansible/roles/basic_users/tasks/main.yml
@@ -42,3 +42,12 @@
   - item.ssh_public_key is defined
   - basic_users_manage_homedir
   run_once: true
+
+- name: Write sudo rules
+  copy:
+    dest: /etc/sudoers.d/80-{{ item.name}}-user
+    content: "{{ item.sudo }}"
+  loop: "{{ basic_users_users }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: "'sudo' in item"

--- a/ansible/roles/cluster_infra/defaults/main.yml
+++ b/ansible/roles/cluster_infra/defaults/main.yml
@@ -1,5 +1,0 @@
-# List of hw_scsi_models that result in block devices presenting as /dev/sdX
-# rather than /dev/vdX
-scsi_models:
-  # Ceph [https://docs.ceph.com/en/quincy/rbd/rbd-openstack/#image-properties]
-  - virtio-scsi

--- a/ansible/roles/cluster_infra/defaults/main.yml
+++ b/ansible/roles/cluster_infra/defaults/main.yml
@@ -1,5 +1,3 @@
-cluster_deploy_ssh_keys_extra: []
-
 # List of hw_scsi_models that result in block devices presenting as /dev/sdX
 # rather than /dev/vdX
 scsi_models:

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -359,18 +359,12 @@ resource "openstack_compute_instance_v2" "control" {
   user_data = <<-EOF
     #cloud-config
     ssh_authorized_keys:
-    {%- if cluster_user_ssh_public_key is defined %}
-      - {{ cluster_user_ssh_public_key }}
-    {%- endif %}
     {%- if cluster_deploy_ssh_public_key is defined %}
       - {{ cluster_deploy_ssh_public_key }}
     {%- endif %}
     {%- if cluster_ssh_private_key_file is not defined %}
       - "${openstack_compute_keypair_v2.cluster_keypair.public_key}"
     {%- endif %}
-    {%- for ssh_key in cluster_deploy_ssh_keys_extra %}
-      - {{ ssh_key }}
-    {%- endfor %}
     bootcmd:
     %{for volume in [openstack_blockstorage_volume_v3.state, {% if not cluster_home_manila_share | bool %} openstack_blockstorage_volume_v3.home {% endif %}]}
     - BLKDEV=$(readlink -f $(ls /dev/disk/by-id/*${substr(volume.id, 0, 20)}* | head -n1 )); blkid -o value -s TYPE $BLKDEV ||  mke2fs -t ext4 -L ${lower(split(" ", volume.description)[0])} $BLKDEV
@@ -420,18 +414,12 @@ resource "openstack_compute_instance_v2" "{{ partition.name }}" {
   user_data = <<-EOF
     #cloud-config
     ssh_authorized_keys:
-    {%- if cluster_user_ssh_public_key is defined %}
-      - {{ cluster_user_ssh_public_key }}
-    {%- endif %}
     {%- if cluster_deploy_ssh_public_key is defined %}
       - {{ cluster_deploy_ssh_public_key }}
     {%- endif %}
     {%- if cluster_ssh_private_key_file is not defined %}
       - "${openstack_compute_keypair_v2.cluster_keypair.public_key}"
     {%- endif %}
-    {%- for ssh_key in cluster_deploy_ssh_keys_extra %}
-      - {{ ssh_key }}
-    {%- endfor %}
   EOF
 }
 

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -307,9 +307,6 @@ resource "openstack_compute_instance_v2" "login" {
     {%- if cluster_ssh_private_key_file is not defined %}
       - "${openstack_compute_keypair_v2.cluster_keypair.public_key}"
     {%- endif %}
-    {%- for ssh_key in cluster_deploy_ssh_keys_extra %}
-      - {{ ssh_key }}
-    {%- endfor %}
   EOF
 }
 

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -298,9 +298,6 @@ resource "openstack_compute_instance_v2" "login" {
   user_data = <<-EOF
     #cloud-config
     ssh_authorized_keys:
-    {%- if cluster_user_ssh_public_key is defined %}
-      - {{ cluster_user_ssh_public_key }}
-    {%- endif %}
     {%- if cluster_deploy_ssh_public_key is defined %}
       - {{ cluster_deploy_ssh_public_key }}
     {%- endif %}

--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -59,7 +59,6 @@
       blockinfile:
         path: /etc/security/access.conf
         block: |
-          +:wheel:ALL
-          +:{{ ansible_user }}:ALL
+          +:adm:ALL
           -:ALL:ALL
       # vagrant uses (deprecated) ansible_ssh_user

--- a/environments/.caas/inventory/group_vars/all/basic_users.yml
+++ b/environments/.caas/inventory/group_vars/all/basic_users.yml
@@ -4,3 +4,4 @@ basic_users_users:
     password: "{{ vault_azimuth_user_password | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
     uid: 1005
     public_key: "{{ cluster_user_ssh_public_key }}"
+    shell: /bin/bash

--- a/environments/.caas/inventory/group_vars/all/basic_users.yml
+++ b/environments/.caas/inventory/group_vars/all/basic_users.yml
@@ -5,3 +5,8 @@ basic_users_users:
     uid: 1005
     public_key: "{{ cluster_user_ssh_public_key }}"
     shell: /bin/bash
+    append: true
+    groups:
+      - adm
+      - systemd-journal
+    sudo: azimuth ALL=(ALL) NOPASSWD:ALL

--- a/environments/.caas/inventory/group_vars/all/nfs.yml
+++ b/environments/.caas/inventory/group_vars/all/nfs.yml
@@ -13,7 +13,7 @@ caas_nfs_home:
   - comment: Export /exports/home from Slurm control node as /home
     nfs_enable:
         server:  "{{ inventory_hostname in groups['control'] }}"
-        clients: "{{ inventory_hostname in groups['cluster'] and inventory_hostname not in groups['control'] }}"
+        clients: "{{ inventory_hostname in groups['cluster'] }}"
     nfs_export: "/exports/home" # assumes skeleton TF is being used
     nfs_client_mnt_point: "/home"
 

--- a/environments/.caas/ui-meta/slurm-infra-fast-volume-type.yml
+++ b/environments/.caas/ui-meta/slurm-infra-fast-volume-type.yml
@@ -125,7 +125,7 @@ usage_template: |-
   compute*     up 60-00:00:0    {{ "%3s" | format(cluster.parameter_values.compute_count) }}   idle {{ cluster.name }}-compute-[0-{{ cluster.parameter_values.compute_count - 1 }}]
   ```
 
-  The `rocky` user can be accessed the same way and has passwordless `sudo` enabled.
+  The `azimuth` user can ssh between nodes and has passwordless sudo.
 
   SSH access can be granted to additional users by placing their SSH public key in `~azimuth/.ssh/authorized_keys`.
 

--- a/environments/.caas/ui-meta/slurm-infra-manila-home.yml
+++ b/environments/.caas/ui-meta/slurm-infra-manila-home.yml
@@ -115,7 +115,7 @@ usage_template: |-
   compute*     up 60-00:00:0    {{ "%3s" | format(cluster.parameter_values.compute_count) }}   idle {{ cluster.name }}-compute-[0-{{ cluster.parameter_values.compute_count - 1 }}]
   ```
 
-  The `rocky` user can be accessed the same way and has passwordless `sudo` enabled.
+  The `azimuth` user can ssh between nodes and has passwordless sudo.
 
   SSH access can be granted to additional users by placing their SSH public key in `~azimuth/.ssh/authorized_keys`.
 

--- a/environments/.caas/ui-meta/slurm-infra.yml
+++ b/environments/.caas/ui-meta/slurm-infra.yml
@@ -112,7 +112,7 @@ usage_template: |-
   compute*     up 60-00:00:0    {{ "%3s" | format(cluster.parameter_values.compute_count) }}   idle {{ cluster.name }}-compute-[0-{{ cluster.parameter_values.compute_count - 1 }}]
   ```
 
-  The `rocky` user can be accessed the same way and has passwordless `sudo` enabled.
+  The `azimuth` user can ssh between nodes and has passwordless sudo.
 
   SSH access can be granted to additional users by placing their SSH public key in `~azimuth/.ssh/authorized_keys`.
 


### PR DESCRIPTION
For the caas environment:
- The user's ssh key is only injected for the `azimuth` user (not `rocky`)
- The deploy key is only injected for the `rocky` user
- The `azimuth` user has passwordless sudo on all nodes
- The `azimuth` user is permitted to ssh into compute nodes even without jobs running

Note that:
- The `azimuth` user is setup via the `basic_users` role instead of cloud-init as ssh keys need to be created on a shared `$HOME` and propagated across the cluster.
- To allow the `azimuth` user to login to the control node, the default shell logic in the `basic_users` role is overriden and NFS configuration is modified so the control node has `/home` mounted.