### PR TITLE
Support additional volumes on compute nodes

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute.tf
@@ -18,6 +18,7 @@ module "compute" {
   vnic_profile = lookup(each.value, "vnic_profile", var.vnic_profile)
   volume_backed_instances = lookup(each.value, "volume_backed_instances", var.volume_backed_instances)
   root_volume_size = lookup(each.value, "root_volume_size", var.root_volume_size)
+  extra_volumes = lookup(each.value, "extra_volumes", {})
 
   key_pair = var.key_pair
   environment_root = var.environment_root

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/nodes.tf
@@ -1,3 +1,33 @@
+locals {
+  all_compute_volumes = {for v in setproduct(var.nodes, keys(var.extra_volumes)): "${v[0]}-${v[1]}" => {"node" = v[0], "volume" = v[1]}}
+  # e.g. with
+  # var.nodes = ["compute-0", "compute-1"]
+  # var.extra_volumes = {
+  #     "vol-a" = {size = 10},
+  #     "vol-b" = {size = 20}
+  # }
+  # this is a mapping with
+  # keys "compute-0-vol-a", "compute-0-vol-b" ...
+  # values which are a mapping e.g. {"node"="compute-0", "volume"="vol-a"}
+}
+
+resource "openstack_blockstorage_volume_v3" "compute" {
+
+    for_each = local.all_compute_volumes
+
+    name = "${var.cluster_name}-${each.key}"
+    description = "Compute node ${each.value.node} volume ${each.value.volume}"
+    size = var.extra_volumes[each.value.volume].size
+}
+
+resource "openstack_compute_volume_attach_v2" "compute" {
+
+  for_each = local.all_compute_volumes
+
+  instance_id = openstack_compute_instance_v2.compute["${each.value.node}"].id
+  volume_id  = openstack_blockstorage_volume_v3.compute["${each.key}"].id
+}
+
 resource "openstack_networking_port_v2" "compute" {
 
   for_each = toset(var.nodes)

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/compute/variables.tf
@@ -64,6 +64,18 @@ variable "root_volume_size" {
     default = 40
 }
 
+variable "extra_volumes" {
+    description = <<-EOF
+        Mapping defining additional volumes to create and attach.
+        Keys are unique volume name.
+        Values are a mapping with:
+            size: Size of volume in GB
+        **NB**: The order in /dev is not guaranteed to match the mapping
+        EOF
+    type = any
+    default = {}
+}
+
 variable "security_group_ids" {
     type = list
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/terraform/variables.tf
@@ -54,6 +54,11 @@ variable "compute" {
             vnic_profile: Overrides variable vnic_profile
             volume_backed_instances: Overrides variable volume_backed_instances
             root_volume_size: Overrides variable root_volume_size
+            extra_volumes: Mapping defining additional volumes to create and attach
+                           Keys are unique volume name.
+                           Values are a mapping with:
+                                size: Size of volume in GB
+                           **NB**: The order in /dev is not guaranteed to match the mapping
     EOF
 }
 


### PR DESCRIPTION
Adds an `extra_volumes` property to the tofu `compute` mapping to allow defining volumes which OpenTofu will create and attach to compute nodes. Useful for simulating additional disks present in baremetal instances using virtualized instances.

Note that:

- Unlike the default home and state volumes attached to the control node, compute volumes defined this way are not automatically formatted or mounted.
- Volumes are attached after instance creation and the path under /dev/{v,s}d* may not reflect the ordering in the `extra_volumes` property and may change across reboots. Use e.g. /dev/disk/by-path/ for mounts etc.
- As long as volume-backed compute instances are not used, OpenTofu will update instances in place (i.e. reimage) to change the node image, even with `extra_volumes` specified.