### PR TITLE
Allow creating tofu-controlled compute volumes

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute.tf
@@ -14,6 +14,8 @@ module "compute" {
   vnic_type = lookup(each.value, "vnic_type", var.vnic_type)
   vnic_profile = lookup(each.value, "vnic_profile", var.vnic_profile)
   key_pair = var.key_pair
+  volumes = lookup(each.value, "volumes", {})
+
   environment_root = var.environment_root
   k3s_token = var.k3s_token
   control_address = [for n in openstack_compute_instance_v2.control["control"].network: n.fixed_ip_v4 if n.access_network][0]

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/nodes.tf
@@ -1,3 +1,25 @@
+locals {
+  all_compute_volumes = {for v in setproduct(var.nodes, keys(var.volumes)): "${v[0]}-${v[1]}" => {"node" = v[0], "volume" = v[1]}}
+  # e.g. with
+  # var.nodes = ["compute-0", "compute-1"]
+  # var.volumes = {
+  #     "vol-a" = {size = 10},
+  #     "vol-b" = {size = 20}
+  # }
+  # this is a mapping with
+  # keys "compute-0-vol-a", "compute-0-vol-b" ...
+  # values which are a mapping e.g. {"node"="compute-0", "volume"="vol-a"}
+}
+
+resource "openstack_blockstorage_volume_v3" "compute" {
+    
+    for_each = local.all_compute_volumes
+
+    name = "${var.cluster_name}-${each.key}"
+    description = "Compute node ${each.value.node} volume ${each.value.volume}"
+    size = var.volumes[each.value.volume].size
+}
+
 resource "openstack_networking_port_v2" "compute" {
 
   for_each = toset(var.nodes)
@@ -27,15 +49,24 @@ resource "openstack_compute_instance_v2" "compute" {
   flavor_name = var.flavor
   key_pair = var.key_pair
 
+  # root device:
+  block_device {
+    uuid = var.image_id
+    source_type  = "image"
+    destination_type = var.volume_backed_instances ? "volume" : "local"
+    volume_size = var.volume_backed_instances ? var.root_volume_size : null
+    boot_index = 0
+    delete_on_termination = true
+  }
+  
+  # additional volumes:
   dynamic "block_device" {
-    for_each = var.volume_backed_instances ? [1]: []
+    for_each = var.volumes
     content {
-      uuid = var.image_id
-      source_type  = "image"
       destination_type = "volume"
-      volume_size = var.root_volume_size
-      boot_index = 0
-      delete_on_termination = true
+      source_type  = "volume"
+      boot_index = -1
+      uuid = openstack_blockstorage_volume_v3.compute["${each.key}-${block_device.key}"].id
     }
   }
   

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/variables.tf
@@ -64,6 +64,17 @@ variable "root_volume_size" {
     default = 40
 }
 
+variable "volumes" {
+    description = <<-EOF
+        Mapping defining volumes to create and attach.
+        Keys are unique volume name.
+        Values are a mapping with:
+            size: Size of volume in GB
+        EOF
+    type = any
+    default = {}
+}
+
 variable "security_group_ids" {
     type = list
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
@@ -52,6 +52,10 @@ variable "compute" {
             image_id: Overrides variable cluster_image_id
             vnic_type: Overrides variable vnic_type
             vnic_profile: Overrides variable vnic_profile
+            volumes: Mapping defining volumes to create and attach to compute nodes.
+                     Keys are a unique volume name.
+                     Values are a mapping containing:
+                        size: Size of volume in GB
     EOF
 }
 


### PR DESCRIPTION
Adds a "volumes" property to the `compute` terraform variable which defines optional OpenTofu-controlled volumes attached to compute nodes. Useful for simulating additional disks present in baremetal instances using virtualized instances.

Note that:
- Unlike the default `home` and `state` volumes` attached to the control node, compute volumes defined this way are not automatically formatted or mounted.
- Volumes are attached after instance creation and the path under `/dev/{v,s}d*` is likely to change across reboots. Use e.g. `/dev/disk/by-path/` for mounts etc.