### PR TITLE
Upload main images to Arcus S3 and sync clouds

### DIFF
--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -1,72 +1,42 @@
-name: Build fat image
+name: Upload CI-tested images to Arcus S3 and sync clouds
 on:
   workflow_dispatch:
-      inputs:
-        ci_cloud:
-          description: 'Select the CI_CLOUD'
-          required: true
-          type: choice
-          options:
-            - LEAFCLOUD
-            - SMS
-            - ARCUS
+  push:
+    branches:
+      - main
+    paths:
+      - 'environments/.stackhpc/terraform/cluster_image.auto.tfvars.json'
 
 jobs:
-  openstack:
-    name: openstack-imagebuild
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os_version }}-${{ matrix.build }} # to branch/PR + OS + build
-      cancel-in-progress: true
+  image_upload:
     runs-on: ubuntu-22.04
+    concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build }}
     strategy:
-      fail-fast: false # allow other matrix jobs to continue even if one fails
-      matrix: # build RL8+OFED, RL9+OFED, RL9+OFED+CUDA versions
-        os_version:
+      fail-fast: false
+      matrix:
+        build:
           - RL8
           - RL9
-        build:
-          - openstack.openhpc
-          - openstack.openhpc-cuda
-        exclude:
-          - os_version: RL8
-            build: openstack.openhpc-cuda
+          - RL9-cuda
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
-      CI_CLOUD: ${{ github.event.inputs.ci_cloud }}
-      SOURCE_IMAGES_MAP: |
-        {
-          "RL8": {
-            "openstack.openhpc": "rocky-latest-RL8",
-            "openstack.openhpc-cuda": "rocky-latest-cuda-RL8"
-          },
-          "RL9": {
-            "openstack.openhpc": "rocky-latest-RL9",
-            "openstack.openhpc-cuda": "rocky-latest-cuda-RL9"
-          }
-        }
-
+      CI_CLOUD: ${{ vars.CI_CLOUD }}
+      IMAGE_PATH: environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
     steps:
       - uses: actions/checkout@v2
 
-      - name: Record settings for CI cloud
+      - name: Record which cloud CI is running on
         run: |
           echo CI_CLOUD: ${{ env.CI_CLOUD }}
 
-      - name: Setup ssh
+      - name: setup environment
         run: |
-          set -x
-          mkdir ~/.ssh
-          echo "${{ secrets[format('{0}_SSH_KEY', env.CI_CLOUD)] }}" > ~/.ssh/id_rsa
-          chmod 0600 ~/.ssh/id_rsa
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install -U pip
+          pip install $(grep -o 'python-openstackclient[><=0-9\.]*' requirements.txt)
         shell: bash
-
-      - name: Add bastion's ssh key to known_hosts
-        run: cat environments/.stackhpc/bastion_fingerprints >> ~/.ssh/known_hosts
-        shell: bash
-
-      - name: Install ansible etc
-        run: dev/setup-env.sh
 
       - name: Write clouds.yaml
         run: |
@@ -74,47 +44,111 @@ jobs:
           echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
         shell: bash
 
-      - name: Setup environment
+      - name: Write s3cmd configuration
+        run: |
+          echo "${{ secrets['ARCUS_S3CFG'] }}" > ~/.s3cfg
+        shell: bash
+
+      - name: Install s3cmd
+        run: |
+          sudo apt-get --yes install s3cmd
+
+      - name: Check for image in Arcus S3 bucket
+        id: s3_ls
+        run: |
+
+          TARGET_IMAGE=$(jq --arg version "${{ matrix.build }}" -r '.cluster_image[$version]' "${{ env.IMAGE_PATH }}")
+          echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
+          echo "target-image-${{ matrix.build }}=${TARGET_IMAGE}" >> "$GITHUB_OUTPUT"
+
+          S3_IMAGES=$(s3cmd ls s3://openhpc-images)
+          
+          if echo "$S3_IMAGES" | grep -q "$TARGET_IMAGE"; then
+            echo "Image ${TARGET_IMAGE} is already present in S3."
+            echo "IMAGE_EXISTS=true" >> $GITHUB_ENV
+          else
+            echo "Image ${TARGET_IMAGE} is not present in S3."
+            echo "IMAGE_EXISTS=false" >> $GITHUB_ENV
+          fi
+        shell: bash
+
+      - name: Download image to runner
+        if: env.IMAGE_EXISTS == 'false'
         run: |
           . venv/bin/activate
-          . environments/.stackhpc/activate
+          openstack image save --file ${{ env.TARGET_IMAGE }} ${{ env.TARGET_IMAGE }}
+        shell: bash
 
-      - name: Build fat image with packer
-        id: packer_build
+      - name: Conditionally Upload Image to S3
+        if: env.IMAGE_EXISTS == 'false'
         run: |
-          set -x
+          echo "Uploading Image: ${{ env.TARGET_IMAGE }} to S3..."
+          s3cmd put ${{ env.TARGET_IMAGE }}.qcow2 s3://openhpc-images
+        shell: bash
+
+  image_sync:
+    needs: image_upload
+    runs-on: ubuntu-22.04
+    concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.cloud }}-${{ matrix.build }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cloud:
+          - LEAFCLOUD
+          - SMS
+          - ARCUS
+        build:
+          - RL8
+          - RL9
+          - RL9-cuda
+        exclude: 
+          - cloud: LEAFCLOUD
+
+    env:
+      ANSIBLE_FORCE_COLOR: True
+      OS_CLOUD: openstack
+      CI_CLOUD: ${{ matrix.cloud }}
+      IMAGE_PATH: environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Record which cloud CI is running on
+        run: |
+          echo CI_CLOUD: ${{ env.CI_CLOUD }}
+
+      - name: setup environment
+        run: |
+          python3 -m venv venv
           . venv/bin/activate
-          . environments/.stackhpc/activate
-          cd packer/
-          packer init .
+          pip install -U pip
+          pip install $(grep -o 'python-openstackclient[><=0-9\.]*' requirements.txt)
+        shell: bash
 
-          PACKER_LOG=1 packer build \
-          -on-error=${{ vars.PACKER_ON_ERROR }} \
-          -only=${{ matrix.build }} \
-          -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
-          -var "source_image_name=${{ env.SOURCE_IMAGE }}" \
-          openstack.pkr.hcl
-        env:
-          PKR_VAR_os_version: ${{ matrix.os_version }}
-          SOURCE_IMAGE: ${{ fromJSON(env.SOURCE_IMAGES_MAP)[matrix.os_version][matrix.build] }}
+      - name: Write clouds.yaml
+        run: |
+          mkdir -p ~/.config/openstack/
+          echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
+        shell: bash
 
-      - name: Get created image names from manifest
-        id: manifest
+      - name: Retrieve image name
+        run: |
+          TARGET_IMAGE=$(jq --arg version "${{ matrix.build }}" -r '.cluster_image[$version]' "${{ env.IMAGE_PATH }}")
+          echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Upload latest image if missing
         run: |
           . venv/bin/activate
-          IMAGE_ID=$(jq --raw-output '.builds[-1].artifact_id' packer/packer-manifest.json)
-          while ! openstack image show -f value -c name $IMAGE_ID; do
-            sleep 5
-          done
-          IMAGE_NAME=$(openstack image show -f value -c name $IMAGE_ID)
-          echo $IMAGE_ID > image-id.txt
-          echo $IMAGE_NAME > image-name.txt
+          bash .github/bin/get-s3-image.sh ${{ env.TARGET_IMAGE }} openhpc-images
 
-      - name: Upload manifest artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: image-details-${{ matrix.build }}-${{ matrix.os_version }}
-          path: |
-            ./image-id.txt
-            ./image-name.txt
-          overwrite: true
+      - name: Cleanup OpenStack Image (on error or cancellation)
+        if: cancelled()
+        run: |
+          . venv/bin/activate
+          image_hanging=$(openstack image list --name ${{ env.TARGET_IMAGE }} -f value -c ID -c Status | grep -v ' active$' | awk '{print $1}')
+          if [ -n "$image_hanging" ]; then
+            echo "Cleaning up OpenStack image with ID: $image_hanging"
+            openstack image delete $image_hanging
+          else
+            echo "No image ID found, skipping cleanup."
+          fi
+        shell: bash

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -6,10 +6,35 @@ on:
       - main
     paths:
       - 'environments/.stackhpc/terraform/cluster_image.auto.tfvars.json'
+env:
+  S3_BUCKET: openhpc-images-prerelease
+  IMAGE_PATH: environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
 
 jobs:
+  s3_cleanup:
+    runs-on: ubuntu-22.04
+    concurrency: ${{ github.workflow }}-${{ github.ref }}
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Write s3cmd configuration
+        run: |
+          echo "${{ secrets['ARCUS_S3_CFG'] }}" > ~/.s3cfg
+        shell: bash
+
+      - name: Install s3cmd
+        run: |
+          sudo apt-get --yes install s3cmd
+      
+      - name: Cleanup S3 bucket
+        run: |
+          s3cmd rm s3://${{ env.S3_BUCKET }} --recursive --force
+
   image_upload:
     runs-on: ubuntu-22.04
+    needs: s3_cleanup
     concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build }}
     strategy:
       fail-fast: false
@@ -22,7 +47,6 @@ jobs:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
       CI_CLOUD: ${{ vars.CI_CLOUD }}
-      IMAGE_PATH: environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
     steps:
       - uses: actions/checkout@v2
 
@@ -53,37 +77,22 @@ jobs:
         run: |
           sudo apt-get --yes install s3cmd
 
-      - name: Check for image in Arcus S3 bucket
-        id: s3_ls
+      - name: Retrieve image name
         run: |
-          . venv/bin/activate
           TARGET_IMAGE=$(jq --arg version "${{ matrix.build }}" -r '.cluster_image[$version]' "${{ env.IMAGE_PATH }}")
           echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
-          echo "target-image-${{ matrix.build }}=${TARGET_IMAGE}" >> "$GITHUB_OUTPUT"
-
-          S3_IMAGES=$(s3cmd ls s3://openhpc-images-prerelease)
-
-          if echo "$S3_IMAGES" | grep -q "$TARGET_IMAGE"; then
-            echo "Image ${TARGET_IMAGE} is already present in S3."
-            echo "IMAGE_EXISTS=true" >> $GITHUB_ENV
-          else
-            echo "Image ${TARGET_IMAGE} is not present in S3."
-            echo "IMAGE_EXISTS=false" >> $GITHUB_ENV
-          fi
         shell: bash
 
       - name: Download image to runner
-        if: env.IMAGE_EXISTS == 'false'
         run: |
           . venv/bin/activate
           openstack image save --file ${{ env.TARGET_IMAGE }} ${{ env.TARGET_IMAGE }}
         shell: bash
 
-      - name: Conditionally Upload Image to S3
-        if: env.IMAGE_EXISTS == 'false'
+      - name: Upload Image to S3
         run: |
           echo "Uploading Image: ${{ env.TARGET_IMAGE }} to S3..."
-          s3cmd --multipart-chunk-size-mb=300 put ${{ env.TARGET_IMAGE }} s3://openhpc-images-prerelease
+          s3cmd --multipart-chunk-size-mb=150 put ${{ env.TARGET_IMAGE }} s3://${{ env.S3_BUCKET }}
         shell: bash
 
   image_sync:
@@ -108,7 +117,6 @@ jobs:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
       CI_CLOUD: ${{ matrix.cloud }}
-      IMAGE_PATH: environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
     steps:
       - uses: actions/checkout@v2
 
@@ -138,7 +146,7 @@ jobs:
       - name: Download latest image if missing
         run: |
           . venv/bin/activate
-          bash .github/bin/get-s3-image.sh ${{ env.TARGET_IMAGE }} openhpc-images-prerelease
+          bash .github/bin/get-s3-image.sh ${{ env.TARGET_IMAGE }} ${{ env.S3_BUCKET }}
 
       - name: Cleanup OpenStack Image (on error or cancellation)
         if: cancelled()

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -44,42 +44,9 @@ jobs:
           echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
         shell: bash
 
-      - name: Create EC2 credentials if not present
-        id: check_creds
-        run: |
-          . venv/bin/activate
-          # List existing EC2 credentials
-          existing_creds=$(openstack ec2 credentials list --format json)
-
-          # Check if the list is empty
-          if [ "$(echo "$existing_creds" | jq 'length')" -eq 0 ]; then
-            echo "No existing EC2 credentials found."
-            new_creds=$(openstack ec2 credentials create --format json)
-            access_key=$(echo "$new_creds" | jq -r '.Access')
-            secret_key=$(echo "$new_creds" | jq -r '.Secret')
-            echo "Created new EC2 credentials."
-          else
-            echo "Existing EC2 credentials found."
-            access_key=$(echo "$existing_creds" | jq -r '.[0].Access')
-            secret_key=$(echo "$existing_creds" | jq -r '.[0].Secret')
-          fi
-
-          # Save access and secret keys for the next step
-          echo "access_key=${access_key}" >> $GITHUB_ENV
-          echo "secret_key=${secret_key}" >> $GITHUB_ENV
-        shell: bash
-
       - name: Write s3cmd configuration
         run: |
-          cat <<EOF > ~/.s3cfg
-          [default]
-          host_base = https://object.arcus.openstack.hpc.cam.ac.uk
-          host_bucket = https://object.arcus.openstack.hpc.cam.ac.uk
-          access_key = ${{ env.access_key }}
-          secret_key = ${{ env.secret_key }}
-          use_https = True
-          signurl_use_https = True
-          EOF
+          echo "${{ secrets['ARCUS_S3_CFG'] }}" > ~/.s3cfg
         shell: bash
 
       - name: Install s3cmd
@@ -94,8 +61,8 @@ jobs:
           echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
           echo "target-image-${{ matrix.build }}=${TARGET_IMAGE}" >> "$GITHUB_OUTPUT"
 
-          S3_IMAGES=$(s3cmd ls s3://openhpc-images)
-          
+          S3_IMAGES=$(s3cmd ls s3://openhpc-images-prerelease)
+
           if echo "$S3_IMAGES" | grep -q "$TARGET_IMAGE"; then
             echo "Image ${TARGET_IMAGE} is already present in S3."
             echo "IMAGE_EXISTS=true" >> $GITHUB_ENV
@@ -116,7 +83,7 @@ jobs:
         if: env.IMAGE_EXISTS == 'false'
         run: |
           echo "Uploading Image: ${{ env.TARGET_IMAGE }} to S3..."
-          s3cmd put ${{ env.TARGET_IMAGE }}.qcow2 s3://openhpc-images
+          s3cmd put ${{ env.TARGET_IMAGE }}.qcow2 s3://openhpc-images-prerelease
         shell: bash
 
   image_sync:
@@ -168,10 +135,10 @@ jobs:
           TARGET_IMAGE=$(jq --arg version "${{ matrix.build }}" -r '.cluster_image[$version]' "${{ env.IMAGE_PATH }}")
           echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
 
-      - name: Upload latest image if missing
+      - name: Download latest image if missing
         run: |
           . venv/bin/activate
-          bash .github/bin/get-s3-image.sh ${{ env.TARGET_IMAGE }} openhpc-images
+          bash .github/bin/get-s3-image.sh ${{ env.TARGET_IMAGE }} openhpc-images-prerelease
 
       - name: Cleanup OpenStack Image (on error or cancellation)
         if: cancelled()

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -46,7 +46,9 @@ jobs:
 
       - name: Write s3cmd configuration
         run: |
-          echo "${{ secrets['ARCUS_S3CFG'] }}" > ~/.s3cfg
+          . venv/bin/activate
+          S3_CREDS=$(openstack ec2 credentials create)
+          echo "$S3_CREDS" > ~/.s3cfg
         shell: bash
 
       - name: Install s3cmd
@@ -56,7 +58,7 @@ jobs:
       - name: Check for image in Arcus S3 bucket
         id: s3_ls
         run: |
-
+          . venv/bin/activate
           TARGET_IMAGE=$(jq --arg version "${{ matrix.build }}" -r '.cluster_image[$version]' "${{ env.IMAGE_PATH }}")
           echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
           echo "target-image-${{ matrix.build }}=${TARGET_IMAGE}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -44,11 +44,42 @@ jobs:
           echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
         shell: bash
 
-      - name: Write s3cmd configuration
+      - name: Create EC2 credentials if not present
+        id: check_creds
         run: |
           . venv/bin/activate
-          S3_CREDS=$(openstack ec2 credentials create)
-          echo "$S3_CREDS" > ~/.s3cfg
+          # List existing EC2 credentials
+          existing_creds=$(openstack ec2 credentials list --format json)
+
+          # Check if the list is empty
+          if [ "$(echo "$existing_creds" | jq 'length')" -eq 0 ]; then
+            echo "No existing EC2 credentials found."
+            new_creds=$(openstack ec2 credentials create --format json)
+            access_key=$(echo "$new_creds" | jq -r '.Access')
+            secret_key=$(echo "$new_creds" | jq -r '.Secret')
+            echo "Created new EC2 credentials."
+          else
+            echo "Existing EC2 credentials found."
+            access_key=$(echo "$existing_creds" | jq -r '.[0].Access')
+            secret_key=$(echo "$existing_creds" | jq -r '.[0].Secret')
+          fi
+
+          # Save access and secret keys for the next step
+          echo "access_key=${access_key}" >> $GITHUB_ENV
+          echo "secret_key=${secret_key}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Write s3cmd configuration
+        run: |
+          cat <<EOF > ~/.s3cfg
+          [default]
+          host_base = https://object.arcus.openstack.hpc.cam.ac.uk
+          host_bucket = https://object.arcus.openstack.hpc.cam.ac.uk
+          access_key = ${{ env.access_key }}
+          secret_key = ${{ env.secret_key }}
+          use_https = True
+          signurl_use_https = True
+          EOF
         shell: bash
 
       - name: Install s3cmd

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -83,7 +83,7 @@ jobs:
         if: env.IMAGE_EXISTS == 'false'
         run: |
           echo "Uploading Image: ${{ env.TARGET_IMAGE }} to S3..."
-          s3cmd put ${{ env.TARGET_IMAGE }}.qcow2 s3://openhpc-images-prerelease
+          s3cmd --multipart-chunk-size-mb=300 put ${{ env.TARGET_IMAGE }} s3://openhpc-images-prerelease
         shell: bash
 
   image_sync:

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -1,66 +1,72 @@
-name: Upload CI-tested images to Arcus S3 and sync clouds
+name: Build fat image
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'environments/.stackhpc/terraform/cluster_image.auto.tfvars.json'
-env:
-  S3_BUCKET: openhpc-images-prerelease
-  IMAGE_PATH: environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+      inputs:
+        ci_cloud:
+          description: 'Select the CI_CLOUD'
+          required: true
+          type: choice
+          options:
+            - LEAFCLOUD
+            - SMS
+            - ARCUS
 
 jobs:
-  s3_cleanup:
+  openstack:
+    name: openstack-imagebuild
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os_version }}-${{ matrix.build }} # to branch/PR + OS + build
+      cancel-in-progress: true
     runs-on: ubuntu-22.04
-    concurrency: ${{ github.workflow }}-${{ github.ref }}
     strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Write s3cmd configuration
-        run: |
-          echo "${{ secrets['ARCUS_S3_CFG'] }}" > ~/.s3cfg
-        shell: bash
-
-      - name: Install s3cmd
-        run: |
-          sudo apt-get --yes install s3cmd
-      
-      - name: Cleanup S3 bucket
-        run: |
-          s3cmd rm s3://${{ env.S3_BUCKET }} --recursive --force
-
-  image_upload:
-    runs-on: ubuntu-22.04
-    needs: s3_cleanup
-    concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build }}
-    strategy:
-      fail-fast: false
-      matrix:
-        build:
+      fail-fast: false # allow other matrix jobs to continue even if one fails
+      matrix: # build RL8+OFED, RL9+OFED, RL9+OFED+CUDA versions
+        os_version:
           - RL8
           - RL9
-          - RL9-cuda
+        build:
+          - openstack.openhpc
+          - openstack.openhpc-cuda
+        exclude:
+          - os_version: RL8
+            build: openstack.openhpc-cuda
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
-      CI_CLOUD: ${{ vars.CI_CLOUD }}
+      CI_CLOUD: ${{ github.event.inputs.ci_cloud }}
+      SOURCE_IMAGES_MAP: |
+        {
+          "RL8": {
+            "openstack.openhpc": "rocky-latest-RL8",
+            "openstack.openhpc-cuda": "rocky-latest-cuda-RL8"
+          },
+          "RL9": {
+            "openstack.openhpc": "rocky-latest-RL9",
+            "openstack.openhpc-cuda": "rocky-latest-cuda-RL9"
+          }
+        }
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: Record which cloud CI is running on
+      - name: Record settings for CI cloud
         run: |
           echo CI_CLOUD: ${{ env.CI_CLOUD }}
 
-      - name: setup environment
+      - name: Setup ssh
         run: |
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install -U pip
-          pip install $(grep -o 'python-openstackclient[><=0-9\.]*' requirements.txt)
+          set -x
+          mkdir ~/.ssh
+          echo "${{ secrets[format('{0}_SSH_KEY', env.CI_CLOUD)] }}" > ~/.ssh/id_rsa
+          chmod 0600 ~/.ssh/id_rsa
         shell: bash
+
+      - name: Add bastion's ssh key to known_hosts
+        run: cat environments/.stackhpc/bastion_fingerprints >> ~/.ssh/known_hosts
+        shell: bash
+
+      - name: Install ansible etc
+        run: dev/setup-env.sh
 
       - name: Write clouds.yaml
         run: |
@@ -68,95 +74,47 @@ jobs:
           echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
         shell: bash
 
-      - name: Write s3cmd configuration
-        run: |
-          echo "${{ secrets['ARCUS_S3_CFG'] }}" > ~/.s3cfg
-        shell: bash
-
-      - name: Install s3cmd
-        run: |
-          sudo apt-get --yes install s3cmd
-
-      - name: Retrieve image name
-        run: |
-          TARGET_IMAGE=$(jq --arg version "${{ matrix.build }}" -r '.cluster_image[$version]' "${{ env.IMAGE_PATH }}")
-          echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Download image to runner
+      - name: Setup environment
         run: |
           . venv/bin/activate
-          openstack image save --file ${{ env.TARGET_IMAGE }} ${{ env.TARGET_IMAGE }}
-        shell: bash
+          . environments/.stackhpc/activate
 
-      - name: Upload Image to S3
+      - name: Build fat image with packer
+        id: packer_build
         run: |
-          echo "Uploading Image: ${{ env.TARGET_IMAGE }} to S3..."
-          s3cmd --multipart-chunk-size-mb=150 put ${{ env.TARGET_IMAGE }} s3://${{ env.S3_BUCKET }}
-        shell: bash
-
-  image_sync:
-    needs: image_upload
-    runs-on: ubuntu-22.04
-    concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.cloud }}-${{ matrix.build }}
-    strategy:
-      fail-fast: false
-      matrix:
-        cloud:
-          - LEAFCLOUD
-          - SMS
-          - ARCUS
-        build:
-          - RL8
-          - RL9
-          - RL9-cuda
-        exclude: 
-          - cloud: LEAFCLOUD
-
-    env:
-      ANSIBLE_FORCE_COLOR: True
-      OS_CLOUD: openstack
-      CI_CLOUD: ${{ matrix.cloud }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Record which cloud CI is running on
-        run: |
-          echo CI_CLOUD: ${{ env.CI_CLOUD }}
-
-      - name: setup environment
-        run: |
-          python3 -m venv venv
+          set -x
           . venv/bin/activate
-          pip install -U pip
-          pip install $(grep -o 'python-openstackclient[><=0-9\.]*' requirements.txt)
-        shell: bash
+          . environments/.stackhpc/activate
+          cd packer/
+          packer init .
 
-      - name: Write clouds.yaml
-        run: |
-          mkdir -p ~/.config/openstack/
-          echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
-        shell: bash
+          PACKER_LOG=1 packer build \
+          -on-error=${{ vars.PACKER_ON_ERROR }} \
+          -only=${{ matrix.build }} \
+          -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
+          -var "source_image_name=${{ env.SOURCE_IMAGE }}" \
+          openstack.pkr.hcl
+        env:
+          PKR_VAR_os_version: ${{ matrix.os_version }}
+          SOURCE_IMAGE: ${{ fromJSON(env.SOURCE_IMAGES_MAP)[matrix.os_version][matrix.build] }}
 
-      - name: Retrieve image name
-        run: |
-          TARGET_IMAGE=$(jq --arg version "${{ matrix.build }}" -r '.cluster_image[$version]' "${{ env.IMAGE_PATH }}")
-          echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
-
-      - name: Download latest image if missing
+      - name: Get created image names from manifest
+        id: manifest
         run: |
           . venv/bin/activate
-          bash .github/bin/get-s3-image.sh ${{ env.TARGET_IMAGE }} ${{ env.S3_BUCKET }}
+          IMAGE_ID=$(jq --raw-output '.builds[-1].artifact_id' packer/packer-manifest.json)
+          while ! openstack image show -f value -c name $IMAGE_ID; do
+            sleep 5
+          done
+          IMAGE_NAME=$(openstack image show -f value -c name $IMAGE_ID)
+          echo $IMAGE_ID > image-id.txt
+          echo $IMAGE_NAME > image-name.txt
 
-      - name: Cleanup OpenStack Image (on error or cancellation)
-        if: cancelled()
-        run: |
-          . venv/bin/activate
-          image_hanging=$(openstack image list --name ${{ env.TARGET_IMAGE }} -f value -c ID -c Status | grep -v ' active$' | awk '{print $1}')
-          if [ -n "$image_hanging" ]; then
-            echo "Cleaning up OpenStack image with ID: $image_hanging"
-            openstack image delete $image_hanging
-          else
-            echo "No image ID found, skipping cleanup."
-          fi
-        shell: bash
+      - name: Upload manifest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-details-${{ matrix.build }}-${{ matrix.os_version }}
+          path: |
+            ./image-id.txt
+            ./image-name.txt
+          overwrite: true

--- a/.github/workflows/s3-image-sync.yml
+++ b/.github/workflows/s3-image-sync.yml
@@ -1,0 +1,162 @@
+name: Upload CI-tested images to Arcus S3 and sync clouds
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'environments/.stackhpc/terraform/cluster_image.auto.tfvars.json'
+env:
+  S3_BUCKET: openhpc-images-prerelease
+  IMAGE_PATH: environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+
+jobs:
+  s3_cleanup:
+    runs-on: ubuntu-22.04
+    concurrency: ${{ github.workflow }}-${{ github.ref }}
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Write s3cmd configuration
+        run: |
+          echo "${{ secrets['ARCUS_S3_CFG'] }}" > ~/.s3cfg
+        shell: bash
+
+      - name: Install s3cmd
+        run: |
+          sudo apt-get --yes install s3cmd
+      
+      - name: Cleanup S3 bucket
+        run: |
+          s3cmd rm s3://${{ env.S3_BUCKET }} --recursive --force
+
+  image_upload:
+    runs-on: ubuntu-22.04
+    needs: s3_cleanup
+    concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          - RL8
+          - RL9
+          - RL9-cuda
+    env:
+      ANSIBLE_FORCE_COLOR: True
+      OS_CLOUD: openstack
+      CI_CLOUD: ${{ vars.CI_CLOUD }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Record which cloud CI is running on
+        run: |
+          echo CI_CLOUD: ${{ env.CI_CLOUD }}
+
+      - name: setup environment
+        run: |
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install -U pip
+          pip install $(grep -o 'python-openstackclient[><=0-9\.]*' requirements.txt)
+        shell: bash
+
+      - name: Write clouds.yaml
+        run: |
+          mkdir -p ~/.config/openstack/
+          echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
+        shell: bash
+
+      - name: Write s3cmd configuration
+        run: |
+          echo "${{ secrets['ARCUS_S3_CFG'] }}" > ~/.s3cfg
+        shell: bash
+
+      - name: Install s3cmd
+        run: |
+          sudo apt-get --yes install s3cmd
+
+      - name: Retrieve image name
+        run: |
+          TARGET_IMAGE=$(jq --arg version "${{ matrix.build }}" -r '.cluster_image[$version]' "${{ env.IMAGE_PATH }}")
+          echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Download image to runner
+        run: |
+          . venv/bin/activate
+          openstack image save --file ${{ env.TARGET_IMAGE }} ${{ env.TARGET_IMAGE }}
+        shell: bash
+
+      - name: Upload Image to S3
+        run: |
+          echo "Uploading Image: ${{ env.TARGET_IMAGE }} to S3..."
+          s3cmd --multipart-chunk-size-mb=150 put ${{ env.TARGET_IMAGE }} s3://${{ env.S3_BUCKET }}
+        shell: bash
+
+  image_sync:
+    needs: image_upload
+    runs-on: ubuntu-22.04
+    concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.cloud }}-${{ matrix.build }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cloud:
+          - LEAFCLOUD
+          - SMS
+          - ARCUS
+        build:
+          - RL8
+          - RL9
+          - RL9-cuda
+        exclude: 
+          - cloud: LEAFCLOUD
+
+    env:
+      ANSIBLE_FORCE_COLOR: True
+      OS_CLOUD: openstack
+      CI_CLOUD: ${{ matrix.cloud }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Record which cloud CI is running on
+        run: |
+          echo CI_CLOUD: ${{ env.CI_CLOUD }}
+
+      - name: setup environment
+        run: |
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install -U pip
+          pip install $(grep -o 'python-openstackclient[><=0-9\.]*' requirements.txt)
+        shell: bash
+
+      - name: Write clouds.yaml
+        run: |
+          mkdir -p ~/.config/openstack/
+          echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
+        shell: bash
+
+      - name: Retrieve image name
+        run: |
+          TARGET_IMAGE=$(jq --arg version "${{ matrix.build }}" -r '.cluster_image[$version]' "${{ env.IMAGE_PATH }}")
+          echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Download latest image if missing
+        run: |
+          . venv/bin/activate
+          bash .github/bin/get-s3-image.sh ${{ env.TARGET_IMAGE }} ${{ env.S3_BUCKET }}
+
+      - name: Cleanup OpenStack Image (on error or cancellation)
+        if: cancelled()
+        run: |
+          . venv/bin/activate
+          image_hanging=$(openstack image list --name ${{ env.TARGET_IMAGE }} -f value -c ID -c Status | grep -v ' active$' | awk '{print $1}')
+          if [ -n "$image_hanging" ]; then
+            echo "Cleaning up OpenStack image with ID: $image_hanging"
+            openstack image delete $image_hanging
+          else
+            echo "No image ID found, skipping cleanup."
+          fi
+        shell: bash

--- a/.github/workflows/s3-image-sync.yml
+++ b/.github/workflows/s3-image-sync.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           echo CI_CLOUD: ${{ env.CI_CLOUD }}
 
-      - name: setup environment
+      - name: Setup environment
         run: |
           python3 -m venv venv
           . venv/bin/activate
@@ -124,7 +124,7 @@ jobs:
         run: |
           echo CI_CLOUD: ${{ env.CI_CLOUD }}
 
-      - name: setup environment
+      - name: Setup environment
         run: |
           python3 -m venv venv
           . venv/bin/activate
@@ -149,7 +149,7 @@ jobs:
           bash .github/bin/get-s3-image.sh ${{ env.TARGET_IMAGE }} ${{ env.S3_BUCKET }}
 
       - name: Cleanup OpenStack Image (on error or cancellation)
-        if: cancelled()
+        if: cancelled() || failure()
         run: |
           . venv/bin/activate
           image_hanging=$(openstack image list --name ${{ env.TARGET_IMAGE }} -f value -c ID -c Status | grep -v ' active$' | awk '{print $1}')

--- a/.github/workflows/s3-image-sync.yml
+++ b/.github/workflows/s3-image-sync.yml
@@ -47,12 +47,15 @@ jobs:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
       CI_CLOUD: ${{ vars.CI_CLOUD }}
+    outputs:
+      ci_cloud: ${{ steps.ci.outputs.CI_CLOUD }}
     steps:
       - uses: actions/checkout@v2
 
       - name: Record which cloud CI is running on
+        id: ci
         run: |
-          echo CI_CLOUD: ${{ env.CI_CLOUD }}
+          echo "CI_CLOUD=${{ env.CI_CLOUD }}" >> "$GITHUB_OUTPUT"
 
       - name: Setup environment
         run: |
@@ -111,7 +114,7 @@ jobs:
           - RL9
           - RL9-cuda
         exclude: 
-          - cloud: LEAFCLOUD
+          - cloud: ${{ needs.image_upload.outputs.ci_cloud }}
 
     env:
       ANSIBLE_FORCE_COLOR: True

--- a/.github/workflows/upload-release-image.yml.sample
+++ b/.github/workflows/upload-release-image.yml.sample
@@ -53,7 +53,7 @@ jobs:
           bash .github/bin/get-s3-image.sh ${{ inputs.image_name }} ${{ inputs.bucket_name }}
 
       - name: Cleanup OpenStack Image (on error or cancellation)
-        if: cancelled()
+        if: cancelled() || failure()
         run: |
           . venv/bin/activate
           image_hanging=$(openstack image list --name ${{ inputs.image_name }} -f value -c ID -c Status | grep -v ' active$' | awk '{print $1}')


### PR DESCRIPTION
1st job cleans all images in Arcus S3 openhpc-images-prerelease bucket

2nd job uploads main branch fatimage to Arcus S3 openhpc-images-prerelease bucket when bumped.

3rd job retrieves image from S3 and saves to remianing ci cloud openstacks.