### PR TITLE
Add role to install NVIDIA DOCA on top of an existing "fat" image

### DIFF
--- a/.github/workflows/doca.yml
+++ b/.github/workflows/doca.yml
@@ -92,7 +92,7 @@ jobs:
           -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
           -var "source_image_name=${{ matrix.build.source_image_name }}" \
           -var "image_name=openhpc-doca" \
-          -var "groups=doca" \
+          -var "inventory_groups=doca" \
           openstack.pkr.hcl
         
       - name: Get created image names from manifest

--- a/.github/workflows/doca.yml
+++ b/.github/workflows/doca.yml
@@ -5,28 +5,18 @@ on:
     branches:
       - main
     paths:
-      - '**'
-      - '!dev/**'
-      - 'dev/setup-env.sh'
-      - '!docs/**'
-      - '!README.md'
-      - '!.gitignore'
-      - '!.github/workflows/'
+      - 'environments/.stackhpc/terraform/cluster_image.auto.tfvars.json'
+      - 'ansible/roles/doca/**'
       - '.github/workflows/doca'
   pull_request:
     paths:
-      - '**'
-      - '!dev/**'
-      - 'dev/setup-env.sh'
-      - '!docs/**'
-      - '!README.md'
-      - '!.gitignore'
-      - '!.github/workflows/'
+      - 'environments/.stackhpc/terraform/cluster_image.auto.tfvars.json'
+      - 'ansible/roles/doca/**'
       - '.github/workflows/doca'
 
 jobs:
-  openstack:
-    name: openstack-docabuild
+  doca:
+    name: doca-build
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.image_name }} # to branch/PR + OS
       cancel-in-progress: true
@@ -116,8 +106,21 @@ jobs:
             sleep 5
           done
           IMAGE_NAME=$(openstack image show -f value -c name $IMAGE_ID)
+          echo "image-name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "image-id=$IMAGE_ID" >> "$GITHUB_OUTPUT"
           echo $IMAGE_ID > image-id.txt
           echo $IMAGE_NAME > image-name.txt
+
+      - name: Make image usable for further builds
+        run: |
+          . venv/bin/activate
+          openstack image unset --property signature_verified "${{ steps.manifest.outputs.image-id }}"
+
+      - name: Delete image for automatically-run workflows
+        run: |
+          . venv/bin/activate
+          openstack image delete "${{ steps.manifest.outputs.image-id }}"
+        if: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Upload manifest artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/doca.yml
+++ b/.github/workflows/doca.yml
@@ -1,0 +1,117 @@
+name: Test DOCA extra build
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '**'
+      - '!dev/**'
+      - 'dev/setup-env.sh'
+      - '!docs/**'
+      - '!README.md'
+      - '!.gitignore'
+      - '!.github/workflows/'
+      - '.github/workflows/doca'
+  pull_request:
+    paths:
+      - '**'
+      - '!dev/**'
+      - 'dev/setup-env.sh'
+      - '!docs/**'
+      - '!README.md'
+      - '!.gitignore'
+      - '!.github/workflows/'
+      - '.github/workflows/doca'
+
+jobs:
+  openstack:
+    name: openstack-docabuild
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.label }} # to branch/PR + OS
+      cancel-in-progress: true
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false # allow other matrix jobs to continue even if one fails
+      matrix: # build RL8, RL9
+        build:
+          - label: RL8
+            source_image_name: rocky-latest-RL8
+          - label: RL9
+            source_image_name: rocky-latest-RL9
+    env:
+      ANSIBLE_FORCE_COLOR: True
+      OS_CLOUD: openstack
+      CI_CLOUD: ${{ vars.CI_CLOUD }} # default from repo settings
+      ARK_PASSWORD: ${{ secrets.ARK_PASSWORD }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Record settings for CI cloud
+        run: |
+          echo CI_CLOUD: ${{ env.CI_CLOUD }}
+
+      - name: Setup ssh
+        run: |
+          set -x
+          mkdir ~/.ssh
+          echo "${{ secrets[format('{0}_SSH_KEY', env.CI_CLOUD)] }}" > ~/.ssh/id_rsa
+          chmod 0600 ~/.ssh/id_rsa
+        shell: bash
+
+      - name: Add bastion's ssh key to known_hosts
+        run: cat environments/.stackhpc/bastion_fingerprints >> ~/.ssh/known_hosts
+        shell: bash
+
+      - name: Install ansible etc
+        run: dev/setup-env.sh
+
+      - name: Write clouds.yaml
+        run: |
+          mkdir -p ~/.config/openstack/
+          echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
+        shell: bash
+
+      - name: Setup environment
+        run: |
+          . venv/bin/activate
+          . environments/.stackhpc/activate
+
+      - name: Build fat image with packer
+        id: packer_build
+        run: |
+          set -x
+          . venv/bin/activate
+          . environments/.stackhpc/activate
+          cd packer/
+          packer init .
+          
+          PACKER_LOG=1 packer build \
+          -on-error=${{ vars.PACKER_ON_ERROR }} \
+          -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
+          -var "source_image_name=${{ matrix.build.source_image_name }}" \
+          -var "image_name=openhpc-doca" \
+          -var "groups=doca" \
+          openstack.pkr.hcl
+        
+      - name: Get created image names from manifest
+        id: manifest
+        run: |
+          . venv/bin/activate
+          IMAGE_ID=$(jq --raw-output '.builds[-1].artifact_id' packer/packer-manifest.json)
+          while ! openstack image show -f value -c name $IMAGE_ID; do
+            sleep 5
+          done
+          IMAGE_NAME=$(openstack image show -f value -c name $IMAGE_ID)
+          echo $IMAGE_ID > image-id.txt
+          echo $IMAGE_NAME > image-name.txt
+
+      - name: Upload manifest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-details-openhpc-${{ matrix.label }}
+          path: |
+            ./image-id.txt
+            ./image-name.txt
+          overwrite: true

--- a/.github/workflows/doca.yml
+++ b/.github/workflows/doca.yml
@@ -50,9 +50,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Record settings for CI cloud
+      - name: Load current fat images into GITHUB_ENV
+        # see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-of-a-multiline-string
+        run: |
+          {
+            echo 'FAT_IMAGES<<EOF'
+            cat cat environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+            echo EOF
+          } >> "$GITHUB_ENV"
+
+      - name: Record settings
         run: |
           echo CI_CLOUD: ${{ env.CI_CLOUD }}
+          echo FAT_IMAGES: ${FAT_IMAGES}
 
       - name: Setup ssh
         run: |

--- a/.github/workflows/doca.yml
+++ b/.github/workflows/doca.yml
@@ -36,10 +36,10 @@ jobs:
       matrix: # build RL8, RL9
         build:
           - image_name: openhpc-doca-RL8
-            source_image_name: openhpc-RL8 # TODO: needs to be injected from environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+            source_image_name_key: RL8 # key into environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
             inventory_groups: doca
           - image_name: openhpc-doca-RL9
-            source_image_name: openhpc-RL9 # TODO: as above
+            source_image_name_key: RL9
             inventory_groups: doca
     env:
       ANSIBLE_FORCE_COLOR: True
@@ -102,7 +102,7 @@ jobs:
           PACKER_LOG=1 packer build \
           -on-error=${{ vars.PACKER_ON_ERROR }} \
           -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
-          -var "source_image_name=${{ matrix.build.source_image_name }}" \
+          -var "source_image_name=${{ fromJSON(env.FAT_IMAGES)['cluster_image'][matrix.build.source_image_name_key] }}" \
           -var "image_name=${{ matrix.build.image_name }}" \
           -var "inventory_groups=${{ matrix.build.inventory_groups }}" \
           openstack.pkr.hcl

--- a/.github/workflows/doca.yml
+++ b/.github/workflows/doca.yml
@@ -35,10 +35,12 @@ jobs:
       fail-fast: false # allow other matrix jobs to continue even if one fails
       matrix: # build RL8, RL9
         build:
-          - label: RL8
-            source_image_name: rocky-latest-RL8
-          - label: RL9
-            source_image_name: rocky-latest-RL9
+          - image_name: openhpc-doca-RL8
+            source_image_name: openhpc-RL8 # TODO: needs to be injected from environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+            inventory_groups: doca
+          - image_name: openhpc-doca-RL9
+            source_image_name: openhpc-RL9 # TODO: as above
+            inventory_groups: doca
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
@@ -91,8 +93,8 @@ jobs:
           -on-error=${{ vars.PACKER_ON_ERROR }} \
           -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
           -var "source_image_name=${{ matrix.build.source_image_name }}" \
-          -var "image_name=openhpc-doca-${{ matrix.build.label }}" \
-          -var "inventory_groups=doca" \
+          -var "image_name=${{ matrix.build.image_name }}" \
+          -var "inventory_groups=${{ matrix.build.inventory_groups }}" \
           openstack.pkr.hcl
         
       - name: Get created image names from manifest

--- a/.github/workflows/doca.yml
+++ b/.github/workflows/doca.yml
@@ -28,7 +28,7 @@ jobs:
   openstack:
     name: openstack-docabuild
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.label }} # to branch/PR + OS
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.image_name }} # to branch/PR + OS
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     strategy:
@@ -122,7 +122,7 @@ jobs:
       - name: Upload manifest artifact
         uses: actions/upload-artifact@v4
         with:
-          name: image-details-${{ matrix.build.label }}
+          name: image-details-${{ matrix.build.image_name }}
           path: |
             ./image-id.txt
             ./image-name.txt

--- a/.github/workflows/doca.yml
+++ b/.github/workflows/doca.yml
@@ -91,7 +91,7 @@ jobs:
           -on-error=${{ vars.PACKER_ON_ERROR }} \
           -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
           -var "source_image_name=${{ matrix.build.source_image_name }}" \
-          -var "image_name=openhpc-doca" \
+          -var "image_name=openhpc-doca-${{ matrix.build.label }}" \
           -var "inventory_groups=doca" \
           openstack.pkr.hcl
         
@@ -110,7 +110,7 @@ jobs:
       - name: Upload manifest artifact
         uses: actions/upload-artifact@v4
         with:
-          name: image-details-openhpc-${{ matrix.label }}
+          name: image-details-${{ matrix.build.label }}
           path: |
             ./image-id.txt
             ./image-name.txt

--- a/.github/workflows/doca.yml
+++ b/.github/workflows/doca.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           {
             echo 'FAT_IMAGES<<EOF'
-            cat cat environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+            cat environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
             echo EOF
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -93,8 +93,15 @@ jobs:
             sleep 5
           done
           IMAGE_NAME=$(openstack image show -f value -c name $IMAGE_ID)
+          echo "image-name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "image-id=$IMAGE_ID" >> "$GITHUB_OUTPUT"
           echo $IMAGE_ID > image-id.txt
           echo $IMAGE_NAME > image-name.txt
+
+      - name: Make image usable for further builds
+        run: |
+          . venv/bin/activate
+          openstack image unset --property signature_verified "${{ steps.manifest.outputs.image-id }}"
 
       - name: Upload manifest artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -15,30 +15,21 @@ jobs:
   openstack:
     name: openstack-imagebuild
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os_version }}-${{ matrix.build }} # to branch/PR + OS + build
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.label }} # to branch/PR + OS
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false # allow other matrix jobs to continue even if one fails
       matrix: # build RL8, RL9
-        os_version:
-          - RL8
-          - RL9
         build:
-          - openstack.openhpc
+          - label: RL8
+            source_image_name: rocky-latest-RL8
+          - label: RL9
+            source_image_name: rocky-latest-RL9
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
       CI_CLOUD: ${{ github.event.inputs.ci_cloud }}
-      SOURCE_IMAGES_MAP: |
-        {
-          "RL8": {
-            "openstack.openhpc": "rocky-latest-RL8"
-          },
-          "RL9": {
-            "openstack.openhpc": "rocky-latest-RL9"
-          }
-        }
       ARK_PASSWORD: ${{ secrets.ARK_PASSWORD }}
 
     steps:
@@ -85,13 +76,11 @@ jobs:
 
           PACKER_LOG=1 packer build \
           -on-error=${{ vars.PACKER_ON_ERROR }} \
-          -only=${{ matrix.build }} \
           -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
-          -var "source_image_name=${{ env.SOURCE_IMAGE }}" \
+          -var "source_image_name=${{ matrix.build.source_image_name }}" \
+          -var "image_name=openhpc-${{ matrix.build.label }}" \
+          -var "inventory_groups=control,compute,login" \
           openstack.pkr.hcl
-        env:
-          PKR_VAR_os_version: ${{ matrix.os_version }}
-          SOURCE_IMAGE: ${{ fromJSON(env.SOURCE_IMAGES_MAP)[matrix.os_version][matrix.build] }}
 
       - name: Get created image names from manifest
         id: manifest
@@ -108,7 +97,7 @@ jobs:
       - name: Upload manifest artifact
         uses: actions/upload-artifact@v4
         with:
-          name: image-details-${{ matrix.build }}-${{ matrix.os_version }}
+          name: image-details-${{ matrix.build.label }}
           path: |
             ./image-id.txt
             ./image-name.txt

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -15,7 +15,7 @@ jobs:
   openstack:
     name: openstack-imagebuild
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.label }} # to branch/PR + OS
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.image_name }} # to branch/PR + OS
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -22,10 +22,12 @@ jobs:
       fail-fast: false # allow other matrix jobs to continue even if one fails
       matrix: # build RL8, RL9
         build:
-          - label: RL8
+          - image_name: openhpc-RL8
             source_image_name: rocky-latest-RL8
-          - label: RL9
+            inventory_groups: control,compute,login
+          - image_name: openhpc-RL9
             source_image_name: rocky-latest-RL9
+            inventory_groups: control,compute,login
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
@@ -78,8 +80,8 @@ jobs:
           -on-error=${{ vars.PACKER_ON_ERROR }} \
           -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
           -var "source_image_name=${{ matrix.build.source_image_name }}" \
-          -var "image_name=openhpc-${{ matrix.build.label }}" \
-          -var "inventory_groups=control,compute,login" \
+          -var "image_name=${{ matrix.build.image_name }}" \
+          -var "inventory_groups=${{ matrix.build.inventory_groups }}" \
           openstack.pkr.hcl
 
       - name: Get created image names from manifest
@@ -97,7 +99,7 @@ jobs:
       - name: Upload manifest artifact
         uses: actions/upload-artifact@v4
         with:
-          name: image-details-${{ matrix.build.label }}
+          name: image-details-${{ matrix.build.image_name }}
           path: |
             ./image-id.txt
             ./image-name.txt

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -11,32 +11,27 @@ on:
             - SMS
             - ARCUS
   schedule:
-    - cron: '0 0 * * *'  # Run at midnight
+    - cron: '0 0 * * *'  # Run at midnight on default branch
 
 jobs:
   openstack:
     name: openstack-imagebuild
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os_version }}-${{ matrix.build }} # to branch/PR + OS + build
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.label }} # to branch/PR + OS
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false # allow other matrix jobs to continue even if one fails
       matrix: # build RL8, RL9
-        os_version:
-          - RL8
-          - RL9
         build:
-          - openstack.rocky-latest
+          - label: RL8
+            source_image_name: Rocky-8-GenericCloud-Base-8.9-20231119.0.x86_64.qcow2
+          - label: RL9
+            source_image_name: Rocky-9-GenericCloud-Base-9.4-20240523.0.x86_64.qcow2
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
       CI_CLOUD: ${{ github.event.inputs.ci_cloud || vars.CI_CLOUD }}
-      SOURCE_IMAGES_MAP: |
-        {
-          "RL8": "Rocky-8-GenericCloud-Base-8.9-20231119.0.x86_64.qcow2",
-          "RL9": "Rocky-9-GenericCloud-Base-9.4-20240523.0.x86_64.qcow2"
-        }
       ARK_PASSWORD: ${{ secrets.ARK_PASSWORD }}
 
     steps:
@@ -83,14 +78,11 @@ jobs:
 
           PACKER_LOG=1 packer build \
           -on-error=${{ vars.PACKER_ON_ERROR }} \
-          -only=${{ matrix.build }} \
           -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
-          -var "source_image_name=${{ env.SOURCE_IMAGE }}" \
+          -var "source_image_name=${{ matrix.build.source_image_name }}" \
+          -var "image_name=rocky-latest-${{ matrix.build.label }}" \
+          -var "inventory_groups=update" \
           openstack.pkr.hcl
-
-        env:
-          PKR_VAR_os_version: ${{ matrix.os_version }}
-          SOURCE_IMAGE: ${{ fromJSON(env.SOURCE_IMAGES_MAP)[matrix.os_version] }}
 
       - name: Get created image names from manifest
         id: manifest
@@ -125,7 +117,7 @@ jobs:
     name: upload-nightly-targets
     needs: openstack
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os_version }}-${{ matrix.image }}-${{ matrix.target_cloud }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.label }}-${{ matrix.target_cloud }}
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     strategy:
@@ -135,18 +127,16 @@ jobs:
           - LEAFCLOUD
           - SMS
           - ARCUS
-        os_version:
-          - RL8
-          - RL9
-        image:
-          - rocky-latest
+        build:
+          - label: RL8
+          - label: RL9
         exclude:
           - target_cloud: LEAFCLOUD
     env:
       OS_CLOUD: openstack
       SOURCE_CLOUD: ${{ github.event.inputs.ci_cloud || vars.CI_CLOUD }}
       TARGET_CLOUD: ${{ matrix.target_cloud }}
-      IMAGE_NAME: "${{ matrix.image }}-${{ matrix.os_version }}"
+      IMAGE_NAME: "rocky-latest-${{ matrix.build.label }}"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -17,7 +17,7 @@ jobs:
   openstack:
     name: openstack-imagebuild
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.label }} # to branch/PR + OS
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.image_name }} # to branch/PR + OS
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     strategy:
@@ -130,15 +130,14 @@ jobs:
           - SMS
           - ARCUS
         build:
-          - label: RL8
-          - label: RL9
+          - image_name: rocky-latest-RL8
+          - image_name: rocky-latest-RL9
         exclude:
           - target_cloud: LEAFCLOUD
     env:
       OS_CLOUD: openstack
       SOURCE_CLOUD: ${{ github.event.inputs.ci_cloud || vars.CI_CLOUD }}
       TARGET_CLOUD: ${{ matrix.target_cloud }}
-      IMAGE_NAME: "rocky-latest-${{ matrix.build.label }}"
     steps:
       - uses: actions/checkout@v2
 
@@ -153,42 +152,37 @@ jobs:
           . venv/bin/activate
           pip install -U pip
           pip install $(grep -o 'python-openstackclient[><=0-9\.]*' requirements.txt)
-        shell: bash
 
       - name: Write clouds.yaml
         run: |
           mkdir -p ~/.config/openstack/
           echo "${{ secrets[format('{0}_CLOUDS_YAML', env.SOURCE_CLOUD)] }}" > ~/.config/openstack/source_clouds.yaml
           echo "${{ secrets[format('{0}_CLOUDS_YAML', env.TARGET_CLOUD)] }}" > ~/.config/openstack/target_clouds.yaml
-        shell: bash
 
       - name: Download source image
         run: |
           . venv/bin/activate
           export OS_CLIENT_CONFIG_FILE=~/.config/openstack/source_clouds.yaml
-          openstack image save --file ${{ env.IMAGE_NAME }} ${{ env.IMAGE_NAME }}
-        shell: bash
+          openstack image save --file ${{ matrix.build.image_name }} ${{ matrix.build.image_name }}
 
       - name: Upload to target cloud
         run: |
           . venv/bin/activate
           export OS_CLIENT_CONFIG_FILE=~/.config/openstack/target_clouds.yaml
 
-          openstack image create "${{ env.IMAGE_NAME }}" \
-            --file "${{ env.IMAGE_NAME }}" \
+          openstack image create "${{ matrix.build.image_name }}" \
+            --file "${{ matrix.build.image_name }}" \
             --disk-format qcow2 \
-        shell: bash
 
       - name: Delete old latest image from target cloud
         run: |
           . venv/bin/activate
           export OS_CLIENT_CONFIG_FILE=~/.config/openstack/target_clouds.yaml
 
-          IMAGE_COUNT=$(openstack image list --name ${{ env.IMAGE_NAME }} -f value -c ID | wc -l)
+          IMAGE_COUNT=$(openstack image list --name ${{ matrix.build.image_name }} -f value -c ID | wc -l)
           if [ "$IMAGE_COUNT" -gt 1 ]; then
-            OLD_IMAGE_ID=$(openstack image list --sort created_at:asc --name "${{ env.IMAGE_NAME }}"  -f value -c ID | head -n 1)
+            OLD_IMAGE_ID=$(openstack image list --sort created_at:asc --name "${{ matrix.build.image_name }}"  -f value -c ID | head -n 1)
             openstack image delete "$OLD_IMAGE_ID"
           else
             echo "Only one image exists, skipping deletion."
           fi
-        shell: bash

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -24,10 +24,12 @@ jobs:
       fail-fast: false # allow other matrix jobs to continue even if one fails
       matrix: # build RL8, RL9
         build:
-          - label: RL8
+          - image_name: rocky-latest-RL8
             source_image_name: Rocky-8-GenericCloud-Base-8.9-20231119.0.x86_64.qcow2
-          - label: RL9
+            inventory_groups: update
+          - image_name: rocky-latest-RL9
             source_image_name: Rocky-9-GenericCloud-Base-9.4-20240523.0.x86_64.qcow2
+            inventory_groups: update
     env:
       ANSIBLE_FORCE_COLOR: True
       OS_CLOUD: openstack
@@ -80,8 +82,8 @@ jobs:
           -on-error=${{ vars.PACKER_ON_ERROR }} \
           -var-file=$PKR_VAR_environment_root/${{ env.CI_CLOUD }}.pkrvars.hcl \
           -var "source_image_name=${{ matrix.build.source_image_name }}" \
-          -var "image_name=rocky-latest-${{ matrix.build.label }}" \
-          -var "inventory_groups=update" \
+          -var "image_name=${{ matrix.build.image_name }}" \
+          -var "inventory_groups=${{ matrix.build.inventory_groups }}" \
           openstack.pkr.hcl
 
       - name: Get created image names from manifest

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -119,7 +119,7 @@ jobs:
     name: upload-nightly-targets
     needs: openstack
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.label }}-${{ matrix.target_cloud }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.image_name }}-${{ matrix.target_cloud }}
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     strategy:

--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -66,3 +66,5 @@ roles/*
 !roles/lustre/**
 !roles/dnf_repos/
 !roles/dnf_repos/**
+!roles/doca/
+!roles/doca/**

--- a/ansible/cleanup.yml
+++ b/ansible/cleanup.yml
@@ -61,5 +61,10 @@
       os: "{{ ansible_distribution }} {{ ansible_distribution_version }}"
       kernel: "{{ ansible_kernel }}"
       ofed: "{{ ansible_facts.packages['mlnx-ofa_kernel'].0.version | default('-') }}"
+      doca: "{{ ansible_facts.packages[doca_profile | default('doca-ofed') ].0.version | default('-') }}"
       cuda:  "{{ ansible_facts.packages['cuda'].0.version | default('-') }}"
       slurm-ohpc: "{{ ansible_facts.packages['slurm-ohpc'].0.version | default('-') }}"
+
+- name: Show image summary
+  debug:
+    var: image_info

--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -6,6 +6,9 @@
   tasks:
     - name: Report hostname (= final image name)
       command: hostname
+    - name: Report inventory groups
+      debug:
+        var: group_names
 
 - name: Run pre.yml hook
   vars:
@@ -203,9 +206,10 @@
   become: yes
   gather_facts: yes
   tasks:
-    - name: Install Mellanox DOCA
-      include_role:
+    - name: Install NVIDIA DOCA
+      import_role:
         name: doca
+    - meta: end_here
 
 - name: Run post.yml hook
   vars:

--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -199,6 +199,14 @@
         name: cloudalchemy.grafana
         tasks_from: install.yml
 
+- hosts: doca
+  become: yes
+  gather_facts: yes
+  tasks:
+    - name: Install Mellanox DOCA
+      include_role:
+        name: doca
+
 - name: Run post.yml hook
   vars:
     appliances_environment_root: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}"

--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -209,7 +209,6 @@
     - name: Install NVIDIA DOCA
       import_role:
         name: doca
-    - meta: end_here
 
 - name: Run post.yml hook
   vars:

--- a/ansible/roles/doca/README.md
+++ b/ansible/roles/doca/README.md
@@ -1,0 +1,12 @@
+# doca
+
+Install [NVIDIA DOCA](https://docs.nvidia.com/doca/sdk/index.html).
+
+This role is not idempotent and is only intended to be run during an image build. It builds DOCA kernel modules to match the installed kernel and then installs these
+plus the selected DOCA packages.
+
+## Role Variables
+
+- `doca_version`: Optional. String giving doca version.
+- `doca_profile`: Optional. Name of [profile](https://docs.nvidia.com/doca/sdk/nvidia+doca+profiles/index.html) defining subset of DOCA to install. Default is `doca-ofed`.
+- `doca_repo_url`: Optional. URL of DOCA repository. Default is appropriate upstream public repository for DOCA version, distro version and architecture.

--- a/ansible/roles/doca/defaults/main.yml
+++ b/ansible/roles/doca/defaults/main.yml
@@ -1,0 +1,3 @@
+doca_version: '2.9.1' # 2.9 is LTS, last to support ConnectX-4, 3 years for bug fixes and CVE updates
+doca_profile: doca-ofed
+doca_repo_url: "https://linux.mellanox.com/public/repo/doca/{{ doca_version }}/rhel{{ ansible_distribution_version }}/{{ ansible_architecture }}/"

--- a/ansible/roles/doca/tasks/install-kernel-devel.yml
+++ b/ansible/roles/doca/tasks/install-kernel-devel.yml
@@ -1,0 +1,24 @@
+- name: Get installed kernels
+  command: dnf list --installed kernel
+  register: _ofed_dnf_kernels
+  changed_when: false
+
+- name: Determine running kernel
+  command: uname -r # e.g. 4.18.0-513.18.1.el8_9.x86_64
+  register: _ofed_loaded_kernel
+  changed_when: false
+
+- name: Check current kernel is newest installed
+  assert:
+    that: _ofed_kernel_current == _ofed_dnf_kernels_newest
+    fail_msg: "Kernel {{ _ofed_loaded_kernel.stdout }} is loaded but newer {{ _ofed_dnf_kernels_newest }} is installed: consider rebooting?"
+  vars:
+    _ofed_kernel_current: >-
+      {{ _ofed_loaded_kernel.stdout | regex_replace('\.(?:.(?!\.))+$', '') | regex_replace('\.(?:.(?!\.))+$', '') }}
+    _ofed_dnf_kernels_newest: >-
+      {{ _ofed_dnf_kernels.stdout_lines[1:] | map('split') | map(attribute=1) | map('regex_replace', '\.(?:.(?!\.))+$', '') | community.general.version_sort | last }}
+    # dnf line format e.g. "kernel.x86_64  4.18.0-513.18.1.el8_9   @baseos  "
+
+- name: Install matching kernel-devel package
+  dnf:
+    name: "kernel-devel-{{ _ofed_loaded_kernel.stdout | trim }}"

--- a/ansible/roles/doca/tasks/install.yml
+++ b/ansible/roles/doca/tasks/install.yml
@@ -1,0 +1,53 @@
+- import_tasks: install-kernel-devel.yml
+
+- name: Install DOCA repo
+  ansible.builtin.yum_repository:
+    name: doca
+    file: doca
+    description: DOCA Online Repo
+    baseurl: "{{ doca_repo_url }}"
+    enabled: true
+    gpgcheck: false
+
+- name: Install doca-extra package
+  ansible.builtin.dnf:
+    name: doca-extra
+
+- name: Build DOCA kernel modules
+  ansible.builtin.shell:
+    cmd: /opt/mellanox/doca/tools/doca-kernel-support
+  register: _doca_kernel_build
+
+
+- name: Find generated doca-kernel-repo
+  ansible.builtin.shell: 'find /tmp/DOCA.* -name doca-kernel-repo-*'
+  register: _doca_kernel_repo # e.g. /tmp/DOCA.WVMchs2QWo/doca-kernel-repo-24.10.1.1.4.0-1.kver.5.14.0.427.31.1.el9.4.x86.64.x86_64.rpm
+  changed_when: false
+
+- name: Create dnf cache
+  ansible.builtin.command: dnf makecache
+
+- name: Install DOCA repository package
+  ansible.builtin.dnf:
+    name: "{{ _doca_kernel_repo.stdout }}"
+    disable_gpg_check: true
+
+- name: Install DOCA packages
+  ansible.builtin.dnf:
+    name: "{{ doca_profile }}"
+
+- name: Cleanup DOCA build directories
+  ansible.builtin.file:
+    state: absent
+    path: "{{ (_doca_kernel_repo.stdout | split('/'))[:2] | join('/') }}"
+
+- name: Update initramfs
+  ansible.builtin.command:
+    cmd: dracut -f --tmpdir /var/tmp
+  environment:
+     TMPDIR: /var/tmp
+  register: _doca_dracut
+  failed_when: _doca_dracut.stderr != '' # appears rc is always 0
+
+- name: Load the new driver
+  ansible.builtin.command: /etc/init.d/openibd restart

--- a/ansible/roles/doca/tasks/main.yml
+++ b/ansible/roles/doca/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_tasks: install.yml

--- a/environments/.stackhpc/inventory/extra_groups
+++ b/environments/.stackhpc/inventory/extra_groups
@@ -30,4 +30,4 @@ compute
 
 [squid:children]
 # Install squid into fat image
-builder
+control

--- a/environments/.stackhpc/inventory/extra_groups
+++ b/environments/.stackhpc/inventory/extra_groups
@@ -30,4 +30,4 @@ compute
 
 [squid:children]
 # Install squid into fat image
-control
+builder

--- a/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-241203-1659-b0558b95",
-        "RL9": "openhpc-RL9-241203-1659-b0558b95"
+        "RL8": "openhpc-RL8-241211-1322-ded60c2c",
+        "RL9": "openhpc-RL9-241211-1322-ded60c2c"
     }
 }

--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -132,11 +132,11 @@ variable "metadata" {
   default = {}
 }
 
-variable "groups" {
+variable "inventory_groups" {
   type = string
-  description = "Comma-separated list of additional inventory groups (other than 'builder') to add build VM to"
-  default = "" # this is 
-  # rocky-latest = ["update"]
+  description = "Comma-separated list of additional inventory groups (other than 'builder') to add build VM to. Default is none."
+  default = ""
+  # rocky-latest = ["update"] # TODO: fix this in workflow
   # openhpc = ["control", "compute", "login"]
 }
 
@@ -206,7 +206,7 @@ build {
 
   provisioner "ansible" {
     playbook_file = "${var.repo_root}/ansible/fatimage.yml"
-    groups = concat(["builder"], split(",", var.groups))
+    groups = concat(["builder"], var.inventory_groups == "" ? [] : split(",", var.inventory_groups))
     keep_inventory_file = true # for debugging
     use_proxy = false # see https://www.packer.io/docs/provisioners/ansible#troubleshooting
     extra_arguments = [

--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -185,22 +185,9 @@ source "openstack" "openhpc" {
 
 build {
 
-  # latest nightly image:
-  # source "source.openstack.openhpc" {
-  #   name = "rocky-latest"
-  #   image_name = "${source.name}-${var.os_version}"
-  # }
-
-  # fat image:
   source "source.openstack.openhpc" {
     image_name = "${var.image_name}${local.image_name_version}"
   }
-
-  # # Extended site-specific image, built on fat image:
-  # source "source.openstack.openhpc" {
-  #   name = "openhpc-extra"
-  #   image_name = "openhpc-${var.extra_build_image_name}-${var.os_version}-${local.timestamp}-${substr(local.git_commit, 0, 8)}"
-  # }
 
   provisioner "ansible" {
     playbook_file = "${var.repo_root}/ansible/fatimage.yml"

--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -136,8 +136,6 @@ variable "inventory_groups" {
   type = string
   description = "Comma-separated list of additional inventory groups (other than 'builder') to add build VM to. Default is none."
   default = ""
-  # rocky-latest = ["update"] # TODO: fix this in workflow
-  # openhpc = ["control", "compute", "login"]
 }
 
 variable "image_name" {


### PR DESCRIPTION
- [x] Adds new `doca` role to install NVIDIA DOCA:
  - This is only run during image builds where `inventory_groups` include `doca`.
  - It may be run on an existing "fat image" e.g. as part of an "extra" build.
  - It rebuilds the DOCA kernel packages to match the installed kernel.

  This role should be preferred over the `ofed` role which may be deprecated at a later date.
  **NB**: This uses doca packages from upstream repos, not StackHPC's ark.

- [x] Adds a workflow to test the DOCA build during CI on the current RL8/RL9 fat images.
  Unless run manually, the built image is deleted on completion.
  **NB:** the resulting DOCA image is *not*  tested by CI.

- [x] Simplifies the configuration for packer builds:
  - Only a single build is now defined. Control of behaviour is via variables, rather than by selecting a build.
  - All variables are now simple (instead of some being maps keyed by the OS version).
  - The inventory groups to add the build VM is now specified via `inventory_groups`, taking a comma-separated list (instead `groups` which took a map).
- [x] All image build workflows have been adjusted to use the new packer configuration

The following manually-triggered checks related to packer configuration changes have been completed:
- [x] Check build works with empty groups
- [x] Check fatimage workflow works
- [x] Check nightly workflow works

Ticket: PLATFORM-537