### PR TITLE
Enable setting per-compute group availability zones

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/nodes.tf
@@ -26,6 +26,7 @@ resource "openstack_compute_instance_v2" "compute" {
   image_id = var.image_id
   flavor_name = var.flavor
   key_pair = var.key_pair
+  availability_zone = var.availability_zone_prefix == "" ? null : "${var.availability_zone_prefix}${regex(".*-(.*)$", each.key)[0]}"
 
   dynamic "block_device" {
     for_each = var.volume_backed_instances ? [1]: []

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/variables.tf
@@ -67,3 +67,9 @@ variable "root_volume_size" {
 variable "security_group_ids" {
     type = list
 }
+
+variable "availability_zone_prefix" {
+    description = "If non-empty, then the availability_zone is set to this + the last portion of the nodename when split on '-'"
+    type = string
+    default = ""
+}

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
@@ -52,6 +52,7 @@ variable "compute" {
             image_id: Overrides variable cluster_image_id
             vnic_type: Overrides variable vnic_type
             vnic_profile: Overrides variable vnic_profile
+            availability_zone_prefix: If set, use this + last portion of nodename when split on '-' to set availability_zone
     EOF
 }
 


### PR DESCRIPTION
**NB:** This won't work as is, the availability zone host needs to be the node UUID, not the node name.

Adds a new option `availability_zone_prefix` to the compute groups in the skeleton terraform. If set, this is prefixed to the last portion of each compute node name split on "-" and used to set the instance availability zone

This enables scheduling baremetal instances to specific hosts. For example if `openstack baremetal node list` shows baremetal nodes `compute-[0,5]` then the following OpenTofu configuration will result in instances `${cluster_name}-hpc-[0,2]` landing on the first 3x baremetal nodes. This can simplify troubleshooting.

```
# environments/$env/terraform/terraform.tfvars:
...
compute = {
  baremetal = {
   flavor = "baremetal.xlarge"
   availability_zone_prefix = "nova::compute-"
   nodes = ["hpc-0", "hpc-1", "hpc-2"]
  }
}
...
```
