### PR TITLE
Fix volume_backed_instances not working for compute nodes

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute.tf
@@ -3,16 +3,22 @@ module "compute" {
 
   for_each = var.compute
 
+  # must be set for group:
   nodes = each.value.nodes
+  flavor = each.value.flavor
+
   cluster_name = var.cluster_name
   cluster_domain_suffix = var.cluster_domain_suffix
   cluster_net_id = data.openstack_networking_network_v2.cluster_net.id
   cluster_subnet_id = data.openstack_networking_subnet_v2.cluster_subnet.id
 
-  flavor = each.value.flavor
+  # can be set for group, defaults to top-level value:
   image_id = lookup(each.value, "image_id", var.cluster_image_id)
   vnic_type = lookup(each.value, "vnic_type", var.vnic_type)
   vnic_profile = lookup(each.value, "vnic_profile", var.vnic_profile)
+  volume_backed_instances = lookup(each.value, "volume_backed_instances", var.volume_backed_instances)
+  root_volume_size = lookup(each.value, "root_volume_size", var.root_volume_size)
+
   key_pair = var.key_pair
   environment_root = var.environment_root
   k3s_token = var.k3s_token

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
@@ -52,6 +52,8 @@ variable "compute" {
             image_id: Overrides variable cluster_image_id
             vnic_type: Overrides variable vnic_type
             vnic_profile: Overrides variable vnic_profile
+            volume_backed_instances: Overrides variable volume_backed_instances
+            root_volume_size: Overrides variable root_volume_size
     EOF
 }
 


### PR DESCRIPTION
Relevant variables were not passed in to compute module.

Tested:
- setting volume_backed_instances and root_volume_size just for one compute group
- setting volume_backed_instances at top-level and non-default root_volume_size for one compute group

Note CI does not test this so can be merged without that passing.