### PR TITLE
Update hpctests to obey UCX_NET_DEVICES when RoCE devices present

### DIFF
--- a/ansible/roles/hpctests/templates/pingmatrix.sh.j2
+++ b/ansible/roles/hpctests/templates/pingmatrix.sh.j2
@@ -16,4 +16,8 @@ echo UCX_NET_DEVICES: $UCX_NET_DEVICES
 module load {{ hpctests_pingmatrix_modules | join(' ' ) }}
 
 mpicc -o nxnlatbw mpi_nxnlatbw.c
+
+{# mpirun flags force using UCX TCP transports, overriding higher #}
+{# priority of OpenMPI btl/openib component, which is also using RDMA #}
+{# https://wiki.stackhpc.com/s/985dae84-7bd8-4924-94b7-9629a7827100 #}
 mpirun -mca pml_ucx_tls any -mca pml_ucx_devices any nxnlatbw

--- a/ansible/roles/hpctests/templates/pingmatrix.sh.j2
+++ b/ansible/roles/hpctests/templates/pingmatrix.sh.j2
@@ -17,7 +17,7 @@ module load {{ hpctests_pingmatrix_modules | join(' ' ) }}
 
 mpicc -o nxnlatbw mpi_nxnlatbw.c
 
-{# mpirun flags force using UCX TCP transports, overriding higher #}
-{# priority of OpenMPI btl/openib component, which is also using RDMA #}
-{# https://wiki.stackhpc.com/s/985dae84-7bd8-4924-94b7-9629a7827100 #}
+# mpirun flags force using UCX TCP transports, overriding higher
+# priority of OpenMPI btl/openib component, which is also using RDMA
+# https://wiki.stackhpc.com/s/985dae84-7bd8-4924-94b7-9629a7827100 
 mpirun -mca pml_ucx_tls any -mca pml_ucx_devices any nxnlatbw

--- a/ansible/roles/hpctests/templates/pingmatrix.sh.j2
+++ b/ansible/roles/hpctests/templates/pingmatrix.sh.j2
@@ -16,4 +16,4 @@ echo UCX_NET_DEVICES: $UCX_NET_DEVICES
 module load {{ hpctests_pingmatrix_modules | join(' ' ) }}
 
 mpicc -o nxnlatbw mpi_nxnlatbw.c
-mpirun nxnlatbw
+mpirun -mca pml_ucx_tls any -mca pml_ucx_devices any nxnlatbw

--- a/ansible/roles/hpctests/templates/pingpong.sh.j2
+++ b/ansible/roles/hpctests/templates/pingpong.sh.j2
@@ -16,4 +16,8 @@ echo UCX_NET_DEVICES: $UCX_NET_DEVICES
 module load {{ hpctests_pingpong_modules | join(' ' ) }}
 
 #srun --mpi=pmi2 IMB-MPI1 pingpong # doesn't work in ohpc v2.1
+
+{# mpirun flags force using UCX TCP transports, overriding higher #}
+{# priority of OpenMPI btl/openib component, which is also using RDMA #}
+{# https://wiki.stackhpc.com/s/985dae84-7bd8-4924-94b7-9629a7827100 #}
 mpirun -mca pml_ucx_tls any -mca pml_ucx_devices any IMB-MPI1 pingpong

--- a/ansible/roles/hpctests/templates/pingpong.sh.j2
+++ b/ansible/roles/hpctests/templates/pingpong.sh.j2
@@ -16,4 +16,4 @@ echo UCX_NET_DEVICES: $UCX_NET_DEVICES
 module load {{ hpctests_pingpong_modules | join(' ' ) }}
 
 #srun --mpi=pmi2 IMB-MPI1 pingpong # doesn't work in ohpc v2.1
-mpirun IMB-MPI1 pingpong
+mpirun -mca pml_ucx_tls any -mca pml_ucx_devices any IMB-MPI1 pingpong

--- a/ansible/roles/hpctests/templates/pingpong.sh.j2
+++ b/ansible/roles/hpctests/templates/pingpong.sh.j2
@@ -17,7 +17,7 @@ module load {{ hpctests_pingpong_modules | join(' ' ) }}
 
 #srun --mpi=pmi2 IMB-MPI1 pingpong # doesn't work in ohpc v2.1
 
-{# mpirun flags force using UCX TCP transports, overriding higher #}
-{# priority of OpenMPI btl/openib component, which is also using RDMA #}
-{# https://wiki.stackhpc.com/s/985dae84-7bd8-4924-94b7-9629a7827100 #}
+# mpirun flags force using UCX TCP transports, overriding higher 
+# priority of OpenMPI btl/openib component, which is also using RDMA 
+# https://wiki.stackhpc.com/s/985dae84-7bd8-4924-94b7-9629a7827100
 mpirun -mca pml_ucx_tls any -mca pml_ucx_devices any IMB-MPI1 pingpong


### PR DESCRIPTION
Adds openmpi runtime options to prevent openmpi's own RoCE detection overriding UCX_NET_DEVICES, if set. See https://github.com/openucx/ucx/issues/10049 for more information.