### PR TITLE
Fix squid/dnf ordering problem

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -127,21 +127,35 @@
       that: dnf_repos_password is undefined
       fail_msg: Passwords should not be templated into repofiles during configure, unset 'dnf_repos_password'
     when: appliances_mode == 'configure'
-  - name: Replace system repos with pulp repos 
-    ansible.builtin.include_role:
-      name: dnf_repos
-      tasks_from: set_repos.yml
 
-# --- tasks after here require access to package repos ---
 - hosts: squid
   tags: squid
   gather_facts: yes
   become: yes
   tasks:
+    # - Installing squid requires working dnf repos
+    # - Configuring dnf_repos itself requires working dnf repos to install epel
+    # - Hence do this on squid nodes first in case they are proxying others
+    - name: Replace system repos with pulp repos
+      ansible.builtin.include_role:
+        name: dnf_repos
+        tasks_from: set_repos.yml
+      when: "'dnf_repos' in group_names"
     - name: Configure squid proxy
       import_role:
         name: squid
 
+- hosts: dnf_repos
+  tags: dnf_repos
+  gather_facts: yes
+  become: yes
+  tasks:
+  - name: Replace system repos with pulp repos 
+    ansible.builtin.include_role:
+      name: dnf_repos
+      tasks_from: set_repos.yml
+
+# --- tasks after here require general access to package repos ---
 - hosts: tuned
   tags: tuned
   gather_facts: yes

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-250115-1510-99f67c6d",
-        "RL9": "openhpc-RL9-250115-1510-99f67c6d"
+        "RL8": "openhpc-RL8-250122-1150-a0899ef8",
+        "RL9": "openhpc-RL9-250122-1150-a0899ef8"
     }
 }


### PR DESCRIPTION
Fix dependency cycle between squid and dnf_repos:
- Running `squid` role may require working dnf repos in order to install packages
- Running `dnf_repos` role requires working dnf connectivity in order to install epel-release package
Without this fix, nodes which were proxied via squid could not run the `dnf_repos` task because squid was not yet set up.