### PR TITLE
Ensure podman copes with a hard reboot

### DIFF
--- a/ansible/roles/podman/defaults/main.yml
+++ b/ansible/roles/podman/defaults/main.yml
@@ -1,3 +1,2 @@
 podman_users:
   - name: "{{ ansible_user }}"
-podman_tmp_dir_root: /run # MUST be on a tmpfs

--- a/ansible/roles/podman/tasks/config.yml
+++ b/ansible/roles/podman/tasks/config.yml
@@ -44,3 +44,19 @@
   with_items: "{{ podman_users }}"
   register: podman_user_info
   become: yes
+
+- name: Clear up podman temporary files on startup
+  copy:
+    content: |
+      # Created by ansible
+      # Delete ephemeral podman files to avoid issues where /tmp is not of type tmpfs and persists across reboots.
+      # See tmpfiles.d(5) man page, note "R" specifies recursive removal and "!" marks as happening only on boot.
+      #
+      # Type Path Mode User Group Age Argument
+      R! /tmp/containers-user-*
+      R! /tmp/podman-run-*
+    dest: /etc/tmpfiles.d/podman-local.conf
+    owner: root
+    group: root
+    mode: 0660
+  become: true

--- a/ansible/roles/podman/tasks/validate.yml
+++ b/ansible/roles/podman/tasks/validate.yml
@@ -1,9 +1,0 @@
-- name: Get tmp directory filesystem type
-  command: stat -f -c %T {{ podman_tmp_dir_root }}
-  register: podman_tmp_fstype
-  changed_when: false
-    
-- name: Check tmp directory is on tmpfs
-  assert:
-    that: podman_tmp_fstype.stdout == 'tmpfs'
-    fail_msg: "{{ podman_tmp_fstype }} (variable podman_tmp_fstype) must be on tmpfs"

--- a/ansible/validate.yml
+++ b/ansible/validate.yml
@@ -29,16 +29,6 @@
           'enable_configless' not found in openhpc_config.SlurmctldParameters - is variable openhpc_config overridden?
           Additional slurm.conf parameters should be provided using variable openhpc_config_extra.
         success_msg: Checked Slurm will be configured for configless operation
-    
-- name: Validate podman configuration
-  hosts: podman
-  gather_facts: false
-  tags: podman
-  tasks:
-    - import_role:
-        name: podman
-        tasks_from: validate.yml
-      tags: validate
 
 - name: Validate filebeat configuration
   hosts: filebeat


### PR DESCRIPTION
This PR fixes podman containers failing to start after a hard reboot, with an error "invalid internal status" in the journal for the unit.

Note that originally the podman role ensured the podman temporary directories were on a tmpfs; this appeared to be problematic with later podman and  #351 removed this.

Fixes #459.