### PR TITLE
Avoid python-openstackclient v7 due to rebuild bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible==6.0.0
 openstacksdk
-python-openstackclient
+python-openstackclient==6.6.1 # v7.0.0 has a bug re. rebuild
 python-manilaclient
 jmespath
 passlib[bcrypt]==1.7.4


### PR DESCRIPTION
With the current latest v7.0.0 python-openstackclient the rebuild command in CI fails, see https://bugs.launchpad.net/python-openstackclient/+bug/2076232