### PR TITLE
Upgrade RL8 ceph to quincy + trivy rate limit and OOD false positives fix

### DIFF
--- a/.github/workflows/trivyscan.yml
+++ b/.github/workflows/trivyscan.yml
@@ -94,6 +94,7 @@ jobs:
           timeout: 15m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIVY_DB_REPOSITORY: ghcr.io/azimuth-cloud/trivy-db:2
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/trivyscan.yml
+++ b/.github/workflows/trivyscan.yml
@@ -114,3 +114,4 @@ jobs:
           timeout: 15m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIVY_DB_REPOSITORY: ghcr.io/azimuth-cloud/trivy-db:2

--- a/environments/.stackhpc/hooks/post.yml
+++ b/environments/.stackhpc/hooks/post.yml
@@ -9,8 +9,6 @@
         path: "{{ item }}"
         state: absent
       with_items:
-        - /opt/ood/ondemand/root/usr/share/gems/3.1/ondemand/3.1.7-1/gems/bootstrap_form-2.7.0/test/dummy/Gemfile.lock
-        - /opt/ood/ondemand/root/usr/share/gems/3.1/ondemand/3.1.9-1/gems/bootstrap_form-2.7.0/test/dummy/Gemfile.lock
-        - /opt/ood/ondemand/root/usr/share/gems/3.1/ondemand/3.1.7-1/gems/bootstrap_form-4.5.0/demo/yarn.lock
-        - /opt/ood/ondemand/root/usr/share/gems/3.1/ondemand/3.1.9-1/gems/bootstrap_form-4.5.0/demo/yarn.lock
+        - "/opt/ood/ondemand/root/usr/share/gems/3.1/ondemand/{{ ondemand_package_version }}-1/gems/bootstrap_form-2.7.0/test/dummy/Gemfile.lock"
+        - "/opt/ood/ondemand/root/usr/share/gems/3.1/ondemand/{{ ondemand_package_version }}-1/gems/bootstrap_form-4.5.0/demo/yarn.lock"
         - /var/www/ood/apps/sys/dashboard/node_modules/data-confirm-modal/Gemfile.lock

--- a/environments/.stackhpc/inventory/group_vars/openondemand/overrides.yml
+++ b/environments/.stackhpc/inventory/group_vars/openondemand/overrides.yml
@@ -4,3 +4,5 @@ openondemand_desktop_partition: standard
 #openondemand_dashboard_support_url: 
 #openondemand_dashboard_docs_url:
 #openondemand_filesapp_paths:
+ondemand_package: ondemand-"{{ ondemand_package_version }}"
+ondemand_package_version: '3.1.10'

--- a/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
@@ -1,7 +1,7 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-241024-1439-177083b1",
-        "RL9": "openhpc-RL9-241024-1438-177083b1",
-        "RL9-cuda": "openhpc-cuda-RL9-241024-1628-177083b1"
+        "RL8": "openhpc-RL8-241113-1501-403d729b",
+        "RL9": "openhpc-RL9-241113-1416-403d729b",
+        "RL9-cuda": "openhpc-cuda-RL9-241113-1416-403d729b"
     }
 }

--- a/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
@@ -1,7 +1,7 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-241113-1501-403d729b",
-        "RL9": "openhpc-RL9-241113-1416-403d729b",
-        "RL9-cuda": "openhpc-cuda-RL9-241113-1416-403d729b"
+        "RL8": "openhpc-RL8-241114-1531-6f0a3a02",
+        "RL9": "openhpc-RL9-241114-1531-6f0a3a02",
+        "RL9-cuda": "openhpc-cuda-RL9-241114-1531-6f0a3a02"
     }
 }

--- a/requirements.yml
+++ b/requirements.yml
@@ -21,7 +21,7 @@ roles:
     version: v3.1.5
   - src: https://github.com/stackhpc/ansible-role-os-manila-mount.git
     name: stackhpc.os-manila-mount
-    version: fix/rl8-ceph # Bump when merges # Support ceph quincy for RL9
+    version: v24.11.0 # Support ceph quincy for RL9
 
 collections:
   - name: containers.podman

--- a/requirements.yml
+++ b/requirements.yml
@@ -21,7 +21,7 @@ roles:
     version: v3.1.5
   - src: https://github.com/stackhpc/ansible-role-os-manila-mount.git
     name: stackhpc.os-manila-mount
-    version: v24.5.1 # Support ceph quincy for RL9
+    version: fix/rl8-ceph # Bump when merges # Support ceph quincy for RL9
 
 collections:
   - name: containers.podman


### PR DESCRIPTION
- Ceph default version is now `quincy` via bump to manila role. Repos for previous `octopus` version have become unavailable. See https://github.com/stackhpc/ansible-role-os-manila-mount/pull/11.
- `ondemand` package in stackhpc fat image now bumped to version 3.1.10. Note the default version is still undefined so that running `ansible/site.yml` in other environments will not upgrade existing deployments.
- CI uses a mirror of the trivy vulnerability database from [azimuth-cloud](https://github.com/azimuth-cloud) to avoid rate limiting.
