### PR TITLE
Support attaching FIPs to login nodes

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
@@ -23,6 +23,8 @@ module "login" {
   # optionally set for group
   networks = concat(var.cluster_networks, lookup(each.value, "extra_networks", []))
   extra_volumes = lookup(each.value, "extra_volumes", {})
+  fip_addresses = lookup(each.value, "fip_addresses", [])
+  fip_network = lookup(each.value, "fip_network", "")
 
   # can't be set for login
   compute_init_enable = []

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -151,6 +151,14 @@ resource "openstack_compute_instance_v2" "compute" {
 
 }
 
+resource "openstack_networking_floatingip_associate_v2" "fip" {
+  for_each = {for idx in range(length(var.fip_addresses)): var.nodes[idx] => var.fip_addresses[idx]} # zip, fip_addresses can be shorter
+
+  floating_ip = each.value
+  port_id     = openstack_networking_port_v2.compute["${each.key}-${length(var.networks) == 1 ? var.networks[0].network : var.fip_network}"].id
+
+}
+
 output "compute_instances" {
     value = local.compute_instances
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
@@ -95,3 +95,22 @@ variable "networks" {
     type = list(map(string))
     default = []
 }
+
+variable "fip_addresses" {
+    type = list(string)
+    description = <<-EOT
+        List of addresses of floating IPs to associate with nodes,
+        in same order as nodes parameter. The floating IPs must already be
+        allocated to the project.
+    EOT
+    default = []
+}
+
+variable "fip_network" {
+    type = string
+    description = <<-EOT
+        Name of network containing ports to attach FIPs to. Only required if multiple
+        networks are defined.
+    EOT
+    default = ""
+}

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
@@ -53,6 +53,12 @@ variable "login" {
                         Values are a mapping with:
                             size: Size of volume in GB
                         **NB**: The order in /dev is not guaranteed to match the mapping
+        fip_addresses: List of addresses of floating IPs to associate with nodes,
+                       in the same order as nodes parameter. The floating IPs
+                       must already be allocated to the project.
+        fip_network: Name of network containing ports to attach FIPs to. Only
+                     required if multiple networks are defined.
+
   EOF
 }
 


### PR DESCRIPTION
Allows attaching FIPs to login nodes, e.g.:

```terraform
login = {
        login: {
            nodes: ["login-0"]
            flavor: var.other_node_flavor
            fip_addresses = ["45.135.56.139"]
        }
    }
```

Note FIPs must already be allocated to the project using e.g.:

```shell
openstack floating ip add external
```

This approach means cluster deletion does not release the FIPs from the project.