### PR TITLE
Support ceph quincy for RL9

### DIFF
--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -29,9 +29,9 @@ variable "cluster_image" {
     description = "single image for all cluster nodes, keyed by os_version - a convenience for CI"
     type = map(string)
     default = {
-        # https://github.com/stackhpc/ansible-slurm-appliance/pull/394
-        RL8: "openhpc-RL8-240605-1205-a3002d19"
-        RL9: "openhpc-ofed-RL9-240605-1204-a3002d19"
+        # https://github.com/stackhpc/ansible-slurm-appliance/pull/397
+        RL8: "openhpc-RL8-240606-1054-5ec8558e"
+        RL9: "openhpc-ofed-RL9-240606-1054-5ec8558e"
     }
 }
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -22,7 +22,7 @@ roles:
     version: v3.1.5
   - src: https://github.com/stackhpc/ansible-role-os-manila-mount.git
     name: stackhpc.os-manila-mount
-    version: v24.2.0 # Support RockyLinux 9
+    version: v24.5.1 # Support ceph quincy for RL9
 
 collections:
   - name: containers.podman


### PR DESCRIPTION
Changes default Ceph versions as per [here](https://github.com/stackhpc/ansible-role-os-manila-mount/pull/9):
    "8": from nautilus to octopus (15.2.17)
    "9": from reef to quincy (17.2.7)