### PR TITLE
Support lustre on Rocky 8

### DIFF
--- a/ansible/roles/lustre/tasks/validate.yml
+++ b/ansible/roles/lustre/tasks/validate.yml
@@ -1,8 +1,3 @@
-- name: Assert using RockyLinux 9
-  assert:
-    that: ansible_distribution_major_version | int == 9
-    fail_msg: The 'lustre' role requires RockyLinux 9
-
 - name: Check kernel-devel package is installed
   command: "dnf list --installed kernel-devel-{{ ansible_kernel }}"
   changed_when: false


### PR DESCRIPTION
Turns out this worked out of the box and we just needed to remove the validation check. No other changes necessary.