### PR TITLE
Use Tofu path for variables file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Variables marked `*` refer to OpenStack resources which must already exist. The 
 To deploy this infrastructure, ensure the venv and the environment are [activated](#create-a-new-environment) and run:
 
     export OS_CLOUD=openstack
-    cd environments/$ENV/terraform/
+    cd environments/$ENV/tofu/
     tofu init
     tofu apply
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ And generate secrets for it:
 
 Create an OpenTofu variables file to define the required infrastructure, e.g.:
 
-    # environments/$ENV/terraform/terraform.tfvars:
+    # environments/$ENV/tofu/terraform.tfvars:
 
     cluster_name = "mycluster"
     cluster_net = "some_network" # *


### PR DESCRIPTION
The path created by cookiecutter is now `tofu`, not `terraform`. 