### PR TITLE
Fix python/ansible/pulp squeezer versions for RL8 deploy hosts

### DIFF
--- a/ansible/filter_plugins/utils.py
+++ b/ansible/filter_plugins/utils.py
@@ -41,6 +41,9 @@ def to_ood_regex(items):
         eg {{ [compute-001, compute-002, control] | to_regex }} -> '(compute-\d+)|(control)'
     """
     
+    # NB: for python3.12+ the \d in this function & docstring
+    # need to be raw strings. See https://docs.python.org/3/reference/lexical_analysis.html
+
     # There's a python bug which means re.sub() can't use '\d' in the replacement so
     # have to do replacement in two stages:
     r = [re.sub(r"\d+", 'XBACKSLASHX', v) for v in items]

--- a/dev/setup-env.sh
+++ b/dev/setup-env.sh
@@ -17,6 +17,7 @@ PYTHON_VERSION=""
 if [[ "$OS" == "ubuntu" && "$MAJOR_VERSION" == "22" ]]; then
     PYTHON_VERSION="/usr/bin/python3.10"
 elif [[ "$OS" == "rocky" && "$MAJOR_VERSION" == "8" ]]; then
+    # python3.9+ doesn't have selinux bindings
     PYTHON_VERSION="/usr/bin/python3.8" # use `sudo yum install python38` on Rocky Linux 8 to install this
 elif [[ "$OS" == "rocky" && "$MAJOR_VERSION" == "9" ]]; then
     PYTHON_VERSION="/usr/bin/python3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ cookiecutter
 selinux # this is a shim to avoid having to use --system-site-packages, you still need sudo yum install libselinux-python3
 netaddr
 matplotlib
-pulp-cli==0.29.2
+pulp-cli==0.23.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==8.0.0
+ansible==6.7.0 # cloudalchemy.prometheus uses ansible.builtin.include, removed in ansible-core==2.16 => ansible==9
 openstacksdk
 python-openstackclient==6.6.1 # v7.0.0 has a bug re. rebuild
 python-manilaclient

--- a/requirements.yml
+++ b/requirements.yml
@@ -51,4 +51,8 @@ collections:
     version: 0.4.0
   - name: stackhpc.pulp
     version: 0.5.5
+  # stackhpc.pulp has pulp.squeezer as dependency, any version, but latest
+  # requires newer ansible than can install
+  - name: pulp.squeezer
+    version: 0.0.15
 ...

--- a/requirements.yml
+++ b/requirements.yml
@@ -49,10 +49,10 @@ collections:
   - name: https://github.com/azimuth-cloud/ansible-collection-image-utils
     type: git
     version: 0.4.0
-  - name: stackhpc.pulp
-    version: 0.5.5
   # stackhpc.pulp has pulp.squeezer as dependency, any version, but latest
   # requires newer ansible than can install
   - name: pulp.squeezer
     version: 0.0.15
+  - name: stackhpc.pulp
+    version: 0.5.5
 ...


### PR DESCRIPTION
See comments in commits for this PR - are limited by pulp squeezer, selinux, cloudalchemy.prometheus dependencies