### PR TITLE
Fix adhoc/rebuild wait_for_connection race condition

### DIFF
--- a/ansible/adhoc/rebuild.yml
+++ b/ansible/adhoc/rebuild.yml
@@ -16,3 +16,6 @@
     - command: "openstack server rebuild {{ instance_id | default(inventory_hostname) }}{% if rebuild_image is defined %} --image {{ rebuild_image }}{% endif %}"
       delegate_to: localhost
     - wait_for_connection:
+        delay: 60
+        timeout: 600
+


### PR DESCRIPTION
When rebuilding nodes, a race condition can result in ssh connection being re-established before rebuild has begun.

Delay of 60s fixes this.