### PR TITLE
avoid tf updates to login/compute on control delete/recreate

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
@@ -28,6 +28,8 @@ module "compute" {
 
   # computed
   k3s_token = local.k3s_token
-  control_address = openstack_compute_instance_v2.control.access_ip_v4
+  # not using openstack_compute_instance_v2.control.access_ip_v4 to avoid
+  # updates to node metadata on deletion/recreation of the control node:
+  control_address = openstack_networking_port_v2.control[var.cluster_networks[0].network].all_fixed_ips[0]
   security_group_ids = [for o in data.openstack_networking_secgroup_v2.nonlogin: o.id]
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
@@ -7,8 +7,11 @@ module "login" {
   nodes = each.value.nodes
   flavor = each.value.flavor
 
+  # always taken from top-level value:
   cluster_name = var.cluster_name
   cluster_domain_suffix = var.cluster_domain_suffix
+  key_pair = var.key_pair
+  environment_root = var.environment_root
   
   # can be set for group, defaults to top-level value:
   image_id = lookup(each.value, "image_id", var.cluster_image_id)
@@ -25,9 +28,10 @@ module "login" {
   compute_init_enable = []
   ignore_image_changes = false
 
-  key_pair = var.key_pair
-  environment_root = var.environment_root
+  # computed
   k3s_token = local.k3s_token
-  control_address = openstack_compute_instance_v2.control.access_ip_v4
+  # not using openstack_compute_instance_v2.control.access_ip_v4 to avoid
+  # updates to node metadata on deletion/recreation of the control node:
+  control_address = openstack_networking_port_v2.control[var.cluster_networks[0].network].all_fixed_ips[0]
   security_group_ids = [for o in data.openstack_networking_secgroup_v2.login: o.id]
 }


### PR DESCRIPTION
Uses the control node port to derive the control node IP instead of the control node's access_ip property. This avoids opentofu recalculating the compute/login metadata when it deletes/recreate the control node. Works because the first cluster_network is always the access network.