### PR TITLE
Extend caas manila /home

### DIFF
--- a/environments/.caas/inventory/extra_groups
+++ b/environments/.caas/inventory/extra_groups
@@ -9,8 +9,7 @@ grafana
 openondemand
 
 [manila:children]
-login
-compute
+cluster
 
 [podman:children]
 zenith


### PR DESCRIPTION
Mount caas environment's manila `/home` share on control node to permit azimuth user to ssh to the control node.