### PR TITLE
Fix squid port default

### DIFF
--- a/environments/common/inventory/group_vars/all/proxy.yml
+++ b/environments/common/inventory/group_vars/all/proxy.yml
@@ -1,2 +1,2 @@
 # default proxy address to first squid api address port 3128 if squid group non-empty, else empty string to avoid breaking hostvars
-proxy_http_proxy: "{{ 'http://' + hostvars[groups['squid'].0].api_address + ':' + squid_http_port if groups['squid'] else '' }}"
+proxy_http_proxy: "{{ 'http://' + hostvars[groups['squid'].0].api_address + ':' + (squid_http_port | string) if groups['squid'] else '' }}"


### PR DESCRIPTION
default `squid_http_port` is an int (and that makes sense) which means it can't be concatenated onto a string