### PR TITLE
Adds support for configuring chrony

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -58,7 +58,7 @@
   become: yes
   tasks:
     - import_role:
-        name: chrony
+        name: mrlesmithjr.chrony
 
 - hosts: cluster
   gather_facts: false

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -53,7 +53,6 @@
         name: proxy
 
 - hosts: chrony
-  gather_facts: false
   tags: chrony
   become: yes
   tasks:

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -52,6 +52,14 @@
     - import_role:
         name: proxy
 
+- hosts: chrony
+  gather_facts: false
+  tags: chrony
+  become: yes
+  tasks:
+    - import_role:
+        name: chrony
+
 - hosts: cluster
   gather_facts: false
   become: yes

--- a/ansible/roles/compute_init/README.md
+++ b/ansible/roles/compute_init/README.md
@@ -40,6 +40,7 @@ it also requires an image build with the role name added to the
 | bootstrap.yml            | (wait for ansible-init) | Not relevant during boot        | n/a                 |
 | bootstrap.yml            | resolv_conf             | Fully supported                 | No                  |
 | bootstrap.yml            | etc_hosts               | Fully supported                 | No                  |
+| bootstrap.yml            | chrony                  | Fully supported                 | No                  |
 | bootstrap.yml            | proxy                   | None at present                 | No                  |
 | bootstrap.yml            | (/etc permissions)      | None required - use image build | No                  |
 | bootstrap.yml            | (ssh /home fix)         | None required - use image build | No                  |

--- a/ansible/roles/compute_init/files/compute-init.yml
+++ b/ansible/roles/compute_init/files/compute-init.yml
@@ -17,6 +17,7 @@
     enable_manila: "{{ os_metadata.meta.manila | default(false) | bool }}"
     enable_basic_users: "{{ os_metadata.meta.basic_users | default(false) | bool }}"
     enable_eessi: "{{ os_metadata.meta.eessi | default(false) | bool }}"
+    enable_chrony: "{{ os_metadata.meta.chrony | default(false) | bool }}"
 
     # TODO: "= role defaults" - could be moved to a vars_file: on play with similar precedence effects
     resolv_conf_nameservers: []
@@ -99,6 +100,10 @@
         file: "/mnt/cluster/hostvars/{{ ansible_hostname }}/hostvars.yml" # can't use inventory_hostname
 
       # TODO: should /mnt/cluster now be UNMOUNTED to avoid future hang-ups?
+
+    - name: Run chrony role
+      ansible.builtin.include_role:
+        name: mrlesmithjr.chrony
 
     - name: Configure resolve.conf
       block:

--- a/ansible/roles/compute_init/files/compute-init.yml
+++ b/ansible/roles/compute_init/files/compute-init.yml
@@ -104,6 +104,7 @@
     - name: Run chrony role
       ansible.builtin.include_role:
         name: mrlesmithjr.chrony
+      when: enable_chrony | bool
 
     - name: Configure resolve.conf
       block:

--- a/ansible/roles/compute_init/tasks/install.yml
+++ b/ansible/roles/compute_init/tasks/install.yml
@@ -43,6 +43,8 @@
       dest: tasks/tuned.yml
     - src: ../../stackhpc.nfs/tasks/nfs-clients.yml
       dest: tasks/nfs-clients.yml
+    - src: ../../mrlesmithjr.chrony
+      dest: roles/
 
 - name: Add filter_plugins to ansible.cfg
   lineinfile:

--- a/docs/chrony.md
+++ b/docs/chrony.md
@@ -1,8 +1,4 @@
-# Configuration
-
-This page provides configuration snippets for various services.
-
-## Chrony
+# Chrony configuration
 
 Use variables from the [mrlesmithjr.chrony](https://github.com/mrlesmithjr/ansible-chrony) role.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,25 @@
+# Configuration
+
+This page provides configuration snippets for various services.
+
+## Chrony
+
+Use variables from the [mrlesmithjr.chrony](https://github.com/mrlesmithjr/ansible-chrony) role.
+
+For example in: `environments/<environment>/inventory/group_vars/all/chrony`:
+
+```
+---
+chrony_ntp_servers:
+  - server: ntp-0.example.org
+    options:
+      - option: iburst
+      - option: minpoll
+        val: 8
+  - server: ntp-1.example.org
+    options:
+      - option: iburst
+      - option: minpoll
+        val: 8
+
+```

--- a/environments/.stackhpc/inventory/extra_groups
+++ b/environments/.stackhpc/inventory/extra_groups
@@ -24,6 +24,9 @@ cluster
 login
 compute
 
+[chrony:children]
+cluster
+
 [tuned:children]
 # Install tuned into fat image
 builder

--- a/environments/.stackhpc/tofu/main.tf
+++ b/environments/.stackhpc/tofu/main.tf
@@ -80,7 +80,7 @@ module "cluster" {
         standard: { # NB: can't call this default!
             nodes: ["compute-0", "compute-1"]
             flavor: var.other_node_flavor
-            compute_init_enable: ["compute", "etc_hosts", "nfs", "basic_users", "eessi", "tuned", "cacerts"]
+            compute_init_enable: ["compute", "chrony", "etc_hosts", "nfs", "basic_users", "eessi", "tuned", "cacerts"]
             ignore_image_changes: true
         }
         # Example of how to add another partition:

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -168,3 +168,6 @@ extra_packages
 
 [cacerts]
 # Hosts to configure CA certificates and trusts on
+
+[chrony]
+# Hosts where crony configuration is applied. See docs/configuration.md#Chrony for more details.

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -170,4 +170,4 @@ extra_packages
 # Hosts to configure CA certificates and trusts on
 
 [chrony]
-# Hosts where crony configuration is applied. See docs/configuration.md#Chrony for more details.
+# Hosts where crony configuration is applied. See docs/chrony.md for more details.

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -115,4 +115,4 @@ builder
 # Hosts to configure CA certificates and trusts on
 
 [chrony]
-# Hosts where crony configuration is applied. See docs/configuration.md#Chrony for more details.
+# Hosts where crony configuration is applied. See docs/chrony.md for more details.

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -114,3 +114,6 @@ builder
 
 [cacerts]
 # Hosts to configure CA certificates and trusts on
+
+[chrony]
+# Hosts where crony configuration is applied. See docs/configuration.md#Chrony for more details.

--- a/requirements.yml
+++ b/requirements.yml
@@ -22,6 +22,8 @@ roles:
   - src: https://github.com/stackhpc/ansible-role-os-manila-mount.git
     name: stackhpc.os-manila-mount
     version: v25.1.1
+  - src: mrlesmithjr.chrony
+    version: v0.1.4
 
 collections:
   - name: containers.podman


### PR DESCRIPTION
Chrony is already bundled in the generic cloud image so we just have to configure it. For this I am using an off the shelf role. I've chosen mrlesmithjr.chrony as it is also used in kayobe (so we can share development effort)