### PR TITLE
Fix ControlPath for cookiecutter ansible.cfg

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/ansible.cfg
+++ b/environments/skeleton/{{cookiecutter.environment}}/ansible.cfg
@@ -11,5 +11,5 @@ roles_path = ../../ansible/roles
 filter_plugins = ../../ansible/filter_plugins
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto ControlPath=~/.ssh/%r@%h-%p -o ControlPersist=240s -o PreferredAuthentications=publickey -o UserKnownHostsFile=/dev/null
+ssh_args = -o ControlMaster=auto -o ControlPath=~/.ssh/%r@%h-%p -o ControlPersist=240s -o PreferredAuthentications=publickey -o UserKnownHostsFile=/dev/null
 pipelining = True


### PR DESCRIPTION
Current cookiecutter ansible.cfg has an error in the ssh options which means that ssh doens't actually work.