### PR TITLE
Add blackbox exporter to k3s monitoring stack with probe for OOD

### DIFF
--- a/ansible/roles/kube_prometheus_stack/defaults/main/install.yml
+++ b/ansible/roles/kube_prometheus_stack/defaults/main/install.yml
@@ -9,3 +9,4 @@ image_list:
 - { name: "quay.io/kiwigrid/k8s-sidecar", tag: "{{ grafana_sidecar_image_tag }}" }
 - { name: "registry.k8s.io/kube-state-metrics/kube-state-metrics", tag: "{{ kube_prometheus_stack_metrics_image_tag }}" }
 - { name: "registry.k8s.io/ingress-nginx/kube-webhook-certgen", tag: "{{ kube_prometheus_stack_patch_image_tag }}" }
+- { name: "quay.io/prometheus/blackbox-exporter", tag: "{{ kube_prometheus_stack_blackbox_exporter_image_tag }}" }

--- a/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
+++ b/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
@@ -19,8 +19,9 @@ kube_prometheus_stack_wait_timeout: 5m
 
 kube_prometheus_stack_metrics_image_tag: v2.12.0
 kube_prometheus_stack_patch_image_tag: v20221220-controller-v1.5.1-58-g787ea74b6
-kube_prometheus_stack_blackbox_exporter_image_tag: v0.25.0
 
+kube_prometheus_stack_blackbox_exporter_release_version: 9.0.1
+kube_prometheus_stack_blackbox_exporter_image_tag: v0.25.0
 kube_prometheus_stack_blackbox_exporter_release_name: blackbox-exporter
 
 control_ip: "{{ hostvars[groups['control'].0].ansible_host }}"

--- a/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
+++ b/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
@@ -20,6 +20,8 @@ kube_prometheus_stack_wait_timeout: 5m
 kube_prometheus_stack_metrics_image_tag: v2.12.0
 kube_prometheus_stack_patch_image_tag: v20221220-controller-v1.5.1-58-g787ea74b6
 
+kube_prometheus_stack_blackbox_exporter_release_name: blackbox-exporter
+
 control_ip: "{{ hostvars[groups['control'].0].ansible_host }}"
 
 grafana_auth_anonymous: false
@@ -64,6 +66,7 @@ prometheus_external_labels:
 prometheus_scrape_configs: []
 
 prometheus_extra_rules: []
+prometheus_extra_rules_default: []
 
 prometheus_rules:
   appliance-rules:

--- a/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
+++ b/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
@@ -19,6 +19,7 @@ kube_prometheus_stack_wait_timeout: 5m
 
 kube_prometheus_stack_metrics_image_tag: v2.12.0
 kube_prometheus_stack_patch_image_tag: v20221220-controller-v1.5.1-58-g787ea74b6
+kube_prometheus_stack_blackbox_exporter_image_tag: v0.25.0
 
 kube_prometheus_stack_blackbox_exporter_release_name: blackbox-exporter
 

--- a/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
+++ b/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
@@ -67,7 +67,6 @@ prometheus_external_labels:
 prometheus_scrape_configs: []
 
 prometheus_extra_rules: []
-prometheus_extra_rules_default: []
 
 prometheus_rules:
   appliance-rules:

--- a/ansible/roles/kube_prometheus_stack/tasks/main.yml
+++ b/ansible/roles/kube_prometheus_stack/tasks/main.yml
@@ -113,6 +113,35 @@
                 - port: 9301
                   name: ood-exporter
                   protocol: TCP
+    
+    - name: Creating headless service for OOD server 
+      kubernetes.core.k8s:
+        namespace: "{{ kube_prometheus_stack_release_namespace }}"
+        definition:
+          kind: Service
+          metadata:
+            name: ondemand
+          spec:
+            clusterIP: None
+            ports:
+            - name: https
+              port: 443
+              protocol: TCP
+
+    - name: Binding OOD server service to host
+      kubernetes.core.k8s:
+        namespace: "{{ kube_prometheus_stack_release_namespace }}"
+        definition:
+          kind: Endpoints
+          metadata:
+            name: ondemand
+          subsets:
+            - addresses:
+                - ip: "{{ openondemand_ip }}"
+              ports:
+                - port: 443
+                  name: https
+                  protocol: TCP
 
 - name: Creating headless service for slurm exporter
   kubernetes.core.k8s:
@@ -177,6 +206,7 @@
     name: grafana-dashboards
 
 - name: Install blackbox exporter helm chart
+  no_log: true
   kubernetes.core.helm:
     chart_ref: prometheus-blackbox-exporter
     chart_repo_url: https://prometheus-community.github.io/helm-charts
@@ -186,6 +216,15 @@
     release_values:
       nodeSelector:
         clusterrole: "server"
+      config:
+        modules:
+          http_2xx:
+            http:
+              tls_config:
+                insecure_skip_verify: true
+              basic_auth:
+                username: "testuser"
+                password: "{{ vault_testuser_password }}"
     wait: yes
 
 - name: Install kube-prometheus-stack on target Kubernetes cluster

--- a/ansible/roles/kube_prometheus_stack/tasks/main.yml
+++ b/ansible/roles/kube_prometheus_stack/tasks/main.yml
@@ -225,6 +225,11 @@
               basic_auth:
                 username: "testuser"
                 password: "{{ vault_testuser_password }}"
+      configReloader:
+        image:
+          tag: "{{ kube_prometheus_stack_app_version }}" # keeps consistent with pre-pulled image for kube-prometheus-stack
+      image:
+        tag: "{{ kube_prometheus_stack_blackbox_exporter_image_tag }}"
     wait: yes
 
 - name: Install kube-prometheus-stack on target Kubernetes cluster

--- a/ansible/roles/kube_prometheus_stack/tasks/main.yml
+++ b/ansible/roles/kube_prometheus_stack/tasks/main.yml
@@ -210,7 +210,7 @@
   kubernetes.core.helm:
     chart_ref: prometheus-blackbox-exporter
     chart_repo_url: https://prometheus-community.github.io/helm-charts
-    chart_version: 9.0.1
+    chart_version: "{{ kube_prometheus_stack_blackbox_exporter_release_version }}"
     release_name: "{{ kube_prometheus_stack_blackbox_exporter_release_name }}"
     release_namespace: "{{ kube_prometheus_stack_release_namespace }}"
     release_values:

--- a/ansible/roles/kube_prometheus_stack/tasks/main.yml
+++ b/ansible/roles/kube_prometheus_stack/tasks/main.yml
@@ -176,6 +176,18 @@
   ansible.builtin.import_role:
     name: grafana-dashboards
 
+- name: Install blackbox exporter helm chart
+  kubernetes.core.helm:
+    chart_ref: prometheus-blackbox-exporter
+    chart_repo_url: https://prometheus-community.github.io/helm-charts
+    chart_version: 9.0.1
+    release_name: "{{ kube_prometheus_stack_blackbox_exporter_release_name }}"
+    release_namespace: "{{ kube_prometheus_stack_release_namespace }}"
+    release_values:
+      nodeSelector:
+        clusterrole: "server"
+    wait: yes
+
 - name: Install kube-prometheus-stack on target Kubernetes cluster
   kubernetes.core.helm:
     chart_ref: "{{ kube_prometheus_stack_chart_name }}"

--- a/environments/common/inventory/group_vars/all/grafana.yml
+++ b/environments/common/inventory/group_vars/all/grafana.yml
@@ -38,6 +38,12 @@ grafana_dashboards_default:
       - placeholder: DS_PROMETHEUS
         replacement: prometheus
     revision_id: 3
+  # blackbox probes
+  - dashboard_id: 14928
+    replacements:
+      - placeholder: DS_PROMETHEUS
+        replacement: prometheus
+    revision_id: 6
 grafana_dashboards: "{{ grafana_dashboards_default + (openondemand_dashboard if groups.get('openondemand') else []) }}"
 
 # Configmap names of kube prometheus stack's default dashboards to exclude

--- a/environments/common/inventory/group_vars/all/monitoring.yml
+++ b/environments/common/inventory/group_vars/all/monitoring.yml
@@ -2,5 +2,6 @@ kube_prometheus_stack_chart_version: 59.1.0
 kube_prometheus_stack_release_namespace: monitoring-system
 kube_prometheus_stack_release_name: kube-prometheus-stack
 kube_prometheus_stack_wait_timeout: 5m
+kube_prometheus_stack_blackbox_exporter_release_name: blackbox-exporter
 
 # See prometheus.yml, grafana.yml and alertmanager.yml for config of individual monitoring services

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -196,14 +196,6 @@ openondemand_scrape_configs:
       target_label: target
     - target_label: __address__ 
       replacement: "{{ kube_prometheus_stack_blackbox_exporter_release_name }}-prometheus-blackbox-exporter:9115"
-openondemand_extra_rules:
-- alert: OnDemandProbeFailed
-  annotations:
-    description: '{% raw %}Could not establish secure connection to OOD server at {{ $labels.target }}{% endraw %}'
-    summary: 'Could not establish a secure connection to an Open OnDemand server'
-  expr: "probe_success{target='ondemand.monitoring-system'} < 1\n"
-  labels:
-    severity: warning
 
 openondemand_dashboard:
   - dashboard_id: 13465

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -182,6 +182,28 @@ openondemand_scrape_configs:
       labels:
         environment: "{{ appliances_environment_name }}"
         service: "openondemand"
+  - job_name: "blackbox-probes"
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+        - "https://{{ openondemand_address }}"
+    relabel_configs:
+    - source_labels: [__address__]
+      target_label: __param_target
+    - source_labels: [__param_target]
+      target_label: target
+    - target_label: __address__ 
+      replacement: "{{ kube_prometheus_stack_blackbox_exporter_release_name }}-prometheus-blackbox-exporter:9115"
+openondemand_extra_rules:
+- alert: OnDemandProbeFailed
+  annotations:
+    description: '{% raw %}Could not establish secure connection to OOD server at {{ $labels.target }}{% endraw %}'
+    summary: 'Could not establish a secure connection to an Open OnDemand server'
+  expr: "probe_success{target='https://{{ openondemand_address }}'} < 1\n"
+  labels:
+    severity: warning
 
 openondemand_dashboard:
   - dashboard_id: 13465

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -188,7 +188,7 @@ openondemand_scrape_configs:
       module: [http_2xx]
     static_configs:
       - targets:
-        - "https://{{ openondemand_address }}"
+        - ondemand.monitoring-system
     relabel_configs:
     - source_labels: [__address__]
       target_label: __param_target
@@ -201,7 +201,7 @@ openondemand_extra_rules:
   annotations:
     description: '{% raw %}Could not establish secure connection to OOD server at {{ $labels.target }}{% endraw %}'
     summary: 'Could not establish a secure connection to an Open OnDemand server'
-  expr: "probe_success{target='https://{{ openondemand_address }}'} < 1\n"
+  expr: "probe_success{target='ondemand.monitoring-system'} < 1\n"
   labels:
     severity: warning
 

--- a/environments/common/inventory/group_vars/all/prometheus.yml
+++ b/environments/common/inventory/group_vars/all/prometheus.yml
@@ -20,7 +20,8 @@ prometheus_scrape_configs_default:
     replacement:   '${1}'
 
 prometheus_scrape_configs: "{{ prometheus_scrape_configs_default + (openondemand_scrape_configs if groups['openondemand'] | count > 0 else []) }}"
-prometheus_extra_rules:
+prometheus_extra_rules: "{{ prometheus_extra_rules_default + (openondemand_extra_rules if groups['openondemand'] | count > 0 else []) }}"
+prometheus_extra_rules_default:
   - alert: SlurmNodeDown
     annotations:
       description: '{% raw %}{{ $value }} Slurm nodes are in down status.{% endraw %}'

--- a/environments/common/inventory/group_vars/all/prometheus.yml
+++ b/environments/common/inventory/group_vars/all/prometheus.yml
@@ -20,8 +20,7 @@ prometheus_scrape_configs_default:
     replacement:   '${1}'
 
 prometheus_scrape_configs: "{{ prometheus_scrape_configs_default + (openondemand_scrape_configs if groups['openondemand'] | count > 0 else []) }}"
-prometheus_extra_rules: "{{ prometheus_extra_rules_default + (openondemand_extra_rules if groups['openondemand'] | count > 0 else []) }}"
-prometheus_extra_rules_default:
+prometheus_extra_rules:
   - alert: SlurmNodeDown
     annotations:
       description: '{% raw %}{{ $value }} Slurm nodes are in down status.{% endraw %}'
@@ -29,6 +28,54 @@ prometheus_extra_rules_default:
     expr: "slurm_nodes_down > 0\n"
     labels:
       severity: critical
+  - alert: BlackboxProbeFailed
+    expr: probe_success == 0
+    for: 0m
+    labels:
+      severity: critical
+    annotations:
+      summary: '{% raw %}Blackbox probe failed (target {{ $labels.target }}){% endraw %}'
+      description: "{% raw %}Blackbox probe '{{ $labels.target }}' failed{% endraw %}"
+  - alert: BlackboxSlowProbe
+    expr: avg_over_time(probe_duration_seconds[1m]) > 1.2 #around 1.14 expected due to indirection in cluster
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: '{% raw %}Blackbox slow probe (target {{ $labels.target }}){% endraw %}'
+      description: "{% raw %}Blackbox probe '{{ $labels.target }}' took more than 1s to complete - {{ $value }}{% endraw %}"
+  - alert: BlackboxProbeHttpFailure
+    expr: probe_http_status_code <= 199 OR probe_http_status_code >= 400
+    for: 0m
+    labels:
+      severity: critical
+    annotations:
+      summary: '{% raw %}Blackbox probe HTTP failure (target {{ $labels.target }}){% endraw %}'
+      description: "{% raw %}Blackbox probe '{{ $labels.target }}' returned an HTTP error status - {{ $value }}{% endraw %}"
+  - alert: BlackboxSslCertificateWillExpireSoon
+    expr: (7 * 24 * 3600) <= (last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time()) < (30 * 24 * 3600)
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      summary: '{% raw %}Blackbox SSL certificate will expire soon (target {{ $labels.target }}){% endraw %}'
+      description: "{% raw %}SSL certificate for blackbox probe '{{ $labels.target }}' expires in {{ $value | humanizeDuration }}{% endraw %}"
+  - alert: BlackboxSslCertificateWillExpireVerySoon
+    expr: 0 <= (last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time()) < (7 * 24 * 3600)
+    for: 0m
+    labels:
+      severity: critical
+    annotations:
+      summary: '{% raw %}Blackbox SSL certificate will expire very soon (target {{ $labels.target }}){% endraw %}'
+      description: "{% raw %}SSL certificate for blackbox probe '{{ $labels.target }}' expires in {{ $value | humanizeDuration }}{% endraw %}"
+  - alert: BlackboxSslCertificateExpired
+    expr: (last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time()) < 0
+    for: 0m
+    labels:
+      severity: critical
+    annotations:
+      summary: '{% raw %}Blackbox SSL certificate expired (target {{ $labels.target }}){% endraw %}'
+      description: "{% raw %}SSL certificate for blackbox probe '{{ $labels.target }}' has expired{% endraw %}"
   - record: node_cpu_system_seconds:record
     expr: (100 * sum by(instance)(increase(node_cpu_seconds_total{mode="system",job="node-exporter"}[60s]))) / (sum by(instance)(increase(node_cpu_seconds_total{job="node-exporter"}[60s])))
   - record: node_cpu_user_seconds:record


### PR DESCRIPTION
Installs blackbox exporter into k3s cluster and adds Prometheus scrape job with probe for OOD. Also adds blackbox alerting rules from https://github.com/azimuth-cloud/capi-helm-charts/blob/2355ba6151289f35bba9a9e8bd7c372930c323a4/charts/cluster-addons/templates/monitoring/blackbox-exporter.yaml#L98

NB: probes are slower than typical probes in capi helm charts due to indirection from accessing OOD through headless service in k3s cluster