### PR TITLE
Caas updated to use openstack_networking_floatingip_associate_v2

### DIFF
--- a/ansible/roles/cluster_infra/templates/providers.tf.j2
+++ b/ansible/roles/cluster_infra/templates/providers.tf.j2
@@ -5,6 +5,10 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      # TODO we must upgrade to 3.0.0
+      # but only after we stop using the deprecated
+      # openstack_compute_floatingip_associate_v2
+      version = "~>2.1.0"
     }
   }
 }

--- a/ansible/roles/cluster_infra/templates/resources.tf.j2
+++ b/ansible/roles/cluster_infra/templates/resources.tf.j2
@@ -572,7 +572,7 @@ data "openstack_networking_floatingip_v2" "cluster_floating_ip" {
   {% endif %}
 }
 
-resource "openstack_compute_floatingip_associate_v2" "login_floatingip_assoc" {
+resource "openstack_networking_floatingip_associate_v2" "login_floatingip_assoc" {
   floating_ip = "${data.openstack_networking_floatingip_v2.cluster_floating_ip.address}"
-  instance_id = "${openstack_compute_instance_v2.login.id}"
+  port_id = "${openstack_networking_port_v2.login.id}"
 }


### PR DESCRIPTION
Before we can move to v3.0.0 we need to use the new floating ip resource, now the compute one has been removed.
To unblock this move, we add a tempory pin to use v2.1.0 for a bit.