### PR TITLE
Fix OpenTofu execution as admin

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/network.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/network.tf
@@ -13,14 +13,22 @@ data "openstack_networking_subnet_v2" "cluster_subnet" {
   name = each.value.subnet
 }
 
+data "openstack_identity_auth_scope_v3" "scope" {
+  # This is an arbitrary name which is only used as a unique identifier so an
+  # actual token isn't used as the ID.
+  name = "scope"
+}
+
 data "openstack_networking_secgroup_v2" "login" {
   for_each = toset(var.login_security_groups)
 
   name = each.key
+  tenant_id = data.openstack_identity_auth_scope_v3.scope.project_id
 }
 
 data "openstack_networking_secgroup_v2" "nonlogin" {
   for_each = toset(var.nonlogin_security_groups)
 
   name = each.key
+  tenant_id = data.openstack_identity_auth_scope_v3.scope.project_id
 }


### PR DESCRIPTION
Fetch authentication scope to retrieve the current project ID and use it for security groups. This makes it possible to apply OpenTofu using the admin role, which can be necessary for mapping instances to specific bare metal nodes.