### PR TITLE
Bump openhpc role for slurm restart, templating and nodes in multiple groups

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - src: stackhpc.nfs
     version: v23.12.1 # Tolerate state nfs file handles
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v0.26.0 # https://github.com/stackhpc/ansible-role-openhpc/pull/168
+    version: v0.27.0
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: stackhpc


### PR DESCRIPTION
See https://github.com/stackhpc/ansible-role-openhpc/releases/tag/v0.27.0