### PR TITLE
Add lustre_repo variable

### DIFF
--- a/ansible/roles/lustre/defaults/main.yml
+++ b/ansible/roles/lustre/defaults/main.yml
@@ -6,6 +6,7 @@ lustre_mount_state: mounted
 lustre_mount_options: 'defaults,_netdev,noauto,x-systemd.automount,x-systemd.requires=lnet.service'
 
 # below variables are for build and should not generally require changes
+lustre_repo: "git://git.whamcloud.com/fs/lustre-release.git"
 lustre_build_packages:
   - "kernel-devel-{{ ansible_kernel }}"
   - git

--- a/ansible/roles/lustre/defaults/main.yml
+++ b/ansible/roles/lustre/defaults/main.yml
@@ -6,7 +6,7 @@ lustre_mount_state: mounted
 lustre_mount_options: 'defaults,_netdev,noauto,x-systemd.automount,x-systemd.requires=lnet.service'
 
 # below variables are for build and should not generally require changes
-lustre_repo: "git://git.whamcloud.com/fs/lustre-release.git"
+lustre_git_repo: "git://git.whamcloud.com/fs/lustre-release.git"
 lustre_build_packages:
   - "kernel-devel-{{ ansible_kernel }}"
   - git

--- a/ansible/roles/lustre/tasks/install.yml
+++ b/ansible/roles/lustre/tasks/install.yml
@@ -6,7 +6,7 @@
 - name: Clone lustre git repo
   # https://git.whamcloud.com/?p=fs/lustre-release.git;a=summary
   ansible.builtin.git:
-    repo: git://git.whamcloud.com/fs/lustre-release.git
+    repo: "{{ lustre_git_repo }}"
     dest: "{{ lustre_build_dir }}"
     version: "{{ lustre_version }}"
 


### PR DESCRIPTION
This allows users to configure the git repository used to build lustre. In some environments external ssh is blocked, so I've been using this https mirror:

https://github.com/lustre/lustre-release.git