### PR TITLE
Remove local DNS as a dependency for k3s

### DIFF
--- a/ansible/roles/k3s/files/start_k3s.yml
+++ b/ansible/roles/k3s/files/start_k3s.yml
@@ -4,8 +4,7 @@
     os_metadata: "{{ lookup('url', 'http://169.254.169.254/openstack/latest/meta_data.json') | from_json }}"
     k3s_token: "{{ os_metadata.meta.k3s_token }}"
     k3s_server_name: "{{ os_metadata.meta.k3s_server }}"
-    k3s_node_type: "{{ os_metadata.meta.k3s_node_type }}"
-    service_name: "{{ 'k3s-agent' if k3s_node_type == 'agent' else 'k3s' }}"
+    service_name: "{{ 'k3s-agent' if k3s_server_name is defined else 'k3s' }}"
   tasks:
     - name: Add the token for joining the cluster to the environment
       no_log: false # avoid logging the server token
@@ -17,7 +16,7 @@
       ansible.builtin.lineinfile:
         path: "/etc/systemd/system/{{ service_name }}.service.env"
         line: "K3S_URL=https://{{ k3s_server_name }}:6443"
-      when: k3s_node_type == "agent"
+      when: k3s_server_name is defined
 
     - name: Start k3s service
       ansible.builtin.systemd:
@@ -25,4 +24,3 @@
         daemon_reload: true
         state: started
         enabled: true
-      when: k3s_node_type != "none"

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute.tf
@@ -16,5 +16,6 @@ module "compute" {
   key_pair = var.key_pair
   environment_root = var.environment_root
   k3s_token = var.k3s_token
+  k3s_server = [for n in openstack_compute_instance_v2.control["control"].network: n.fixed_ip_v4 if n.access_network][0]
   security_group_ids = [for o in data.openstack_networking_secgroup_v2.nonlogin: o.id]
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/nodes.tf
@@ -47,7 +47,7 @@ resource "openstack_compute_instance_v2" "compute" {
   metadata = {
     environment_root = var.environment_root
     k3s_token = var.k3s_token
-    k3s_server = "${var.cluster_name}-control"
+    k3s_server = var.k3s_server
     k3s_node_type = "agent"
   }
 

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/variables.tf
@@ -72,3 +72,8 @@ variable "k3s_token" {
     description = "Random cryptographically secure string for K3s token (must be set by ../compute.tf)"
     type = string
 }
+
+variable "k3s_server" {
+    description = "Name/address of k3s server"
+    type = string
+}

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
@@ -77,7 +77,7 @@ resource "openstack_compute_instance_v2" "control" {
   metadata = {
     environment_root = var.environment_root
     k3s_token = var.k3s_token
-    k3s_server = "${var.cluster_name}-control"
+    k3s_server = "" # think this can go?
     k3s_node_type = "server"
   }
 
@@ -128,7 +128,7 @@ resource "openstack_compute_instance_v2" "login" {
   metadata = {
     environment_root = var.environment_root
     k3s_token = var.k3s_token
-    k3s_server = "${var.cluster_name}-control"
+    k3s_server = [for n in openstack_compute_instance_v2.control["control"].network: n.fixed_ip_v4 if n.access_network][0]
     k3s_node_type = "agent"
   }
 

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/nodes.tf
@@ -77,7 +77,6 @@ resource "openstack_compute_instance_v2" "control" {
   metadata = {
     environment_root = var.environment_root
     k3s_token = var.k3s_token
-    k3s_server = "" # think this can go?
     k3s_node_type = "server"
   }
 


### PR DESCRIPTION
I've tested this and terraform appears to behave properly, i.e. dependency tracking works.

Note using `openstack_compute_instance_v2.control["control"].access_ip_v4` is not, in the general case OK:

> [access_ip_v4](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_instance_v2#access_ip_v4) - The first detected Fixed IPv4 address.

([source](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_instance_v2#attributes-reference))

if the terraform is extended with another interface (which it often is) then this might not be right.