### PR TITLE
Reduce HPL memory to 5% memory for caas

### DIFF
--- a/environments/.caas/inventory/group_vars/all/hpctests.yml
+++ b/environments/.caas/inventory/group_vars/all/hpctests.yml
@@ -4,3 +4,7 @@ hpctests_pingpong_plot: false
 # In Azimuth, the Ansible controller is an ephemeral pod, so all that matters is that
 # this is a location that is writable by the container user
 hpctests_outdir: "{{ playbook_dir }}/.tmp/hpctests"
+
+# hpctests run by default in Azimuth but not trying to stress-test the nodes
+# just check compiler, mpi etc works
+hpctests_hpl_mem_frac: 0.05 # 5% node memory


### PR DESCRIPTION
Not trying for a stress-test in caas deployments, just a functional test.