### PR TITLE
Remove squid nodes from podman group

### DIFF
--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -32,7 +32,6 @@ openhpc
 opensearch
 filebeat
 mysql
-squid
 
 [prometheus]
 # Single node to host monitoring server.


### PR DESCRIPTION
Squid is not containerised in the current implementation. Current config could lead to podman being installed/enabled on nodes where is it not required.