### PR TITLE
Add squid role

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -54,3 +54,5 @@ roles/*
 !roles/persist_hostkeys/**
 !roles/ofed/
 !roles/ofed/**
+!roles/squid/
+!roles/squid/**

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -46,10 +46,6 @@
         path: /etc/profile
         search_string: HOSTNAME=$(/usr/bin/hostnamectl --transient 2>/dev/null) || \
         state: absent
-    - name: Remove RHEL cockpit
-      dnf:
-        name: cockpit-ws
-        state: "{{ appliances_cockpit_state }}"
     - name: Add system user groups
       ansible.builtin.group: "{{ item.group }}"
       loop: "{{ appliances_local_users }}"
@@ -91,6 +87,16 @@
         policy: "{{ selinux_policy }}"
       register: sestatus
 
+# --- tasks after here require access to package repos ---
+- hosts: squid
+  tags: squid
+  gather_facts: yes
+  become: yes
+  tasks:
+    - name: Configure squid proxy
+      import_role:
+        name: squid
+
 - hosts: freeipa_server
   # Done here as it might be providing DNS
   tags:
@@ -104,7 +110,15 @@
         name: freeipa
         tasks_from: server.yml
 
-# --- tasks after here require access to package repos ---
+- hosts: cluster
+  gather_facts: false
+  become: yes
+  tags: cockpit
+  tasks:
+    - name: Remove RHEL cockpit
+      dnf:
+        name: cockpit-ws
+        state: "{{ appliances_cockpit_state }}"
 
 - hosts: firewalld
   gather_facts: false

--- a/ansible/roles/proxy/tasks/main.yml
+++ b/ansible/roles/proxy/tasks/main.yml
@@ -43,8 +43,10 @@
     path: /etc/systemd/system.conf.d/90-proxy.conf
     section: Manager
     option: DefaultEnvironment
-    value: >
-        "http_proxy={{ proxy_http_proxy }}" "https_proxy={{ proxy_http_proxy }}" "no_proxy={{ proxy_no_proxy }}"
+    value: >-
+        "http_proxy={{ proxy_http_proxy }}"
+        "https_proxy={{ proxy_http_proxy }}"
+        "no_proxy={{ proxy_no_proxy }}"
     no_extra_spaces: true
     owner: root
     group: root

--- a/ansible/roles/squid/README.md
+++ b/ansible/roles/squid/README.md
@@ -1,0 +1,38 @@
+# squid
+
+Deploy a caching proxy.
+
+**NB:** The default configuration is aimed at providing a proxy for package installs etc. for
+nodes which do not have direct internet connectivity. It assumes access to the proxy is protected
+by the OpenStack security groups applied to the cluster. The generated configuration should be
+reviewed if this is not case.
+
+## Role Variables
+Where noted these map to squid parameters of the same name without the `squid_` prefix - see [squid documentation](https://www.squid-cache.org/Doc/config) for details.
+
+- `squid_conf_template`: Optional str. Path (using Ansible search paths) to squid.conf template. Default is in-role template.
+- `squid_started`: Optional bool. Whether to start squid service. Default `true`.
+- `squid_enabled`: Optional bool. Whether squid service is enabled boot. Default `true`.
+- `squid_cache_mem`: Required str. Size of memory cache, .g "1024 KB", "12 GB" etc. See squid parameter.
+- `squid_cache_dir`: Optional. Path to cache directory. Default `/var/spool/squid`.
+- `squid_cache_disk`: Required int. Size of disk cache in MB. See Mbytes under "ufs" store type for squid parameter [cache_dir](https://www.squid-cache.org/Doc/config/cache_dir/).
+- `squid_maximum_object_size_in_memory`: Optional str. Upper size limit for objects in memory cache, default '64 MB'. See squid parameter.
+- `squid_maximum_object_size`: Optional str. Upper size limit for objects in disk cache, default '200 MB'. See squid parameter.
+- `squid_http_port`: Optional str. Socket addresses to listen for client requests, default '3128'. See squid parameter.
+- `squid_acls`: Optional str, can be multiline. Define access lists. Default `acl anywhere src all`, i.e. rely on OpenStack security groups (or other firewall if deployed). See squid parameter `acl`. NB: The default template also defines acls for `SSL_ports` and `Safe_ports` as is common practice.
+- `squid_http_access`: Optional str, can be multiline. Allow/deny access based on access lists. Default:
+
+        # Deny requests to certain unsafe ports
+        http_access deny !Safe_ports
+        # Deny CONNECT to other than secure SSL ports
+        http_access deny CONNECT !SSL_ports
+        # Only allow cachemgr access from localhost
+        http_access allow localhost manager
+        http_access deny manager
+        # Rules allowing http access
+        http_access allow anywhere
+        http_access allow localhost
+        # Finally deny all other access to this proxy
+        http_access deny all
+        
+  See squid parameter.

--- a/ansible/roles/squid/README.md
+++ b/ansible/roles/squid/README.md
@@ -14,7 +14,7 @@ Where noted these map to squid parameters of the same name without the `squid_` 
 - `squid_conf_template`: Optional str. Path (using Ansible search paths) to squid.conf template. Default is in-role template.
 - `squid_started`: Optional bool. Whether to start squid service. Default `true`.
 - `squid_enabled`: Optional bool. Whether squid service is enabled on boot. Default `true`.
-- `squid_cache_mem`: Required str. Size of memory cache, .g "1024 KB", "12 GB" etc. See squid parameter.
+- `squid_cache_mem`: Required str. Size of memory cache, e.g "1024 KB", "12 GB" etc. See squid parameter.
 - `squid_cache_dir`: Optional. Path to cache directory. Default `/var/spool/squid`.
 - `squid_cache_disk`: Required int. Size of disk cache in MB. See Mbytes under "ufs" store type for squid parameter [cache_dir](https://www.squid-cache.org/Doc/config/cache_dir/).
 - `squid_maximum_object_size_in_memory`: Optional str. Upper size limit for objects in memory cache, default '64 MB'. See squid parameter.

--- a/ansible/roles/squid/README.md
+++ b/ansible/roles/squid/README.md
@@ -13,7 +13,7 @@ Where noted these map to squid parameters of the same name without the `squid_` 
 
 - `squid_conf_template`: Optional str. Path (using Ansible search paths) to squid.conf template. Default is in-role template.
 - `squid_started`: Optional bool. Whether to start squid service. Default `true`.
-- `squid_enabled`: Optional bool. Whether squid service is enabled boot. Default `true`.
+- `squid_enabled`: Optional bool. Whether squid service is enabled on boot. Default `true`.
 - `squid_cache_mem`: Required str. Size of memory cache, .g "1024 KB", "12 GB" etc. See squid parameter.
 - `squid_cache_dir`: Optional. Path to cache directory. Default `/var/spool/squid`.
 - `squid_cache_disk`: Required int. Size of disk cache in MB. See Mbytes under "ufs" store type for squid parameter [cache_dir](https://www.squid-cache.org/Doc/config/cache_dir/).

--- a/ansible/roles/squid/README.md
+++ b/ansible/roles/squid/README.md
@@ -8,6 +8,7 @@ by the OpenStack security groups applied to the cluster. The generated configura
 reviewed if this is not case.
 
 ## Role Variables
+
 Where noted these map to squid parameters of the same name without the `squid_` prefix - see [squid documentation](https://www.squid-cache.org/Doc/config) for details.
 
 - `squid_conf_template`: Optional str. Path (using Ansible search paths) to squid.conf template. Default is in-role template.

--- a/ansible/roles/squid/defaults/main.yml
+++ b/ansible/roles/squid/defaults/main.yml
@@ -2,9 +2,9 @@ squid_conf_template: squid.conf.j2
 squid_started: true
 squid_enabled: true
 
-squid_cache_mem: "{{ undef(hint='squid_cache_mem_size required, e.g. \"12 GB\"')  }}"
+squid_cache_mem: "{{ undef(hint='squid_cache_mem required, e.g. \"12 GB\"')  }}"
 squid_cache_dir: /var/spool/squid
-squid_cache_disk: "{{ undef(hint='squid_cache_disk_size (in MB) required, e.g. \"1024\"')  }}" # always in MB
+squid_cache_disk: "{{ undef(hint='squid_cache_disk (in MB) required, e.g. \"1024\"')  }}" # always in MB
 squid_maximum_object_size_in_memory: '64 MB'
 squid_maximum_object_size: '200 MB'
 squid_http_port: 3128

--- a/ansible/roles/squid/defaults/main.yml
+++ b/ansible/roles/squid/defaults/main.yml
@@ -1,0 +1,24 @@
+squid_conf_template: squid.conf.j2
+squid_started: true
+squid_enabled: true
+
+squid_cache_mem: "{{ undef(hint='squid_cache_mem_size required, e.g. \"12 GB\"')  }}"
+squid_cache_dir: /var/spool/squid
+squid_cache_disk: "{{ undef(hint='squid_cache_disk_size (in MB) required, e.g. \"1024\"')  }}" # always in MB
+squid_maximum_object_size_in_memory: '64 MB'
+squid_maximum_object_size: '200 MB'
+squid_http_port: 3128
+squid_acls: acl anywhere src all # rely on openstack security groups
+squid_http_access: |
+  # Deny requests to certain unsafe ports
+  http_access deny !Safe_ports
+  # Deny CONNECT to other than secure SSL ports
+  http_access deny CONNECT !SSL_ports
+  # Only allow cachemgr access from localhost
+  http_access allow localhost manager
+  http_access deny manager
+  # Rules allowing http access
+  http_access allow anywhere
+  http_access allow localhost
+  # Finally deny all other access to this proxy
+  http_access deny all

--- a/ansible/roles/squid/handlers/main.yml
+++ b/ansible/roles/squid/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: Restart squid
+  service:
+    name: squid
+    state: restarted
+  when: squid_started | bool

--- a/ansible/roles/squid/tasks/configure.yml
+++ b/ansible/roles/squid/tasks/configure.yml
@@ -1,0 +1,24 @@
+- name: Ensure squid cache directory exists
+  file:
+    path: "{{ squid_cache_dir }}"
+    # based on what dnf package creates:
+    owner: squid
+    mode: squid
+    mode: u=rwx,g=rw,o=
+
+- name: Template squid configuration
+  template:
+    src: "{{ squid_conf_template }}"
+    dest: /etc/squid/squid.conf
+    owner: squid
+    group: squid
+    mode: ug=rwX,go=
+  notify: Restart squid
+
+- meta: flush_handlers
+
+- name: Ensure squid service state
+  systemd:
+    name: squid
+    state: "{{ 'started' if squid_started | bool else 'stopped' }}"
+    enabled: "{{ true if squid_enabled else false }}"

--- a/ansible/roles/squid/tasks/configure.yml
+++ b/ansible/roles/squid/tasks/configure.yml
@@ -3,7 +3,7 @@
     path: "{{ squid_cache_dir }}"
     # based on what dnf package creates:
     owner: squid
-    mode: squid
+    group: squid
     mode: u=rwx,g=rw,o=
 
 - name: Template squid configuration

--- a/ansible/roles/squid/tasks/install.yml
+++ b/ansible/roles/squid/tasks/install.yml
@@ -1,0 +1,3 @@
+- name: Install squid package
+  dnf:
+    name: squid

--- a/ansible/roles/squid/tasks/main.yml
+++ b/ansible/roles/squid/tasks/main.yml
@@ -1,0 +1,2 @@
+- import_tasks: install.yml
+- import_tasks: configure.yml

--- a/ansible/roles/squid/templates/squid.conf.j2
+++ b/ansible/roles/squid/templates/squid.conf.j2
@@ -43,7 +43,7 @@ coredump_dir /var/spool/squid
 # Configure refresh
 # cache repodata only few minutes and then query parent whether it is fresh:
 refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims
-# rpm will hardly ever change, force to chache it for very long time:
+# rpm will hardly ever change, force it to cache for very long time:
 refresh_pattern \.rpm$ 10080 100% 525960 override-expire override-lastmod ignore-reload reload-into-ims
 refresh_pattern ^ftp: 1440 20% 10080
 refresh_pattern ^gopher: 1440 0% 1440

--- a/ansible/roles/squid/templates/squid.conf.j2
+++ b/ansible/roles/squid/templates/squid.conf.j2
@@ -1,0 +1,54 @@
+#
+# Based on combination of configs from
+# - https://github.com/stackhpc/docker-squid/blob/master/squid.conf
+# - https://github.com/drosskopp/squid-cache/blob/main/squid.conf
+#
+
+# Define ACLs:
+{{ squid_acls }}
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+# Rules allowing http access
+{{ squid_http_access}}
+
+# Squid normally listens to port 3128
+http_port {{ squid_http_port }}
+
+# Define cache parameters:
+cache_dir ufs /var/spool/squid {{ squid_cache_disk | int }} 16 256
+cache_mem {{ squid_cache_mem }}
+maximum_object_size_in_memory {{ squid_maximum_object_size_in_memory }}
+maximum_object_size {{ squid_maximum_object_size }}
+
+# Keep largest objects around longer:
+cache_replacement_policy heap LFUDA
+
+memory_replacement_policy heap GDSF
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/spool/squid
+
+# Configure refresh
+# cache repodata only few minutes and then query parent whether it is fresh:
+refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims
+# rpm will hardly ever change, force to chache it for very long time:
+refresh_pattern \.rpm$ 10080 100% 525960 override-expire override-lastmod ignore-reload reload-into-ims
+refresh_pattern ^ftp: 1440 20% 10080
+refresh_pattern ^gopher: 1440 0% 1440
+refresh_pattern -i (/cgi-bin/|\?) 0 0% 0
+refresh_pattern . 0 20% 4320
+
+# Disable squid doing logfile rotation as the RockyLinux dnf package configures logrotate
+logfile_rotate 0

--- a/environments/.stackhpc/inventory/extra_groups
+++ b/environments/.stackhpc/inventory/extra_groups
@@ -27,3 +27,7 @@ cluster
 # Allows demo; also installs manila client in fat image
 login
 compute
+
+[squid:children]
+# Install squid into fat image
+builder

--- a/environments/.stackhpc/terraform/main.tf
+++ b/environments/.stackhpc/terraform/main.tf
@@ -29,9 +29,8 @@ variable "cluster_image" {
     description = "single image for all cluster nodes, keyed by os_version - a convenience for CI"
     type = map(string)
     default = {
-        # https://github.com/stackhpc/ansible-slurm-appliance/pull/399
-        RL8: "openhpc-RL8-240619-0949-66c0e540"
-        RL9: "openhpc-ofed-RL9-240619-0949-66c0e540"
+        RL8: "openhpc-RL8-240619-0949-66c0e540" # https://github.com/stackhpc/ansible-slurm-appliance/pull/399
+        RL9: "openhpc-ofed-RL9-240621-1308-96959324" #  https://github.com/stackhpc/ansible-slurm-appliance/pull/401
     }
 }
 

--- a/environments/common/inventory/group_vars/all/proxy.yml
+++ b/environments/common/inventory/group_vars/all/proxy.yml
@@ -1,0 +1,2 @@
+# default proxy address to first squid api address port 3128 if squid group non-empty, else empty string to avoid breaking hostvars
+proxy_http_proxy: "{{ 'http://' + hostvars[groups['squid'].0].api_address + ':3128' if groups['squid'] else '' }}"

--- a/environments/common/inventory/group_vars/all/proxy.yml
+++ b/environments/common/inventory/group_vars/all/proxy.yml
@@ -1,2 +1,2 @@
 # default proxy address to first squid api address port 3128 if squid group non-empty, else empty string to avoid breaking hostvars
-proxy_http_proxy: "{{ 'http://' + hostvars[groups['squid'].0].api_address + ':3128' if groups['squid'] else '' }}"
+proxy_http_proxy: "{{ 'http://' + hostvars[groups['squid'].0].api_address + ':' + squid_http_port if groups['squid'] else '' }}"

--- a/environments/common/inventory/group_vars/all/squid.yml
+++ b/environments/common/inventory/group_vars/all/squid.yml
@@ -1,0 +1,1 @@
+squid_http_port: 3128 # defined here for proxy role

--- a/environments/common/inventory/group_vars/builder/defaults.yml
+++ b/environments/common/inventory/group_vars/builder/defaults.yml
@@ -16,3 +16,6 @@ opensearch_state: stopped # avoid writing config+certs+db into image
 cuda_persistenced_state: stopped # probably don't have GPU in Packer build VMs
 firewalld_enabled: false # dnf install of firewalld enables it
 firewalld_state: stopped
+squid_started: false
+squid_enabled: false
+

--- a/environments/common/inventory/group_vars/builder/defaults.yml
+++ b/environments/common/inventory/group_vars/builder/defaults.yml
@@ -18,4 +18,5 @@ firewalld_enabled: false # dnf install of firewalld enables it
 firewalld_state: stopped
 squid_started: false
 squid_enabled: false
-
+squid_cache_disk: 0 # just needs to be defined
+squid_cache_mem: 0

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -32,6 +32,7 @@ openhpc
 opensearch
 filebeat
 mysql
+squid
 
 [prometheus]
 # Single node to host monitoring server.
@@ -126,3 +127,6 @@ freeipa_client
 
 [persist_hostkeys]
 # Hosts to persist hostkeys for across reimaging. NB: Requires appliances_state_dir on hosts.
+
+[squid]
+# Hosts to run squid proxy

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -72,3 +72,6 @@ openhpc
 
 [persist_hostkeys]
 # Hosts to persist hostkeys for across reimaging. NB: Requires appliances_state_dir on hosts.
+
+[squid]
+# Hosts to run squid proxy


### PR DESCRIPTION
- Adds a `squid` role to allow nodes without direct access to download packages etc.
- Changes `proxy` role defaults to set proxy automatically if `squid` enabled.
- Fixes idempotency off  systemd config from `proxy` role.

Squid here is from the dnf packages and is not containerised. This avoids a dependency on the `podman` role, which otherwise might mean only the control node could run squid (as the control node requires podman). Given the stability of squid this seems a reasonable trade-off.