### PR TITLE
Release train support for Rocky 8.10

### DIFF
--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -23,8 +23,8 @@ jobs:
       matrix: # build RL8, RL9
         build:
           - image_name: openhpc-RL8
-            source_image_name: rocky-latest-RL8
-            inventory_groups: control,compute,login
+            source_image_name: Rocky-8-GenericCloud-Base-8.10-20240528.0.x86_64.qcow2
+            inventory_groups: control,compute,login,update
           - image_name: openhpc-RL9
             source_image_name: rocky-latest-RL9
             inventory_groups: control,compute,login

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: # build RL8, RL9
         build:
           - image_name: rocky-latest-RL8
-            source_image_name: Rocky-8-GenericCloud-Base-8.9-20231119.0.x86_64.qcow2
+            source_image_name: Rocky-8-GenericCloud-Base-8.10-20240528.0.x86_64.qcow2
             inventory_groups: update
           - image_name: rocky-latest-RL9
             source_image_name: Rocky-9-GenericCloud-Base-9.4-20240523.0.x86_64.qcow2

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -122,7 +122,6 @@
     ansible.builtin.include_role:
       name: dnf_repos
       tasks_from: set_repos.yml
-    when: ansible_distribution_major_version == "9" #TODO update role once RL8 config decided
 
 # --- tasks after here require access to package repos ---
 - hosts: squid

--- a/ansible/disable-repos.yml
+++ b/ansible/disable-repos.yml
@@ -5,4 +5,3 @@
       ansible.builtin.include_role:
         name: dnf_repos
         tasks_from: disable_repos.yml
-      when: ansible_distribution_major_version == "9" #TODO update role once RL8 config decided

--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -220,7 +220,7 @@
       import_role:
         name: doca
 
-- import_playbook: disable_repos.yml
+- import_playbook: disable-repos.yml
 
 - name: Run post.yml hook
   vars:

--- a/ansible/roles/dnf_repos/defaults/main.yml
+++ b/ansible/roles/dnf_repos/defaults/main.yml
@@ -4,18 +4,32 @@ dnf_repos_epel_prefix: "epel/{{ ansible_distribution_major_version }}"
 dnf_repos_username: "{{ omit }}"
 dnf_repos_password: "{{ omit }}"
 
+dnf_repos_filenames:
+  '8':
+    baseos: 'Rocky-BaseOS'
+    appstream: 'Rocky-AppStream'
+    crb: 'Rocky-PowerTools'
+    extras: 'Rocky-Extras'
+  '9':
+    baseos: 'rocky'
+    appstream: 'rocky'
+    crb: 'rocky'
+    extras: 'rocky-extras'
+
+dnf_repos_version_filenames: "{{ dnf_repos_filenames[ansible_distribution_major_version] }}"
+
 # epel installed separately
 dnf_repos_repolist:
-- file: rocky
+- file: "{{ dnf_repos_version_filenames.baseos }}"
   name: baseos
   base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/BaseOS/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.baseos[ansible_distribution_version] }}"
-- file: rocky
+- file: "{{ dnf_repos_version_filenames.appstream }}"
   name: appstream
   base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/AppStream/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.appstream[ansible_distribution_version] }}"
-- file: rocky
-  name: crb
+- file: "{{ dnf_repos_version_filenames.crb }}"
+  name: "{{ 'powertools' if ansible_distribution_major_version == '8' else 'crb' }}"
   base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/CRB/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.crb[ansible_distribution_version] }}"
-- file: rocky-extras
+- file: "{{ dnf_repos_version_filenames.extras }}"
   name: extras
   base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/extras/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.extras[ansible_distribution_version] }}"
 

--- a/ansible/roles/dnf_repos/defaults/main.yml
+++ b/ansible/roles/dnf_repos/defaults/main.yml
@@ -28,7 +28,7 @@ dnf_repos_repolist:
   base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/AppStream/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.appstream[ansible_distribution_version] }}"
 - file: "{{ dnf_repos_version_filenames.crb }}"
   name: "{{ 'powertools' if ansible_distribution_major_version == '8' else 'crb' }}"
-  base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/CRB/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.crb[ansible_distribution_version] }}"
+  base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/{{ 'PowerTools' if ansible_distribution_major_version == '8' else 'CRB' }}/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.crb[ansible_distribution_version] }}"
 - file: "{{ dnf_repos_version_filenames.extras }}"
   name: extras
   base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/extras/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.extras[ansible_distribution_version] }}"

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -8,6 +8,7 @@
     description: "{{ item.name }}"
     username: "{{ dnf_repos_username }}"
     password: "{{ dnf_repos_password }}"
+    gpgcheck: false
   loop: "{{ dnf_repos_repolist }}"
 
 - name: Install epel-release

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -27,7 +27,7 @@
 - import_playbook: slurm.yml
 - import_playbook: portal.yml
 - import_playbook: monitoring.yml
-- import_playbook: disable_repos.yml
+- import_playbook: disable-repos.yml
 
 - name: Run post.yml hook
   vars:

--- a/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-241220-1131-a2dde143",
-        "RL9": "openhpc-RL9-241220-1131-a2dde143"
+        "RL8": "openhpc-RL8-250102-1135-8c98e169",
+        "RL9": "openhpc-RL9-250102-1135-8c98e169"
     }
 }

--- a/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/terraform/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-241216-1146-18b220e1",
-        "RL9": "openhpc-RL9-241216-1146-18b220e1"
+        "RL8": "openhpc-RL8-241218-0900-a99d8be6",
+        "RL9": "openhpc-RL9-241218-0859-a99d8be6"
     }
 }

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -85,11 +85,16 @@ appliances_local_users: "{{ appliances_local_users_default + appliances_local_us
 appliances_repo_timestamps:
   baseos:
     '9.4': 20240816T002610
+    '8.10': 20241217T123729
   appstream:
     '9.4': 20240816T002610
+    '8.10': 20241217T123729
   crb:
     '9.4': 20240816T002610
+    '8.10': 20241217T123729
   extras:
     '9.4': 20240816T002610
+    '8.10': 20241217T123729
   epel:
     '9': 20240902T080424
+    '8': 20241216T235733


### PR DESCRIPTION
Rocky 8.10 is on Ark as of https://github.com/stackhpc/stackhpc-release-train/pull/361 so enabled dnf roles for 8.10 and added timestamps