### PR TITLE
EXPERIMENTAL: test lifecycle ignore image changes via variable

### DIFF
--- a/environments/.stackhpc/tofu/main.tf
+++ b/environments/.stackhpc/tofu/main.tf
@@ -81,6 +81,7 @@ module "cluster" {
             nodes: ["compute-0", "compute-1"]
             flavor: var.other_node_flavor
             compute_init_enable: ["compute", "etc_hosts", "nfs", "basic_users", "eessi"]
+            # ignore_image_changes: true
         }
         # Example of how to add another partition:
         # extra: {

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
@@ -6,7 +6,6 @@ module "compute" {
   # must be set for group:
   nodes = each.value.nodes
   flavor = each.value.flavor
-
   cluster_name = var.cluster_name
   cluster_domain_suffix = var.cluster_domain_suffix
   cluster_net_id = data.openstack_networking_network_v2.cluster_net.id
@@ -21,6 +20,7 @@ module "compute" {
   extra_volumes = lookup(each.value, "extra_volumes", {})
 
   compute_init_enable = lookup(each.value, "compute_init_enable", [])
+  ignore_image_changes = lookup(each.value, "ignore_image_changes", false)
 
   key_pair = var.key_pair
   environment_root = var.environment_root

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/compute/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/compute/nodes.tf
@@ -9,6 +9,7 @@ locals {
   # this is a mapping with
   # keys "compute-0-vol-a", "compute-0-vol-b" ...
   # values which are a mapping e.g. {"node"="compute-0", "volume"="vol-a"}
+  compute_instances = var.ignore_image_changes ? openstack_compute_instance_v2.compute_fixed_image : openstack_compute_instance_v2.compute
 }
 
 resource "openstack_blockstorage_volume_v3" "compute" {
@@ -24,7 +25,7 @@ resource "openstack_compute_volume_attach_v2" "compute" {
 
   for_each = local.all_compute_volumes
 
-  instance_id = openstack_compute_instance_v2.compute["${each.value.node}"].id
+  instance_id = local.compute_instances["${each.value.node}"].id
   volume_id  = openstack_blockstorage_volume_v3.compute["${each.key}"].id
 }
 
@@ -48,9 +49,57 @@ resource "openstack_networking_port_v2" "compute" {
   }
 }
 
+resource "openstack_compute_instance_v2" "compute_fixed_image" {
+
+  for_each = var.ignore_image_changes ? toset(var.nodes) : []
+  
+  name = "${var.cluster_name}-${each.key}"
+  image_id = var.image_id
+  flavor_name = var.flavor
+  key_pair = var.key_pair
+
+  dynamic "block_device" {
+    for_each = var.volume_backed_instances ? [1]: []
+    content {
+      uuid = var.image_id
+      source_type  = "image"
+      destination_type = "volume"
+      volume_size = var.root_volume_size
+      boot_index = 0
+      delete_on_termination = true
+    }
+  }
+  
+  network {
+    port = openstack_networking_port_v2.compute[each.key].id
+    access_network = true
+  }
+
+  metadata = merge(
+    {
+        environment_root = var.environment_root
+        k3s_token          = var.k3s_token
+        control_address    = var.control_address
+     },
+    {for e in var.compute_init_enable: e => true}
+  )
+
+  user_data = <<-EOF
+    #cloud-config
+    fqdn: ${var.cluster_name}-${each.key}.${var.cluster_name}.${var.cluster_domain_suffix}
+  EOF
+
+  lifecycle {
+    ignore_changes = [
+     image_id,
+    ]
+  }
+
+}
+
 resource "openstack_compute_instance_v2" "compute" {
 
-  for_each = toset(var.nodes)
+  for_each = var.ignore_image_changes ? [] : toset(var.nodes)
   
   name = "${var.cluster_name}-${each.key}"
   image_id = var.image_id
@@ -91,5 +140,5 @@ resource "openstack_compute_instance_v2" "compute" {
 }
 
 output "compute_instances" {
-    value = openstack_compute_instance_v2.compute
+    value = local.compute_instances
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/compute/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/compute/variables.tf
@@ -94,3 +94,8 @@ variable "compute_init_enable" {
     description = "Groups to activate for ansible-init compute rebuilds"
     default = []
 }
+
+variable "ignore_image_changes" {
+    type = bool
+    default = false
+}

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tpl
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tpl
@@ -28,6 +28,7 @@ ${cluster_name}_${group_name}:
         ${ node.name }:
             ansible_host: ${node.access_ip_v4}
             instance_id: ${ node.id }
+            image_id: ${ node.image_id }
 %{ endfor ~}
 %{ endfor ~}
 


### PR DESCRIPTION
When a compute group has  compute_init_enable set/non-empty:
- Using the ansible variable image_id templated out using the compute group tf var of the same name, into the TF-templated ansible inventory for that compute group.

  -  This means that ansible will have image_id for each compute node, and the compute_init:export.yml task will write that out into the /exports/cluster/hostvars.

 - Add a lifecycle block to the openstack_compute_instance_v2 resource so that subsequent changes to the tf cluster_image variable for that compute group don’t actually result in a change via tf plan/apply. This is done with the meta-argument "ignore_changes"
 
   - In practice this isn't possible due to meta-arguments (e.g. lifecycle and its contents) only taking static values, so duplication of the openstack_compute_instance_v2 is necessary with some gated condition on which is used.