### PR TITLE
Update terraform provider openstack to v3

### DIFF
--- a/ansible/roles/cluster_infra/templates/providers.tf.j2
+++ b/ansible/roles/cluster_infra/templates/providers.tf.j2
@@ -5,10 +5,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
-      # TODO we must upgrade to 3.0.0
-      # but only after we stop using the deprecated
-      # openstack_compute_floatingip_associate_v2
-      version = "~>2.1.0"
+      version = "~>3.0.0"
     }
   }
 }

--- a/environments/.stackhpc/tofu/main.tf
+++ b/environments/.stackhpc/tofu/main.tf
@@ -5,6 +5,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "~>3.0.0"
     }
   }
 }
@@ -86,9 +87,9 @@ module "cluster" {
         #     flavor: var.other_node_flavor
         # }
     }
-    
+
     volume_backed_instances = var.volume_backed_instances
-    
+
     environment_root = var.environment_root
     # Can reduce volume size a lot for short-lived CI clusters:
     state_volume_size = 10

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/main.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/main.tf
@@ -3,6 +3,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "~>3.0.0"
     }
   }
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/main.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/main.tf
@@ -3,6 +3,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "~>3.0.0"
     }
   }
 }


### PR DESCRIPTION
AFAIK the comment regarding `openstack_compute_floatingip_associate_v2` is no longer applicable so I think we can try to upgrade? I don't think we're using any of the other removed resource types listed here so shouldn't require any other changes in the appliance https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/guides/upgrade-guide-version-3