### PR TITLE
Set k3s node IP from access network IP

### DIFF
--- a/ansible/roles/k3s/files/start_k3s.yml
+++ b/ansible/roles/k3s/files/start_k3s.yml
@@ -5,6 +5,7 @@
     k3s_token: "{{ os_metadata.meta.k3s_token }}"
     k3s_server_name: "{{ os_metadata.meta.control_address }}"
     service_name: "{{ 'k3s-agent' if k3s_server_name is defined else 'k3s' }}"
+    access_ip: "{{ os_metadata.meta.access_ip }}"
   tasks:
     - name: Ensure password directory exists
       ansible.builtin.file: 
@@ -21,6 +22,13 @@
       ansible.builtin.lineinfile:
         path: "/etc/systemd/system/{{ service_name }}.service.env"
         line: "K3S_TOKEN={{ k3s_token }}"
+
+    - name: Add the node IP to the environment
+      # NB this isn't natively setable via envvars, have to modify
+      # INSTALL_K3S_EXEC to support it
+      ansible.builtin.lineinfile:
+        path: "/etc/systemd/system/{{ service_name }}.service.env"
+        line: "K3S_NODE_IP={{ access_ip }}"
 
     - name: Add server url to agents
       ansible.builtin.lineinfile:

--- a/ansible/roles/k3s/tasks/install.yml
+++ b/ansible/roles/k3s/tasks/install.yml
@@ -47,7 +47,7 @@
       cmd: /usr/bin/k3s-install.sh
     environment:
       INSTALL_K3S_VERSION: "{{ k3s_version }}"
-      INSTALL_K3S_EXEC: "{{ item }}"
+      INSTALL_K3S_EXEC: "{{ item }} --node-ip=${K3S_NODE_IP}"
       INSTALL_K3S_SKIP_START: "true"
       INSTALL_K3S_SKIP_ENABLE: "true"
       INSTALL_K3S_BIN_DIR: "/usr/bin"

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-250122-1150-a0899ef8",
-        "RL9": "openhpc-RL9-250122-1150-a0899ef8"
+        "RL8": "openhpc-RL8-250130-1126-8f2a7703",
+        "RL9": "openhpc-RL9-250130-1127-8f2a7703"
     }
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
@@ -60,7 +60,7 @@ resource "openstack_compute_instance_v2" "control" {
   metadata = {
     environment_root = var.environment_root
     k3s_token = local.k3s_token
-    # TODO: set k3s_subnet from access_network
+    access_ip = openstack_networking_port_v2.control[var.cluster_networks[0].network].all_fixed_ips[0]
   }
 
   user_data = <<-EOF

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -87,6 +87,7 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
         environment_root = var.environment_root
         k3s_token          = var.k3s_token
         control_address    = var.control_address
+        access_ip = openstack_networking_port_v2.compute["${each.key}-${var.networks[0].network}"].all_fixed_ips[0]
     },
     {for e in var.compute_init_enable: e => true}
   )
@@ -138,7 +139,7 @@ resource "openstack_compute_instance_v2" "compute" {
         environment_root = var.environment_root
         k3s_token          = var.k3s_token
         control_address    = var.control_address
-        # TODO: set k3s_subnet from access_network
+        access_ip = openstack_networking_port_v2.compute["${each.key}-${var.networks[0].network}"].all_fixed_ips[0]
      },
     {for e in var.compute_init_enable: e => true}
   )


### PR DESCRIPTION
The node IP for k3s server and agent nodes is set to be the hosts's IP on the access network (first cluster network). This ensures nodes can communicate with each other properly.