### PR TITLE
Support sshd password authentication on Rocky 8

### DIFF
--- a/ansible/roles/sshd/tasks/configure.yml
+++ b/ansible/roles/sshd/tasks/configure.yml
@@ -1,5 +1,23 @@
-- name: Grab facts to determine distribution
-  setup:
+- name: Ensure drop in directory exists
+  file:
+    path: /etc/ssh/sshd_config.d/*.conf
+    state: directory
+    owner: root
+    group: root
+    mode: 700
+  become: true
+
+- name: Ensure drop in directory is included
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^Include /etc/ssh/sshd_config.d/*.conf"
+    line: "Include /etc/ssh/sshd_config.d/*.conf"
+    state: present
+    insertafter: EOF
+    validate: sshd -t -f %s
+  notify:
+    - Restart sshd
+  become: true
 
 - name: Template sshd configuration
   # NB: If parameters are defined multiple times the first value wins;
@@ -16,16 +34,3 @@
     validate: sshd -t -f %s
   notify:
     - Restart sshd
-  when: ansible_facts.distribution_major_version == '9'
-
-- name: Disallow SSH password authentication
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: "^PasswordAuthentication"
-    line: "PasswordAuthentication {{ 'yes' if sshd_password_authentication | bool else 'no' }}"
-    state: present
-    validate: sshd -t -f %s
-  notify:
-    - Restart sshd
-  become: true
-  when: ansible_facts.distribution_major_version == '8'

--- a/ansible/roles/sshd/tasks/configure.yml
+++ b/ansible/roles/sshd/tasks/configure.yml
@@ -29,4 +29,3 @@
     - Restart sshd
   become: true
   when: ansible_facts.distribution_major_version == '8'
-

--- a/ansible/roles/sshd/tasks/configure.yml
+++ b/ansible/roles/sshd/tasks/configure.yml
@@ -13,7 +13,7 @@
     regexp: "^Include /etc/ssh/sshd_config.d/*.conf"
     line: "Include /etc/ssh/sshd_config.d/*.conf"
     state: present
-    insertafter: EOF
+    insertbefore: "BOF"
     validate: sshd -t -f %s
   notify:
     - Restart sshd

--- a/ansible/roles/sshd/tasks/configure.yml
+++ b/ansible/roles/sshd/tasks/configure.yml
@@ -1,3 +1,6 @@
+- name: Grab facts to determine distribution
+  setup:
+
 - name: Template sshd configuration
   # NB: If parameters are defined multiple times the first value wins;
   # The default /etc/ssh/sshd_config has
@@ -13,3 +16,17 @@
     validate: sshd -t -f %s
   notify:
     - Restart sshd
+  when: ansible_facts.distribution_major_version == '9'
+
+- name: Disallow SSH password authentication
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^PasswordAuthentication"
+    line: "PasswordAuthentication {{ 'yes' if sshd_password_authentication | bool else 'no' }}"
+    state: present
+    validate: sshd -t -f %s
+  notify:
+    - Restart sshd
+  become: true
+  when: ansible_facts.distribution_major_version == '8'
+

--- a/ansible/roles/sshd/tasks/configure.yml
+++ b/ansible/roles/sshd/tasks/configure.yml
@@ -1,3 +1,6 @@
+- name: Grab facts to determine distribution
+  setup:
+
 - name: Ensure drop in directory exists
   file:
     path: /etc/ssh/sshd_config.d/*.conf
@@ -8,16 +11,19 @@
   become: true
 
 - name: Ensure drop in directory is included
-  lineinfile:
+  blockinfile:
     dest: /etc/ssh/sshd_config
-    regexp: "^Include /etc/ssh/sshd_config.d/*.conf"
-    line: "Include /etc/ssh/sshd_config.d/*.conf"
+    content: | 
+      # To modify the system-wide sshd configuration, create a  *.conf  file under
+      #  /etc/ssh/sshd_config.d/  which will be automatically included below
+      Include /etc/ssh/sshd_config.d/*.conf
     state: present
-    insertbefore: "BOF"
+    insertafter: "# default value."
     validate: sshd -t -f %s
   notify:
     - Restart sshd
   become: true
+  when: ansible_facts.distribution_major_version == '8'
 
 - name: Template sshd configuration
   # NB: If parameters are defined multiple times the first value wins;


### PR DESCRIPTION
Rocky 8 doesn't have an sshd_config.d directory, so we need to adjust the main configuration file.