### PR TITLE
Unset signature_verified property from nightly/latest images

### DIFF
--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -108,6 +108,11 @@ jobs:
           echo "image-name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
           echo "image-id=$IMAGE_ID" >> "$GITHUB_OUTPUT"
 
+      - name: Make image usable for further builds
+        run: |
+          . venv/bin/activate
+          openstack image unset --property signature_verified "${{ steps.manifest.outputs.image-id }}"
+
       - name: Delete old latest image
         run: |
           . venv/bin/activate


### PR DESCRIPTION
#467 accidently removed the step which unsets the `signature_verified` property on nightly builds. This property existing means volume creation [fails](https://bugs.launchpad.net/cinder/+bug/1823445) for fatimage builds using the nightly images.