### PR TITLE
Support mapping compute & login instances to Ironic nodes

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/baremetal-node-list.py
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/baremetal-node-list.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+""" opentofu external data program to list baremetal nodes
+
+    Example usage:
+
+        data "external" "example" {
+            program = [this_file]
+        }
+
+    The external data resource's result attribute then contains a mapping of
+    Ironic node names to their UUIDs.
+
+    An empty list is returned if:
+    - There are no baremetal nodes
+    - The listing fails for any reason, e.g.
+        - there is no baremetal service
+        - admin credentials are required and are not provided
+"""
+
+import openstack
+import json
+
+nodes = []
+proxy = None
+output = {}
+conn = openstack.connection.from_config()
+try:
+    proxy = getattr(conn, 'baremetal', None)
+except Exception:
+    pass
+if proxy is not None:
+    nodes = proxy.nodes()
+for node in nodes:
+    output[node.name] = node.id
+print(json.dumps(output))

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
@@ -20,11 +20,13 @@ module "compute" {
   volume_backed_instances = lookup(each.value, "volume_backed_instances", var.volume_backed_instances)
   root_volume_size = lookup(each.value, "root_volume_size", var.root_volume_size)
   
-  # optionally set for group
+  # optionally set for group:
   networks = concat(var.cluster_networks, lookup(each.value, "extra_networks", []))
   extra_volumes = lookup(each.value, "extra_volumes", {})
   compute_init_enable = lookup(each.value, "compute_init_enable", [])
   ignore_image_changes = lookup(each.value, "ignore_image_changes", false)
+  match_ironic_node = lookup(each.value, "match_ironic_node", false)
+  availability_zone = lookup(each.value, "availability_zone", "nova")
 
   # computed
   k3s_token = local.k3s_token
@@ -32,4 +34,5 @@ module "compute" {
   # updates to node metadata on deletion/recreation of the control node:
   control_address = openstack_networking_port_v2.control[var.cluster_networks[0].network].all_fixed_ips[0]
   security_group_ids = [for o in data.openstack_networking_secgroup_v2.nonlogin: o.id]
+  baremetal_nodes = data.external.baremetal_nodes
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
@@ -34,5 +34,5 @@ module "compute" {
   # updates to node metadata on deletion/recreation of the control node:
   control_address = openstack_networking_port_v2.control[var.cluster_networks[0].network].all_fixed_ips[0]
   security_group_ids = [for o in data.openstack_networking_secgroup_v2.nonlogin: o.id]
-  baremetal_nodes = data.external.baremetal_nodes
+  baremetal_nodes = data.external.baremetal_nodes.result
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/data.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/data.tf
@@ -1,0 +1,16 @@
+data "external" "inventory_secrets" {
+  program = ["${path.module}/read-inventory-secrets.py"]
+
+  query = {
+    path = var.inventory_secrets_path == "" ? "${path.module}/../inventory/group_vars/all/secrets.yml" : var.inventory_secrets_path
+  }
+}
+
+data "external" "baremetal_nodes" {
+  # returns an empty map if cannot list baremetal nodes
+  program = ["bash", "-c", <<-EOT
+    openstack baremetal node list --limit 0 -f json 2>/dev/null | \
+    jq -r 'try map( { (.Name|tostring): .UUID } ) | add catch {}' || echo '{}'
+  EOT
+  ]
+}

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/data.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/data.tf
@@ -8,9 +8,6 @@ data "external" "inventory_secrets" {
 
 data "external" "baremetal_nodes" {
   # returns an empty map if cannot list baremetal nodes
-  program = ["bash", "-c", <<-EOT
-    openstack baremetal node list --limit 0 -f json 2>/dev/null | \
-    jq -r 'try map( { (.Name|tostring): .UUID } ) | add catch {}' || echo '{}'
-  EOT
-  ]
+  program = ["${path.module}/baremetal-node-list.py"]
+  query = {}
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
@@ -25,6 +25,8 @@ module "login" {
   extra_volumes = lookup(each.value, "extra_volumes", {})
   fip_addresses = lookup(each.value, "fip_addresses", [])
   fip_network = lookup(each.value, "fip_network", "")
+  match_ironic_node = lookup(each.value, "match_ironic_node", false)
+  availability_zone = lookup(each.value, "availability_zone", "nova")
 
   # can't be set for login
   compute_init_enable = []
@@ -36,4 +38,5 @@ module "login" {
   # updates to node metadata on deletion/recreation of the control node:
   control_address = openstack_networking_port_v2.control[var.cluster_networks[0].network].all_fixed_ips[0]
   security_group_ids = [for o in data.openstack_networking_secgroup_v2.login: o.id]
+  baremetal_nodes = data.external.baremetal_nodes
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
@@ -38,5 +38,5 @@ module "login" {
   # updates to node metadata on deletion/recreation of the control node:
   control_address = openstack_networking_port_v2.control[var.cluster_networks[0].network].all_fixed_ips[0]
   security_group_ids = [for o in data.openstack_networking_secgroup_v2.login: o.id]
-  baremetal_nodes = data.external.baremetal_nodes
+  baremetal_nodes = data.external.baremetal_nodes.result
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -97,6 +97,8 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
     fqdn: ${var.cluster_name}-${each.key}.${var.cluster_name}.${var.cluster_domain_suffix}
   EOF
 
+  availability_zone = var.match_ironic_node ? "${var.availability_zone}::${var.baremetal_nodes[each.key]}" : null
+
   lifecycle {
     ignore_changes = [
       image_id,
@@ -140,7 +142,7 @@ resource "openstack_compute_instance_v2" "compute" {
         k3s_token          = var.k3s_token
         control_address    = var.control_address
         access_ip = openstack_networking_port_v2.compute["${each.key}-${var.networks[0].network}"].all_fixed_ips[0]
-     },
+    },
     {for e in var.compute_init_enable: e => true}
   )
 
@@ -148,6 +150,8 @@ resource "openstack_compute_instance_v2" "compute" {
     #cloud-config
     fqdn: ${var.cluster_name}-${each.key}.${var.cluster_name}.${var.cluster_domain_suffix}
   EOF
+
+  availability_zone = var.match_ironic_node ? "${var.availability_zone}::${var.baremetal_nodes[each.key]}" : null
 
 }
 

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
@@ -114,3 +114,20 @@ variable "fip_network" {
     EOT
     default = ""
 }
+
+variable "match_ironic_node" {
+    type = bool
+    description = "Whether to launch instances on the Ironic node of the same name as each cluster node"
+    default = false
+}
+
+variable "availability_zone" {
+    type = string
+    description = "Name of availability zone - ignored unless match_ironic_node is true"
+    default = "nova"
+}
+
+variable "baremetal_nodes" {
+    type = map(string)
+    default = {}
+}

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
@@ -59,6 +59,8 @@ variable "login" {
         fip_network: Name of network containing ports to attach FIPs to. Only
                      required if multiple networks are defined.
 
+        match_ironic_node: Set true to launch instances on the Ironic node of the same name as each cluster node
+        availability_zone: Name of availability zone - ignored unless match_ironic_node is true (default: "nova")
   EOF
 }
 
@@ -93,6 +95,8 @@ variable "compute" {
                            Values are a mapping with:
                                 size: Size of volume in GB
                            **NB**: The order in /dev is not guaranteed to match the mapping
+            match_ironic_node: Set true to launch instances on the Ironic node of the same name as each cluster node
+            availability_zone: Name of availability zone - ignored unless match_ironic_node is true (default: "nova")
     EOF
 }
 
@@ -184,14 +188,6 @@ variable "inventory_secrets_path" {
   description = "Path to inventory secrets.yml file. Default is standard cookiecutter location."
   type = string
   default = ""
-}
-
-data "external" "inventory_secrets" {
-  program = ["${path.module}/read-inventory-secrets.py"]
-
-  query = {
-    path = var.inventory_secrets_path == "" ? "${path.module}/../inventory/group_vars/all/secrets.yml" : var.inventory_secrets_path
-  }
 }
 
 locals {


### PR DESCRIPTION
Adds support for mapping baremetal compute and/or login nodes to ironic hosts with the same names, e.g:

```terraform
# environments/$env/terraform/terraform.tfvars:
...
cluster_name = "mycloud"
login_nodes = {
    login-0 = {
        flavor: "baremetal.highmem"
        match_ironic_node: true
    }
}
compute = {
    hpc = {
        flavor = "baremetal.xlarge"
        match_ironic_node: true
        availability_zone = "az2"
        nodes = ["hpc-0", "hpc-1", "hpc-2"]
    }
}
...
```

will result in:
- An instance named `mycloud-login-0` on ironic node `login-0` in the default "nova" availability zone
- Compute instances `mycloud-hpc-N` on ironic nodes `hpc-N` in the "az2" availability zone 