### PR TITLE
Refactor pulp/dnf roles to avoid having to redefine Ark URLs

### DIFF
--- a/ansible/filter_plugins/utils.py
+++ b/ansible/filter_plugins/utils.py
@@ -49,7 +49,9 @@ def to_ood_regex(items):
     return '|'.join(r)
 
 def appliances_repo_to_subpath(repo_entry):
-    return repo_entry['path']+'/'+repo_entry['timestamp']
+    """ Take an element from appliances_pulp_repos and convert it to a pulp path. This assumes that the remote and local pulp structures are the same
+    """
+    return repo_entry['path'] + '/' + repo_entry['timestamp']
 
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''

--- a/ansible/filter_plugins/utils.py
+++ b/ansible/filter_plugins/utils.py
@@ -49,7 +49,7 @@ def to_ood_regex(items):
     return '|'.join(r)
 
 def appliances_repo_to_subpath(repo_entry):
-    return repo_entry.path+'/'+repo_entry.timestamp
+    return repo_entry['path']+'/'+repo_entry['timestamp']
 
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
@@ -66,5 +66,5 @@ class FilterModule(object):
             'exists': exists,
             'warn': self.warn,
             'to_ood_regex': to_ood_regex,
-            'appliance_repo_to_subpath': appliances_repo_to_subpath
+            'appliances_repo_to_subpath': appliances_repo_to_subpath
         }

--- a/ansible/filter_plugins/utils.py
+++ b/ansible/filter_plugins/utils.py
@@ -48,6 +48,9 @@ def to_ood_regex(items):
     r = ['(%s)' % v for v in r]
     return '|'.join(r)
 
+def appliances_repo_to_subpath(repo_entry):
+    return repo_entry.path+'/'+repo_entry.timestamp
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -63,4 +66,5 @@ class FilterModule(object):
             'exists': exists,
             'warn': self.warn,
             'to_ood_regex': to_ood_regex,
+            'appliance_repo_to_subpath': appliances_repo_to_subpath
         }

--- a/ansible/roles/dnf_repos/defaults/main.yml
+++ b/ansible/roles/dnf_repos/defaults/main.yml
@@ -1,6 +1,4 @@
 dnf_repos_pulp_content_url: "{{ appliances_pulp_url }}/pulp/content"
-dnf_repos_rocky_prefix: "{{ ansible_distribution | lower }}/{{ ansible_distribution_version }}"
-dnf_repos_epel_prefix: "epel/{{ ansible_distribution_major_version }}"
 dnf_repos_username: "{{ omit }}"
 dnf_repos_password: "{{ omit }}"
 
@@ -8,16 +6,16 @@ dnf_repos_password: "{{ omit }}"
 dnf_repos_repolist:
 - file: rocky
   name: baseos
-  base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/BaseOS/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.baseos[ansible_distribution_version] }}"
+  subpath: "{{ appliances_pulp_repos.baseos[ansible_distribution_version] | appliances_repo_to_subpath }}"
 - file: rocky
   name: appstream
-  base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/AppStream/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.appstream[ansible_distribution_version] }}"
+  subpath: "{{ appliances_pulp_repos.appstream[ansible_distribution_version] | appliances_repo_to_subpath }}"
 - file: rocky
   name: crb
-  base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/CRB/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.crb[ansible_distribution_version] }}"
+  subpath: "{{ appliances_pulp_repos.crb[ansible_distribution_version] | appliances_repo_to_subpath }}"
 - file: rocky-extras
   name: extras
-  base_url: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_rocky_prefix }}/extras/{{ ansible_architecture }}/os/{{ appliances_repo_timestamps.extras[ansible_distribution_version] }}"
+  subpath: "{{ appliances_pulp_repos.extras[ansible_distribution_version] | appliances_repo_to_subpath }}"
 
-dnf_repos_epel_baseurl: "{{ dnf_repos_pulp_content_url }}/epel/{{ ansible_distribution_major_version }}/Everything/{{ ansible_architecture }}/{{ appliances_repo_timestamps.epel[ansible_distribution_major_version] }}"
+dnf_repos_epel_subpath: "{{ appliances_pulp_repos.epel[ansible_distribution_major_version] | appliances_repo_to_subpath }}"
 dnf_repos_epel_description: "epel"

--- a/ansible/roles/dnf_repos/defaults/main.yml
+++ b/ansible/roles/dnf_repos/defaults/main.yml
@@ -6,16 +6,16 @@ dnf_repos_password: "{{ omit }}"
 dnf_repos_repolist:
 - file: rocky
   name: baseos
-  subpath: "{{ appliances_pulp_repos.baseos[ansible_distribution_version] | appliances_repo_to_subpath }}"
+  base_url: "{{ dnf_repos_pulp_content_url }}/{{ appliances_pulp_repos.baseos[ansible_distribution_version] | appliances_repo_to_subpath }}"
 - file: rocky
   name: appstream
-  subpath: "{{ appliances_pulp_repos.appstream[ansible_distribution_version] | appliances_repo_to_subpath }}"
+  base_url: "{{ dnf_repos_pulp_content_url }}/{{ appliances_pulp_repos.appstream[ansible_distribution_version] | appliances_repo_to_subpath }}"
 - file: rocky
   name: crb
-  subpath: "{{ appliances_pulp_repos.crb[ansible_distribution_version] | appliances_repo_to_subpath }}"
+  base_url: "{{ dnf_repos_pulp_content_url }}/{{ appliances_pulp_repos.crb[ansible_distribution_version] | appliances_repo_to_subpath }}"
 - file: rocky-extras
   name: extras
-  subpath: "{{ appliances_pulp_repos.extras[ansible_distribution_version] | appliances_repo_to_subpath }}"
+  base_url: "{{ dnf_repos_pulp_content_url }}/{{ appliances_pulp_repos.extras[ansible_distribution_version] | appliances_repo_to_subpath }}"
 
-dnf_repos_epel_subpath: "{{ appliances_pulp_repos.epel[ansible_distribution_major_version] | appliances_repo_to_subpath }}"
+dnf_repos_epel_baseurl: "{{ dnf_repos_pulp_content_url }}/{{ appliances_pulp_repos.epel[ansible_distribution_major_version] | appliances_repo_to_subpath }}"
 dnf_repos_epel_description: "epel"

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -4,7 +4,7 @@
   ansible.builtin.yum_repository:
     file: "{{ item.file }}"
     name: "{{ item.name }}"
-    baseurl: "{{ dnf_repos_pulp_content_url }}/{{ item.subpath }}"
+    baseurl: "{{ item.base_url }}"
     description: "{{ item.name }}"
     username: "{{ dnf_repos_username }}"
     password: "{{ dnf_repos_password }}"
@@ -21,6 +21,6 @@
     file: epel
     description: "{{ dnf_repos_epel_description }}"
     gpgcheck: false
-    baseurl: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_epel_subpath }}"
+    baseurl: "{{ dnf_repos_epel_baseurl }}"
     username: "{{ dnf_repos_username }}"
     password: "{{ dnf_repos_password }}"

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -4,7 +4,7 @@
   ansible.builtin.yum_repository:
     file: "{{ item.file }}"
     name: "{{ item.name }}"
-    baseurl: "{{ item.base_url }}"
+    baseurl: "{{ dnf_repos_pulp_content_url }}/{{ item.subpath }}"
     description: "{{ item.name }}"
     username: "{{ dnf_repos_username }}"
     password: "{{ dnf_repos_password }}"
@@ -21,6 +21,6 @@
     file: epel
     description: "{{ dnf_repos_epel_description }}"
     gpgcheck: false
-    baseurl: "{{ dnf_repos_epel_baseurl }}"
+    baseurl: "{{ dnf_repos_pulp_content_url }}/{{ dnf_repos_epel_subpath }}"
     username: "{{ dnf_repos_username }}"
     password: "{{ dnf_repos_password }}"

--- a/ansible/roles/pulp_site/defaults/main.yml
+++ b/ansible/roles/pulp_site/defaults/main.yml
@@ -3,28 +3,25 @@ pulp_site_port: 8080
 pulp_site_username: admin # shouldn't be changed
 pulp_site_password: "{{ vault_pulp_admin_password }}"
 pulp_site_upstream_content_url: https://ark.stackhpc.com/pulp/content
-_pulp_site_rocky_prefix: "{{ pulp_site_target_distribution }}/{{ pulp_site_target_distribution_version }}"
 pulp_site_default_upstream_suffix: "{{ pulp_site_target_arch }}/os"
 pulp_site_validate_certs: false
 pulp_site_install_dir: '/home/rocky/pulp'
 pulp_site_selinux_suffix: "{{ ':Z' if ansible_selinux.status == 'enabled' else '' }}"
 pulp_site_target_facts: "{{ hostvars[groups['builder'][0]]['ansible_facts'] }}"
-pulp_site_target_arch: "{{ pulp_site_target_facts['architecture'] }}"
-pulp_site_target_distribution: "{{ pulp_site_target_facts['distribution'] | lower }}"
 pulp_site_target_distribution_version: "{{ pulp_site_target_facts['distribution_version'] }}"
 pulp_site_target_distribution_version_major: "{{ pulp_site_target_facts['distribution_major_version'] }}"
 
 pulp_site_rpm_info:
-- name: "baseos-{{ pulp_site_target_distribution_version }}-{{ appliances_repo_timestamps.baseos[pulp_site_target_distribution_version] }}"
-  subpath: "{{ _pulp_site_rocky_prefix }}/BaseOS/{{ pulp_site_default_upstream_suffix }}/{{ appliances_repo_timestamps.baseos[pulp_site_target_distribution_version] }}"
-- name: "appstream-{{ pulp_site_target_distribution_version }}-{{ appliances_repo_timestamps.appstream[pulp_site_target_distribution_version] }}"
-  subpath: "{{ _pulp_site_rocky_prefix }}/AppStream/{{ pulp_site_default_upstream_suffix }}/{{ appliances_repo_timestamps.appstream[pulp_site_target_distribution_version] }}"
-- name: "crb-{{ pulp_site_target_distribution_version }}-{{ appliances_repo_timestamps.crb[pulp_site_target_distribution_version] }}"
-  subpath: "{{ _pulp_site_rocky_prefix }}/{{ 'PowerTools' if pulp_site_target_distribution_version_major == '8' else 'CRB' }}/{{ pulp_site_default_upstream_suffix }}/{{ appliances_repo_timestamps.crb[pulp_site_target_distribution_version] }}"
-- name: "extras-{{ pulp_site_target_distribution_version }}-{{ appliances_repo_timestamps.extras[pulp_site_target_distribution_version] }}"
-  subpath: "{{ _pulp_site_rocky_prefix }}/extras/{{ pulp_site_default_upstream_suffix }}/{{ appliances_repo_timestamps.extras[pulp_site_target_distribution_version] }}"
-- name: "epel-{{ pulp_site_target_distribution_version_major }}-{{ appliances_repo_timestamps.epel[pulp_site_target_distribution_version_major] }}"
-  subpath: "epel/{{ pulp_site_target_distribution_version_major }}/Everything/{{ pulp_site_target_arch }}/{{ appliances_repo_timestamps.epel[pulp_site_target_distribution_version_major] }}"
+- name: "baseos-{{ pulp_site_target_distribution_version }}-{{ appliances_pulp_repos.baseos[pulp_site_target_distribution_version].timestamp }}"
+  subpath: "{{ appliances_pulp_repos.baseos[pulp_site_target_distribution_version] | appliances_repo_to_subpath }}"
+- name: "appstream-{{ pulp_site_target_distribution_version }}-{{ appliances_pulp_repos.appstream[pulp_site_target_distribution_version].timestamp }}"
+  subpath: "{{ appliances_pulp_repos.appstream[pulp_site_target_distribution_version] | appliances_repo_to_subpath }}"
+- name: "crb-{{ pulp_site_target_distribution_version }}-{{ appliances_pulp_repos.crb[pulp_site_target_distribution_version].timestamp }}"
+  subpath: "{{ appliances_pulp_repos.crb[pulp_site_target_distribution_version] | appliances_repo_to_subpath }}"
+- name: "extras-{{ pulp_site_target_distribution_version }}-{{ appliances_pulp_repos.extras[pulp_site_target_distribution_version].timestamp }}"
+  subpath: "{{ appliances_pulp_repos.extras[pulp_site_target_distribution_version] | appliances_repo_to_subpath }}"
+- name: "epel-{{ pulp_site_target_distribution_version_major }}-{{ appliances_pulp_repos.epel[pulp_site_target_distribution_version_major].timestamp }}"
+  subpath: "{{ appliances_pulp_repos.epel[pulp_site_target_distribution_version_major] | appliances_repo_to_subpath }}"
 
 pulp_site_rpm_repo_defaults:
   remote_username: "{{ pulp_site_upstream_username }}"

--- a/ansible/roles/pulp_site/defaults/main.yml
+++ b/ansible/roles/pulp_site/defaults/main.yml
@@ -7,7 +7,7 @@ pulp_site_default_upstream_suffix: "{{ pulp_site_target_arch }}/os"
 pulp_site_validate_certs: false
 pulp_site_install_dir: '/home/rocky/pulp'
 pulp_site_selinux_suffix: "{{ ':Z' if ansible_selinux.status == 'enabled' else '' }}"
-pulp_site_target_facts: "{{ hostvars[groups['builder'][0]]['ansible_facts'] }}"
+pulp_site_target_facts: "{{ hostvars[groups['pulp'][0]]['ansible_facts'] }}"
 pulp_site_target_distribution_version: "{{ pulp_site_target_facts['distribution_version'] }}"
 pulp_site_target_distribution_version_major: "{{ pulp_site_target_facts['distribution_major_version'] }}"
 

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -82,7 +82,7 @@ appliances_local_users: "{{ appliances_local_users_default + appliances_local_us
 
 ###########################################################################################
 
-appliances_pulp_repositories:
+appliances_pulp_repos:
   baseos:
     '9.4':
       timestamp: 20241115T011711

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -82,14 +82,24 @@ appliances_local_users: "{{ appliances_local_users_default + appliances_local_us
 
 ###########################################################################################
 
-appliances_repo_timestamps:
+appliances_pulp_repositories:
   baseos:
-    '9.4': 20241115T011711
+    '9.4':
+      timestamp: 20241115T011711
+      path: rocky/9.4/BaseOS/x86_64/os
   appstream:
-    '9.4': 20241112T003151
+    '9.4':
+      timestamp: 20241112T003151
+      path: rocky/9.4/AppStream/x86_64/os
   crb:
-    '9.4': 20241115T003133
+    '9.4':
+      timestamp: 20241115T003133
+      path: rocky/9.4/CRB/x86_64/os
   extras:
-    '9.4': 20241118T002802
+    '9.4':
+      timestamp: 20241118T002802
+      path: rocky/9.4/extras/x86_64/os
   epel:
-    '9': 20241213T010218
+    '9':
+      timestamp: 20241213T010218
+      path: epel/9/Everything/x86_64


### PR DESCRIPTION
Pulp URL subpaths now keyed by version in `appliances_pulp_repos`

Tested locally