### PR TITLE
Use shorter names for CI clusters

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
-      TF_VAR_cluster_name: slurmci_${{ matrix.os_version }}_${{ github.run_number }}
+      TF_VAR_cluster_name: slurmci-${{ matrix.os_version }}-${{ github.run_number }}
       CI_CLOUD: ${{ vars.CI_CLOUD }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
-      TF_VAR_cluster_name: slurmci-${{ matrix.os_version }}-${{ github.run_number }}
+      TF_VAR_cluster_name: slurmci_${{ matrix.os_version }}_${{ github.run_number }}
       CI_CLOUD: ${{ vars.CI_CLOUD }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
-      TF_VAR_cluster_name: slurmci-${{ matrix.os_version }}-${{ github.run_id }}
+      TF_VAR_cluster_name: slurmci-${{ matrix.os_version }}-${{ github.run_number }}
       CI_CLOUD: ${{ vars.CI_CLOUD }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
with names like `slurmci-RL9-10011038748-compute-1.slurmci-RL9-10011038748.invalid` munge fails to startup complaining host name is too long

hosts need FQDN for freeipa. Current FDQN scheme is `${var.cluster_name}-${each.key}.${var.cluster_name}.${var.cluster_domain_suffix}`. The cluster-name gets repeated in the hostname and in the middle section of the FQDN as this means you can see the cluster name in e.g. `openstack server list` which is really helpful when e.g. staging and production clusters are in the same project.