### PR TITLE
add storage VLAN interface on all slurm nodes

### DIFF
--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -116,10 +116,12 @@ data "openstack_networking_network_v2" "cluster_external_network" {
   name = "{{ cluster_external_network }}"
 }
 
-# Always get the SRIOV storage network 
-data "openstack_networking_network_v2" "portal_storage_direct" {
-  tags = ["portal-storage-direct"]
+# SRIOV storage network 
+{% if cluster_storage_network is defined %}
+data "openstack_networking_network_v2" "cluster_storage_direct" {
+  name = "{{ cluster_storage_network }}"
 }
+{% endif %}
 
 data "openstack_networking_subnet_ids_v2" "cluster_external_subnets" {
   network_id = "${data.openstack_networking_network_v2.cluster_external_network.id}"
@@ -186,7 +188,7 @@ data "openstack_networking_subnet_v2" "cluster_subnet" {
 # Login node
 ###
 
-# VXLAN
+# Primary network
 resource "openstack_networking_port_v2" "login" {
   name = "{{ cluster_name }}-login-0"
   network_id = "${data.openstack_networking_network_v2.cluster_network.id}"
@@ -212,9 +214,10 @@ resource "openstack_networking_port_v2" "login" {
 }
 
 # Storage VLAN
-resource "openstack_networking_port_v2" "login_portal_storage" {
-  name           = "{{ cluster_name }}-login-0-portal-storage"
-  network_id     = data.openstack_networking_network_v2.portal_storage_direct.id
+{% if cluster_storage_network is defined %}
+resource "openstack_networking_port_v2" "login_storage" {
+  name           = "{{ cluster_name }}-login-storage-0"
+  network_id     = data.openstack_networking_network_v2.cluster_storage_direct.id
   admin_state_up = "true"
 
   # not sure if needed here
@@ -225,15 +228,16 @@ resource "openstack_networking_port_v2" "login_portal_storage" {
 
   # for now, until we set up flavors
   binding {
-    vnic_type = "normal"
+    vnic_type = "{{ cluster_storage_vnic_type | default('normal') }}"
   }
 }
+{% endif %}
 
 ###
 # Control node
 ###
 
-# VLXAN
+# Primary network
 resource "openstack_networking_port_v2" "control" {
   name = "{{ cluster_name }}-control-0"
   network_id = "${data.openstack_networking_network_v2.cluster_network.id}"
@@ -258,10 +262,10 @@ resource "openstack_networking_port_v2" "control" {
 }
 
 # Storage VLAN
-
-resource "openstack_networking_port_v2" "control_portal_storage" {
-  name           = "{{ cluster_name }}-control-0-portal-storage"
-  network_id     = data.openstack_networking_network_v2.portal_storage_direct.id
+{% if cluster_storage_network is defined %}
+resource "openstack_networking_port_v2" "control_storage" {
+  name           = "{{ cluster_name }}-control-storage-0"
+  network_id     = data.openstack_networking_network_v2.cluster_storage_direct.id
   admin_state_up = "true"
 
   # not sure if needed here
@@ -271,15 +275,16 @@ resource "openstack_networking_port_v2" "control_portal_storage" {
 
   # for now, until we set up flavors
   binding {
-    vnic_type = "normal"
+    vnic_type = "{{ cluster_storage_vnic_type | default('normal') }}"
   }
 }
+{% endif %}
 
 ###
 # Workers
 ###
 {% for partition in openhpc_slurm_partitions %}
-# VXLAN
+# Primary network
 resource "openstack_networking_port_v2" "{{ partition.name }}" {
   count = {{ partition.count }}
   name = "{{ cluster_name }}-compute-{{ partition.name }}-${count.index}"
@@ -305,10 +310,11 @@ resource "openstack_networking_port_v2" "{{ partition.name }}" {
 }
 
 # Storage VLAN
-resource "openstack_networking_port_v2" "{{ partition.name }}_portal_storage" {
+{% if cluster_storage_network is defined %}
+resource "openstack_networking_port_v2" "{{ partition.name }}_storage" {
   count          = {{ partition.count }}
-  name           = "{{ cluster_name }}-compute-{{ partition.name }}-${count.index}-portal-storage"
-  network_id     = data.openstack_networking_network_v2.portal_storage_direct.id
+  name           = "{{ cluster_name }}-compute-{{ partition.name }}-storage-${count.index}"
+  network_id     = data.openstack_networking_network_v2.cluster_storage_direct.id
   admin_state_up = "true"
 
   # not sure if needed here
@@ -318,9 +324,10 @@ resource "openstack_networking_port_v2" "{{ partition.name }}_portal_storage" {
 
   # for now, until we set up flavors
   binding {
-    vnic_type = "normal"
+    vnic_type = "{{ cluster_storage_vnic_type | default('normal') }}"
   }
 }
+{% endif %}
 
 {% endfor %}
 
@@ -350,9 +357,11 @@ resource "openstack_compute_instance_v2" "login" {
     port = openstack_networking_port_v2.login.id
   }
 
+  {% if cluster_storage_network is defined %}
   network {
-    port = openstack_networking_port_v2.login_portal_storage.id
+    port = openstack_networking_port_v2.login_storage.id
   }
+  {% endif %}
 
   # root device:
   block_device {
@@ -397,9 +406,11 @@ resource "openstack_compute_instance_v2" "control" {
     port = openstack_networking_port_v2.control.id
   }
 
+  {% if cluster_storage_network is defined %}
   network {
-    port = openstack_networking_port_v2.control_portal_storage.id
+    port = openstack_networking_port_v2.control_storage.id
   }
+  {% endif %}
 
   # root device:
   block_device {
@@ -474,9 +485,11 @@ resource "openstack_compute_instance_v2" "{{ partition.name }}" {
     port = openstack_networking_port_v2.{{ partition.name }}[count.index].id
   }
 
+  {% if cluster_storage_network is defined %}
   network {
-    port = openstack_networking_port_v2.{{ partition.name }}_portal_storage[count.index].id
+    port = openstack_networking_port_v2.{{ partition.name }}_storage[count.index].id
   }
+  {% endif %}
 
   # root device:
   block_device {

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -116,6 +116,11 @@ data "openstack_networking_network_v2" "cluster_external_network" {
   name = "{{ cluster_external_network }}"
 }
 
+# Always get the SRIOV storage network 
+data "openstack_networking_network_v2" "portal_storage_direct" {
+  tags = ["portal-storage-direct"]
+}
+
 data "openstack_networking_subnet_ids_v2" "cluster_external_subnets" {
   network_id = "${data.openstack_networking_network_v2.cluster_external_network.id}"
 }
@@ -177,6 +182,11 @@ data "openstack_networking_subnet_v2" "cluster_subnet" {
 ##### Cluster ports
 #####
 
+###
+# Login node
+###
+
+# VXLAN
 resource "openstack_networking_port_v2" "login" {
   name = "{{ cluster_name }}-login-0"
   network_id = "${data.openstack_networking_network_v2.cluster_network.id}"
@@ -201,6 +211,29 @@ resource "openstack_networking_port_v2" "login" {
   }
 }
 
+# Storage VLAN
+resource "openstack_networking_port_v2" "login_portal_storage" {
+  name           = "{{ cluster_name }}-login-0-portal-storage"
+  network_id     = data.openstack_networking_network_v2.portal_storage_direct.id
+  admin_state_up = "true"
+
+  # not sure if needed here
+  security_group_ids = [
+    "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}",
+    "${openstack_networking_secgroup_v2.secgroup_slurm_login.id}"
+  ]
+
+  # for now, until we set up flavors
+  binding {
+    vnic_type = "normal"
+  }
+}
+
+###
+# Control node
+###
+
+# VLXAN
 resource "openstack_networking_port_v2" "control" {
   name = "{{ cluster_name }}-control-0"
   network_id = "${data.openstack_networking_network_v2.cluster_network.id}"
@@ -224,7 +257,29 @@ resource "openstack_networking_port_v2" "control" {
   }
 }
 
+# Storage VLAN
+
+resource "openstack_networking_port_v2" "control_portal_storage" {
+  name           = "{{ cluster_name }}-control-0-portal-storage"
+  network_id     = data.openstack_networking_network_v2.portal_storage_direct.id
+  admin_state_up = "true"
+
+  # not sure if needed here
+  security_group_ids = [
+    "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
+  ]
+
+  # for now, until we set up flavors
+  binding {
+    vnic_type = "normal"
+  }
+}
+
+###
+# Workers
+###
 {% for partition in openhpc_slurm_partitions %}
+# VXLAN
 resource "openstack_networking_port_v2" "{{ partition.name }}" {
   count = {{ partition.count }}
   name = "{{ cluster_name }}-compute-{{ partition.name }}-${count.index}"
@@ -246,6 +301,24 @@ resource "openstack_networking_port_v2" "{{ partition.name }}" {
     {{ cluster_vnic_profile | to_json }}
     EOF
     {% endif %}
+  }
+}
+
+# Storage VLAN
+resource "openstack_networking_port_v2" "{{ partition.name }}_portal_storage" {
+  count          = {{ partition.count }}
+  name           = "{{ cluster_name }}-compute-{{ partition.name }}-${count.index}-portal-storage"
+  network_id     = data.openstack_networking_network_v2.portal_storage_direct.id
+  admin_state_up = "true"
+
+  # not sure if needed here
+  security_group_ids = [
+    "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
+  ]
+
+  # for now, until we set up flavors
+  binding {
+    vnic_type = "normal"
   }
 }
 
@@ -274,7 +347,11 @@ resource "openstack_compute_instance_v2" "login" {
   {% endif %}
 
   network {
-    port = "${openstack_networking_port_v2.login.id}"
+    port = openstack_networking_port_v2.login.id
+  }
+
+  network {
+    port = openstack_networking_port_v2.login_portal_storage.id
   }
 
   # root device:
@@ -317,7 +394,11 @@ resource "openstack_compute_instance_v2" "control" {
   {% endif %}
 
   network {
-    port = "${openstack_networking_port_v2.control.id}"
+    port = openstack_networking_port_v2.control.id
+  }
+
+  network {
+    port = openstack_networking_port_v2.control_portal_storage.id
   }
 
   # root device:
@@ -391,6 +472,10 @@ resource "openstack_compute_instance_v2" "{{ partition.name }}" {
 
   network {
     port = openstack_networking_port_v2.{{ partition.name }}[count.index].id
+  }
+
+  network {
+    port = openstack_networking_port_v2.{{ partition.name }}_portal_storage[count.index].id
   }
 
   # root device:

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -116,9 +116,9 @@ data "openstack_networking_network_v2" "cluster_external_network" {
   name = "{{ cluster_external_network }}"
 }
 
-# SRIOV storage network 
+# Storage network 
 {% if cluster_storage_network is defined %}
-data "openstack_networking_network_v2" "cluster_storage_direct" {
+data "openstack_networking_network_v2" "cluster_storage" {
   name = "{{ cluster_storage_network }}"
 }
 {% endif %}
@@ -217,15 +217,13 @@ resource "openstack_networking_port_v2" "login" {
 {% if cluster_storage_network is defined %}
 resource "openstack_networking_port_v2" "login_storage" {
   name           = "{{ cluster_name }}-login-storage-0"
-  network_id     = data.openstack_networking_network_v2.cluster_storage_direct.id
+  network_id     = data.openstack_networking_network_v2.cluster_storage.id
   admin_state_up = "true"
 
-  # not sure if needed here
   security_group_ids = [
     "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}",
   ]
 
-  # for now, until we set up flavors
   binding {
     vnic_type = "{{ cluster_storage_vnic_type | default('normal') }}"
   }
@@ -260,19 +258,17 @@ resource "openstack_networking_port_v2" "control" {
   }
 }
 
-# Storage VLAN
+# Storage network
 {% if cluster_storage_network is defined %}
 resource "openstack_networking_port_v2" "control_storage" {
   name           = "{{ cluster_name }}-control-storage-0"
-  network_id     = data.openstack_networking_network_v2.cluster_storage_direct.id
+  network_id     = data.openstack_networking_network_v2.cluster_storage.id
   admin_state_up = "true"
 
-  # not sure if needed here
   security_group_ids = [
     "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
   ]
 
-  # for now, until we set up flavors
   binding {
     vnic_type = "{{ cluster_storage_vnic_type | default('normal') }}"
   }
@@ -308,20 +304,18 @@ resource "openstack_networking_port_v2" "{{ partition.name }}" {
   }
 }
 
-# Storage VLAN
+# Storage network
 {% if cluster_storage_network is defined %}
 resource "openstack_networking_port_v2" "{{ partition.name }}_storage" {
   count          = {{ partition.count }}
   name           = "{{ cluster_name }}-compute-{{ partition.name }}-storage-${count.index}"
-  network_id     = data.openstack_networking_network_v2.cluster_storage_direct.id
+  network_id     = data.openstack_networking_network_v2.cluster_storage.id
   admin_state_up = "true"
 
-  # not sure if needed here
   security_group_ids = [
     "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
   ]
 
-  # for now, until we set up flavors
   binding {
     vnic_type = "{{ cluster_storage_vnic_type | default('normal') }}"
   }

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -205,11 +205,6 @@ resource "openstack_networking_port_v2" "login" {
 
   binding {
     vnic_type = "{{ cluster_vnic_type | default('normal') }}"
-    {% if cluster_vnic_profile is defined %}
-    profile = <<EOF
-    {{ cluster_vnic_profile | to_json }}
-    EOF
-    {% endif %}
   }
 }
 
@@ -250,11 +245,7 @@ resource "openstack_networking_port_v2" "control" {
 
   binding {
     vnic_type = "{{ cluster_vnic_type | default('normal') }}"
-    {% if cluster_vnic_profile is defined %}
-    profile = <<EOF
-    {{ cluster_vnic_profile | to_json }}
-    EOF
-    {% endif %}
+
   }
 }
 
@@ -296,11 +287,6 @@ resource "openstack_networking_port_v2" "{{ partition.name }}" {
 
   binding {
     vnic_type = "{{ cluster_vnic_type | default('normal') }}"
-    {% if cluster_vnic_profile is defined %}
-    profile = <<EOF
-    {{ cluster_vnic_profile | to_json }}
-    EOF
-    {% endif %}
   }
 }
 

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -213,7 +213,7 @@ resource "openstack_networking_port_v2" "login" {
   }
 }
 
-# Storage VLAN
+# Storage network
 {% if cluster_storage_network is defined %}
 resource "openstack_networking_port_v2" "login_storage" {
   name           = "{{ cluster_name }}-login-storage-0"

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -223,7 +223,6 @@ resource "openstack_networking_port_v2" "login_storage" {
   # not sure if needed here
   security_group_ids = [
     "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}",
-    "${openstack_networking_secgroup_v2.secgroup_slurm_login.id}"
   ]
 
   # for now, until we set up flavors


### PR DESCRIPTION


Additional note from @sjpb :
> The `.caas` environment uses `etc_hosts` to template out /etc/hosts. By default (= .caas environment) it uses `ansible_host` as the IP. This is safe after this IP as `stackhpc.terraform.infra/inventory_adopt` uses the terraform output `node.ip` for this, and this is set in `roles/cluster_infra/templates/outputs.tf` to be network[0] on all nodes. This PR adds the storage network as the *2nd* network so it will not be in /etc/hosts.