### PR TITLE
Optimize copying of directories

### DIFF
--- a/ansible/roles/compute_init/tasks/install.yml
+++ b/ansible/roles/compute_init/tasks/install.yml
@@ -15,12 +15,14 @@
     - tasks
 
 - name: Inject files from roles
-  copy:
+  synchronize:
     src: '{{ item.src }}'
     dest: '/etc/ansible-init/playbooks/{{ item.dest }}'
-    owner: root
-    group: root
-    mode: 0644
+    archive: false
+    rsync_opts: ["-p", "--chmod=D770,F644", "--owner=root", "--group=root"]
+    recursive: true
+    use_ssh_args: true
+  become: true
   loop:
     - src: ../../resolv_conf/templates/resolv.conf.j2
       dest: templates/resolv.conf.j2


### PR DESCRIPTION
The ansible copy module is pretty slow when copying directories especially if there are a lot of files. This is true when coping roles installed from galaxy. Switching to the synchronize module yields much better performance.