### PR TITLE
Disable compute-init by default & warn of security issue

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -182,9 +182,8 @@ jobs:
         run: |
           . venv/bin/activate
           . environments/.stackhpc/activate
-          ansible-playbook -v --limit compute ansible/adhoc/rebuild.yml
-          ansible-playbook -v ansible/ci/check_slurm.yml
           ansible-playbook -v ansible/adhoc/reboot_via_slurm.yml
+          ansible-playbook -v ansible/ci/check_slurm.yml
 
       - name: Check sacct state survived reimage
         run: |

--- a/ansible/roles/compute_init/README.md
+++ b/ansible/roles/compute_init/README.md
@@ -9,9 +9,7 @@ mount the share on a user-controlled machine by tunnelling through a login
 node. This feature should not be enabled on production clusters at this time.
 
 To enable this:
-1. Add the `compute` group (or a subset) into the `compute_init` group. This is
-   the default when using cookiecutter to create an environment, via the
-   "everything" template.
+1. Add the `compute` group (or a subset) into the `compute_init` group.
 2. Build an image which includes the `compute_init` group. This is the case
    for StackHPC-built release images.
 3. Enable the required functionalities during boot, by setting the

--- a/ansible/roles/compute_init/README.md
+++ b/ansible/roles/compute_init/README.md
@@ -3,6 +3,11 @@
 Experimental functionality to allow compute nodes to rejoin the cluster after
 a reboot without running the `ansible/site.yml` playbook.
 
+**CAUTION:** The approach used here of exporting cluster secrets over NFS
+is considered to be a security risk due to the potential for cluster users to
+mount the share on a user-controlled machine by tunnelling through a login
+node. This feature should not be enabled on production clusters at this time.
+
 To enable this:
 1. Add the `compute` group (or a subset) into the `compute_init` group. This is
    the default when using cookiecutter to create an environment, via the

--- a/environments/.stackhpc/inventory/extra_groups
+++ b/environments/.stackhpc/inventory/extra_groups
@@ -41,3 +41,6 @@ control
 
 [cacerts:children]
 cluster
+
+[compute_init:children]
+compute

--- a/environments/common/layouts/everything
+++ b/environments/common/layouts/everything
@@ -93,9 +93,8 @@ cluster
 [sshd]
 # Hosts where the OpenSSH server daemon should be configured
 
-[compute_init:children]
+[compute_init]
 # EXPERIMENTAL: Compute hosts to enable joining cluster on boot on
-compute
 
 [k3s:children]
 # Hosts to run k3s server/agent


### PR DESCRIPTION
- Removes compute_init role from everything template, so it requires a manual opt-in
- Warns of security risk due to nfs export of secrets
- Fixes stackhpc CI (which still tests it)