### PR TITLE
Added loki with host logs forwarded

### DIFF
--- a/ansible/roles/grafana-dashboards/files/loki-pod-logs-dashboard.json
+++ b/ansible/roles/grafana-dashboards/files/loki-pod-logs-dashboard.json
@@ -1,0 +1,228 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Search pod logs stored in Loki",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 31,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Loki",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "hidden",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "Loki",
+          "expr": "sum(count_over_time({namespace=\"$namespace\", pod=~\"$pod\"} |~ \"$search\"[$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Loki",
+      "gridPos": {
+        "h": 25,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "maxDataPoints": "",
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": "Loki",
+          "expr": "{namespace=\"$namespace\", pod=~\"$pod\"} |~ \"$search\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs Panel",
+      "type": "logs"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "text": "ingress-nginx",
+          "value": "ingress-nginx"
+        },
+        "datasource": "Loki",
+        "definition": "label_values(namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Loki",
+        "definition": "label_values({namespace=~\"$namespace\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": "label_values({namespace=~\"$namespace\"}, pod)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "hide": 0,
+        "name": "search",
+        "options": [],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Loki / Pod Logs",
+  "uid": "209fd89b771c318dd442225414a50b59",
+  "version": 1,
+  "weekStart": ""
+}

--- a/ansible/roles/grafana-dashboards/files/loki-pod-logs-dashboard.json
+++ b/ansible/roles/grafana-dashboards/files/loki-pod-logs-dashboard.json
@@ -16,7 +16,7 @@
     ]
   },
   "description": "Search pod logs stored in Loki",
-  "editable": false,
+  "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 31,

--- a/ansible/roles/grafana-dashboards/files/loki-systemd-logs-dashboard.json
+++ b/ansible/roles/grafana-dashboards/files/loki-systemd-logs-dashboard.json
@@ -16,7 +16,7 @@
       ]
     },
     "description": "Search systemd logs stored in Loki",
-    "editable": false,
+    "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
     "id": 33,

--- a/ansible/roles/grafana-dashboards/files/loki-systemd-logs-dashboard.json
+++ b/ansible/roles/grafana-dashboards/files/loki-systemd-logs-dashboard.json
@@ -1,0 +1,232 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Search systemd logs stored in Loki",
+    "editable": false,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 33,
+    "links": [],
+    "panels": [
+      {
+        "datasource": "Loki",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "hidden",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "bars",
+              "fillOpacity": 100,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": "Loki",
+            "expr": "sum(count_over_time({unit=~\"$unit\", hostname=~\"$hostname\"} |~ \"$search\"[$__interval]))",
+            "refId": "A"
+          }
+        ],
+        "type": "timeseries"
+      },
+      {
+        "datasource": "Loki",
+        "gridPos": {
+          "h": 25,
+          "w": 24,
+          "x": 0,
+          "y": 3
+        },
+        "id": 2,
+        "maxDataPoints": "",
+        "options": {
+          "dedupStrategy": "none",
+          "enableLogDetails": true,
+          "prettifyLogMessage": false,
+          "showCommonLabels": false,
+          "showLabels": false,
+          "showTime": true,
+          "sortOrder": "Descending",
+          "wrapLogMessage": true
+        },
+        "targets": [
+          {
+            "datasource": "Loki",
+            "expr": "{unit=~\"$unit\", hostname=~\"$hostname\"} |~ \"$search\"",
+            "refId": "A"
+          }
+        ],
+        "title": "Logs Panel",
+        "type": "logs"
+      }
+    ],
+    "schemaVersion": 39,
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": ".+",
+          "current": {
+            "selected": true,
+            "text": "ansible-init.service",
+            "value": "ansible-init.service"
+          },
+          "datasource": "Loki",
+          "definition": "label_values(unit)",
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "unit",
+          "options": [],
+          "query": "label_values(unit)",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": ".+",
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": "Loki",
+          "definition": "label_values({unit=~\"$unit\"}, hostname)",
+          "hide": 0,
+          "includeAll": true,
+          "multi": true,
+          "name": "hostname",
+          "options": [],
+          "query": "label_values({unit=~\"$unit\"}, hostname)",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "current": {},
+          "hide": 0,
+          "name": "search",
+          "options": [],
+          "query": "",
+          "skipUrlSync": false,
+          "type": "textbox"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-3h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "",
+    "title": "Loki / Systemd Logs",
+    "uid": "fa1bd43aed803111be9cc923cada9811",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/ansible/roles/kube_prometheus_stack/defaults/main/helm.yml
+++ b/ansible/roles/kube_prometheus_stack/defaults/main/helm.yml
@@ -193,3 +193,45 @@ kube_prometheus_stack_release_values: >-
     kube_prometheus_stack_release_defaults |
       combine(kube_prometheus_stack_release_overrides, recursive = True)
   }}
+
+kube_prometheus_stack_loki_release_values:
+  loki:
+    nodeSelector:
+      clusterrole: server
+    image:
+      tag: "{{ kube_prometheus_stack_loki_image_tag }}"
+  grafana:
+    sidecar:
+      datasources:
+        enabled: false
+  promtail:
+    config:
+      snippets:
+        extraScrapeConfigs: |
+          - job_name: journal
+            journal:
+              path: /var/log/journal
+              max_age: 12h
+              labels:
+                job: systemd-journal
+            relabel_configs:
+              - source_labels: ['__journal__systemd_unit']
+                target_label: 'unit'
+              - source_labels: ['__journal__hostname']
+                target_label: 'hostname'
+              - source_labels: ['__journal_priority_keyword']
+                target_label: level
+    extraVolumes:
+      - name: journal
+        hostPath:
+          path: /var/log/journal
+      - name: machine-id
+        hostPath:
+          path: /etc/machine-id
+    extraVolumeMounts:
+      - name: journal
+        mountPath: /var/log/journal
+        readOnly: true
+      - name: machine-id
+        mountPath: /etc/machine-id
+        readOnly: true

--- a/ansible/roles/kube_prometheus_stack/defaults/main/install.yml
+++ b/ansible/roles/kube_prometheus_stack/defaults/main/install.yml
@@ -9,3 +9,5 @@ image_list:
 - { name: "quay.io/kiwigrid/k8s-sidecar", tag: "{{ grafana_sidecar_image_tag }}" }
 - { name: "registry.k8s.io/kube-state-metrics/kube-state-metrics", tag: "{{ kube_prometheus_stack_metrics_image_tag }}" }
 - { name: "registry.k8s.io/ingress-nginx/kube-webhook-certgen", tag: "{{ kube_prometheus_stack_patch_image_tag }}" }
+- { name: "docker.io/grafana/loki", tag: "{{ kube_prometheus_stack_loki_image_tag }}" }
+- { name: "docker.io/grafana/promtail", tag: "{{ kube_prometheus_stack_loki_image_tag }}" }

--- a/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
+++ b/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
@@ -20,6 +20,9 @@ kube_prometheus_stack_wait_timeout: 5m
 kube_prometheus_stack_metrics_image_tag: v2.12.0
 kube_prometheus_stack_patch_image_tag: v20221220-controller-v1.5.1-58-g787ea74b6
 
+kube_prometheus_stack_loki_chart_version: 2.10.2
+kube_prometheus_stack_loki_image_tag: 2.9.3
+
 control_ip: "{{ hostvars[groups['control'].0].ansible_host }}"
 
 grafana_auth_anonymous: false

--- a/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
+++ b/ansible/roles/kube_prometheus_stack/defaults/main/main.yml
@@ -21,7 +21,7 @@ kube_prometheus_stack_metrics_image_tag: v2.12.0
 kube_prometheus_stack_patch_image_tag: v20221220-controller-v1.5.1-58-g787ea74b6
 
 kube_prometheus_stack_loki_chart_version: 2.10.2
-kube_prometheus_stack_loki_image_tag: 2.9.3
+kube_prometheus_stack_loki_image_tag: 2.9.3 # also promtail tag
 
 control_ip: "{{ hostvars[groups['control'].0].ansible_host }}"
 

--- a/ansible/roles/kube_prometheus_stack/tasks/main.yml
+++ b/ansible/roles/kube_prometheus_stack/tasks/main.yml
@@ -191,7 +191,7 @@
           tag: 2.9.3
       grafana:
         sidecar:
-          grafana_datasources:
+          datasources:
             enabled: false
     wait: yes
 

--- a/ansible/roles/kube_prometheus_stack/tasks/main.yml
+++ b/ansible/roles/kube_prometheus_stack/tasks/main.yml
@@ -193,6 +193,37 @@
         sidecar:
           datasources:
             enabled: false
+      promtail:
+        config:
+          snippets:
+            extraScrapeConfigs: |
+              - job_name: journal
+                journal:
+                  path: /var/log/journal
+                  max_age: 12h
+                  labels:
+                    job: systemd-journal
+                relabel_configs:
+                  - source_labels: ['__journal__systemd_unit']
+                    target_label: 'unit'
+                  - source_labels: ['__journal__hostname']
+                    target_label: 'hostname'
+                  - source_labels: ['__journal_priority_keyword']
+                    target_label: level
+        extraVolumes:
+          - name: journal
+            hostPath:
+              path: /var/log/journal
+          - name: machine-id
+            hostPath:
+              path: /etc/machine-id
+        extraVolumeMounts:
+          - name: journal
+            mountPath: /var/log/journal
+            readOnly: true
+          - name: machine-id
+            mountPath: /etc/machine-id
+            readOnly: true
     wait: yes
 
 - name: Install kube-prometheus-stack on target Kubernetes cluster

--- a/ansible/roles/kube_prometheus_stack/tasks/main.yml
+++ b/ansible/roles/kube_prometheus_stack/tasks/main.yml
@@ -176,6 +176,25 @@
   ansible.builtin.import_role:
     name: grafana-dashboards
 
+- name: Install loki stack helm chart
+  kubernetes.core.helm:
+    chart_ref: loki-stack
+    chart_repo_url: https://grafana.github.io/helm-charts
+    chart_version: 2.10.2
+    release_name: loki
+    release_namespace: "{{ kube_prometheus_stack_release_namespace }}"
+    release_values:
+      loki:
+        nodeSelector:
+          clusterrole: server
+        image:
+          tag: 2.9.3
+      grafana:
+        sidecar:
+          grafana_datasources:
+            enabled: false
+    wait: yes
+
 - name: Install kube-prometheus-stack on target Kubernetes cluster
   kubernetes.core.helm:
     chart_ref: "{{ kube_prometheus_stack_chart_name }}"

--- a/ansible/roles/kube_prometheus_stack/tasks/main.yml
+++ b/ansible/roles/kube_prometheus_stack/tasks/main.yml
@@ -180,50 +180,10 @@
   kubernetes.core.helm:
     chart_ref: loki-stack
     chart_repo_url: https://grafana.github.io/helm-charts
-    chart_version: 2.10.2
+    chart_version: "{{ kube_prometheus_stack_loki_chart_version }}"
     release_name: loki
     release_namespace: "{{ kube_prometheus_stack_release_namespace }}"
-    release_values:
-      loki:
-        nodeSelector:
-          clusterrole: server
-        image:
-          tag: 2.9.3
-      grafana:
-        sidecar:
-          datasources:
-            enabled: false
-      promtail:
-        config:
-          snippets:
-            extraScrapeConfigs: |
-              - job_name: journal
-                journal:
-                  path: /var/log/journal
-                  max_age: 12h
-                  labels:
-                    job: systemd-journal
-                relabel_configs:
-                  - source_labels: ['__journal__systemd_unit']
-                    target_label: 'unit'
-                  - source_labels: ['__journal__hostname']
-                    target_label: 'hostname'
-                  - source_labels: ['__journal_priority_keyword']
-                    target_label: level
-        extraVolumes:
-          - name: journal
-            hostPath:
-              path: /var/log/journal
-          - name: machine-id
-            hostPath:
-              path: /etc/machine-id
-        extraVolumeMounts:
-          - name: journal
-            mountPath: /var/log/journal
-            readOnly: true
-          - name: machine-id
-            mountPath: /etc/machine-id
-            readOnly: true
+    release_values: "{{ kube_prometheus_stack_loki_release_values }}"
     wait: yes
 
 - name: Install kube-prometheus-stack on target Kubernetes cluster

--- a/environments/common/inventory/group_vars/all/grafana.yml
+++ b/environments/common/inventory/group_vars/all/grafana.yml
@@ -38,6 +38,8 @@ grafana_dashboards_default:
       - placeholder: DS_PROMETHEUS
         replacement: prometheus
     revision_id: 3
+  - dashboard_file: loki-pod-logs-dashboard.json
+    replacements: []
 grafana_dashboards: "{{ grafana_dashboards_default + (openondemand_dashboard if groups.get('openondemand') else []) }}"
 
 # Configmap names of kube prometheus stack's default dashboards to exclude

--- a/environments/common/inventory/group_vars/all/grafana.yml
+++ b/environments/common/inventory/group_vars/all/grafana.yml
@@ -40,6 +40,8 @@ grafana_dashboards_default:
     revision_id: 3
   - dashboard_file: loki-pod-logs-dashboard.json
     replacements: []
+  - dashboard_file: loki-systemd-logs-dashboard.json
+    replacements: []
 grafana_dashboards: "{{ grafana_dashboards_default + (openondemand_dashboard if groups.get('openondemand') else []) }}"
 
 # Configmap names of kube prometheus stack's default dashboards to exclude

--- a/environments/common/inventory/group_vars/all/grafana.yml
+++ b/environments/common/inventory/group_vars/all/grafana.yml
@@ -73,7 +73,13 @@ grafana_datasources:
       version: '7.10.2'
       flavor: elasticsearch
     editable: true
-    # readOnly: false
+    readOnly: false
+  - name: Loki
+    url: http://loki:3100
+    type: loki
+    access: proxy
+    version: 1
+    isDefault: false
 grafana_plugins:
   - grafana-opensearch-datasource 2.8.1
 


### PR DESCRIPTION
Added loki with host log forwarding to k3s based on implementation in https://github.com/azimuth-cloud/capi-helm-charts/blob/main/charts/cluster-addons/templates/monitoring/loki-stack.yaml . Also copied dashboards for k3s pod logs and journalctl logs from https://github.com/azimuth-cloud/capi-helm-charts/tree/main/charts/cluster-addons/grafana-dashboards