### PR TITLE
Fix basic_users not modifying default nfs-shared home correctly

### DIFF
--- a/ansible/roles/basic_users/README.md
+++ b/ansible/roles/basic_users/README.md
@@ -2,16 +2,19 @@
 basic_users
 ===========
 
-Setup users on cluster nodes using `/etc/passwd` and manipulating `$HOME`, i.e. without requiring LDAP etc. Features:
+Setup users on cluster nodes using `/etc/passwd` and manipulating `$HOME`, i.e.
+without requiring LDAP etc. Features:
 - UID/GID is consistent across cluster (and explicitly defined).
 - SSH key generated and propagated to all nodes to allow login between cluster nodes.
 - An "external" SSH key can be added to allow login from elsewhere.
-- Login to the control node is prevented.
+- Login to the control node is prevented (by default)
 - When deleting users, systemd user sessions are terminated first.
 
 Requirements
 ------------
-- $HOME (for normal users, i.e. not `centos`) is assumed to be on a shared filesystem.
+- `$HOME` (for normal users, i.e. not `rocky`) is assumed to be on a shared
+  filesystem. Actions affecting that shared filesystem are run on a single host,
+  see `basic_users_manage_homedir` below.
 
 Role Variables
 --------------
@@ -25,6 +28,11 @@ Role Variables
   - Any other keys may present for other purposes (i.e. not used by this role).
 - `basic_users_groups`: Optional, default empty list. A list of mappings defining information for each group. Mapping keys/values are passed through as parameters to [ansible.builtin.group](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/group_module.html) and default values are as given there.
 - `basic_users_override_sssd`: Optional bool, default false. Whether to disable `sssd` when ensuring users/groups exist with this role. Permits creating local users/groups even if they clash with users provided via sssd (e.g. from LDAP). Ignored if host is not in group `sssd` as well. Note with this option active `sssd` will be stopped and restarted each time this role is run.
+- `basic_users_manage_homedir`: Optional bool, must be true on a single host to
+  determine which host runs tasks affecting the shared filesystem. The default
+  is to use the first play host which is not the control node, because the
+  default NFS configuration does not have the shared `/home` directory mounted
+  on the control node.
 
 Dependencies
 ------------

--- a/ansible/roles/basic_users/README.md
+++ b/ansible/roles/basic_users/README.md
@@ -25,6 +25,7 @@ Role Variables
   - `shell` if *not* set will be `/sbin/nologin` on the `control` node and the default shell on other users. Explicitly setting this defines the shell for all nodes.
   - An additional key `public_key` may optionally be specified to define a key to log into the cluster.
   - An additional key `sudo` may optionally be specified giving a string (possibly multiline) defining sudo rules to be templated.
+  - `ssh_key_type` defaults to `ed25519` instead of the `ansible.builtin.user` default of `rsa`.
   - Any other keys may present for other purposes (i.e. not used by this role).
 - `basic_users_groups`: Optional, default empty list. A list of mappings defining information for each group. Mapping keys/values are passed through as parameters to [ansible.builtin.group](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/group_module.html) and default values are as given there.
 - `basic_users_override_sssd`: Optional bool, default false. Whether to disable `sssd` when ensuring users/groups exist with this role. Permits creating local users/groups even if they clash with users provided via sssd (e.g. from LDAP). Ignored if host is not in group `sssd` as well. Note with this option active `sssd` will be stopped and restarted each time this role is run.

--- a/ansible/roles/basic_users/defaults/main.yml
+++ b/ansible/roles/basic_users/defaults/main.yml
@@ -1,4 +1,4 @@
-basic_users_manage_homedir: "{{ (ansible_hostname == (ansible_play_hosts | first)) }}"
+basic_users_manage_homedir: "{{ ansible_hostname == (ansible_play_hosts | difference(groups['control']) | first) }}"
 basic_users_userdefaults:
   state: present
   create_home: "{{ basic_users_manage_homedir }}"

--- a/ansible/roles/basic_users/defaults/main.yml
+++ b/ansible/roles/basic_users/defaults/main.yml
@@ -4,6 +4,7 @@ basic_users_userdefaults:
   create_home: "{{ basic_users_manage_homedir }}"
   generate_ssh_key:  "{{ basic_users_manage_homedir }}"
   ssh_key_comment: "{{ item.name }}"
+  ssh_key_type: ed25519
   shell: "{{'/sbin/nologin' if 'control' in group_names else omit }}"
 basic_users_users: []
 basic_users_groups: []

--- a/ansible/roles/basic_users/tasks/main.yml
+++ b/ansible/roles/basic_users/tasks/main.yml
@@ -48,18 +48,19 @@
     - basic_users_manage_homedir
 
 - name: Write generated public key as authorized for SSH access
+  # this only runs on the basic_users_manage_homedir so has registered var
+  # from that host too
   authorized_key:
     user: "{{ item.name }}"
     state: present
     manage_dir: no
     key: "{{ item.ssh_public_key }}"
-  loop: "{{ hostvars[ansible_play_hosts | first].basic_users_info.results }}"
+  loop: "{{ basic_users_info.results }}"
   loop_control:
     label: "{{ item.name }}"
   when:
   - item.ssh_public_key is defined
   - basic_users_manage_homedir
-  run_once: true
 
 - name: Write sudo rules
   blockinfile:

--- a/ansible/roles/basic_users/tasks/main.yml
+++ b/ansible/roles/basic_users/tasks/main.yml
@@ -46,7 +46,6 @@
     - item.state | default('present') == 'present'
     - item.public_key is defined
     - basic_users_manage_homedir
-  run_once: true
 
 - name: Write generated public key as authorized for SSH access
   authorized_key:


### PR DESCRIPTION
Fixes an issue where basic_users doesn't always modify /home correctly (i.e. create user home dirs and create/accept ssh keys) for the default NFS configuration, because the control node does not mount /home and might end up being the first host in the play and therefore running these tasks.

This has never been noticed because
a) this aspect of the demo_user isn't tested in CI
b) the caas environment does mount /home on the control node (to provide access to that to allow modification of packages etc across the cluster)

Also changes the default type of the created in-cluster ssh key from rsa to ed25519.