### PR TITLE
Ensure oddjobd is enabled/started

### DIFF
--- a/ansible/roles/sssd/tasks/configure.yml
+++ b/ansible/roles/sssd/tasks/configure.yml
@@ -26,3 +26,9 @@
 - name: Configure nsswitch and PAM for SSSD
   command: "authselect select sssd --force{% if sssd_enable_mkhomedir | bool %} with-mkhomedir{% endif %}"
   when: "'sssd' not in _authselect_current.stdout"
+
+- name: "Ensure oddjob is started"
+  service:
+    name: oddjobd
+    state: started
+    enabled: "{{ sssd_enable_mkhomedir }}"


### PR DESCRIPTION
This is required for home directories to be automatically created.