### PR TITLE
Fix lustre IP route detection if there is no gateway

### DIFF
--- a/ansible/roles/lustre/tasks/configure.yml
+++ b/ansible/roles/lustre/tasks/configure.yml
@@ -43,4 +43,3 @@
     state: "{{ (item.mount_state | default(lustre_mount_state)) }}"
     opts: "{{ item.mount_options | default(lustre_mount_options) }}"
   loop: "{{ lustre_mounts }}"
- 

--- a/ansible/roles/lustre/tasks/configure.yml
+++ b/ansible/roles/lustre/tasks/configure.yml
@@ -12,7 +12,7 @@
     _lustre_interface: "{{ _lustre_ip_r_mgs_info.dev }}"
     _lustre_ip: "{{ _lustre_ip_r_mgs_info.prefsrc }}"
   vars:
-    _lustre_ip_r_mgs_info: "{{ _lustre_ip_r_mgs.stdout | from_json }}"
+    _lustre_ip_r_mgs_info: "{{ _lustre_ip_r_mgs.stdout | from_json | first }}"
 
 - name: Write LNet configuration file
   template:

--- a/ansible/roles/lustre/tasks/configure.yml
+++ b/ansible/roles/lustre/tasks/configure.yml
@@ -9,9 +9,11 @@
 
 - name: Set facts for Lustre interface
   set_fact:
-    _lustre_interface: "{{ _lustre_ip_r_mgs_info[4] }}"
-    _lustre_ip: "{{ _lustre_ip_r_mgs_info[6] }}"
+    _lustre_interface: "{{ _lustre_ip_r_mgs_info[interface_index | int] }}"
+    _lustre_ip: "{{ _lustre_ip_r_mgs_info[ip_index | int] }}"
   vars:
+    interface_index: "{{ 4 if 'via' in _lustre_ip_r_mgs.stdout_lines.0 else 2 }}"
+    ip_index: "{{ 6 if 'via' in _lustre_ip_r_mgs.stdout_lines.0 else 4 }}"
     _lustre_ip_r_mgs_info: "{{ _lustre_ip_r_mgs.stdout_lines.0 | split }}"
     # first line e.g. "10.167.128.1 via 10.179.0.2 dev eth0 src 10.179.3.149 uid 1000"
 

--- a/ansible/roles/lustre/tasks/configure.yml
+++ b/ansible/roles/lustre/tasks/configure.yml
@@ -1,7 +1,7 @@
 - name: Gather Lustre interface info
   shell:
     cmd: |
-      ip r get {{ _lustre_mgs_ip }}
+      ip --json r get {{ _lustre_mgs_ip }}
   changed_when: false
   register: _lustre_ip_r_mgs
   vars:
@@ -9,13 +9,10 @@
 
 - name: Set facts for Lustre interface
   set_fact:
-    _lustre_interface: "{{ _lustre_ip_r_mgs_info[interface_index | int] }}"
-    _lustre_ip: "{{ _lustre_ip_r_mgs_info[ip_index | int] }}"
+    _lustre_interface: "{{ _lustre_ip_r_mgs_info.dev }}"
+    _lustre_ip: "{{ _lustre_ip_r_mgs_info.prefsrc }}"
   vars:
-    interface_index: "{{ 4 if 'via' in _lustre_ip_r_mgs.stdout_lines.0 else 2 }}"
-    ip_index: "{{ 6 if 'via' in _lustre_ip_r_mgs.stdout_lines.0 else 4 }}"
-    _lustre_ip_r_mgs_info: "{{ _lustre_ip_r_mgs.stdout_lines.0 | split }}"
-    # first line e.g. "10.167.128.1 via 10.179.0.2 dev eth0 src 10.179.3.149 uid 1000"
+    _lustre_ip_r_mgs_info: "{{ _lustre_ip_r_mgs.stdout | from_json }}"
 
 - name: Write LNet configuration file
   template:


### PR DESCRIPTION
This handles the following case

```
172.26.0.251 dev ib0 src 172.26.0.196 uid 0
```

in addition to:

```
10.167.128.1 via 10.179.0.2 dev eth0 src 10.179.3.149 uid 1000
```