### PR TITLE
Support disabling port security

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
@@ -14,7 +14,8 @@ resource "openstack_networking_port_v2" "control" {
     subnet_id = data.openstack_networking_subnet_v2.cluster_subnet[each.key].id
   }
 
-  security_group_ids = [for o in data.openstack_networking_secgroup_v2.nonlogin: o.id]
+  port_security_enabled = lookup(each.value, "port_security_enabled", true)
+  security_group_ids = lookup(each.value, "port_security_enabled", true) ? [for o in data.openstack_networking_secgroup_v2.nonlogin: o.id] : []
 
   binding {
     vnic_type = lookup(var.vnic_types, each.key, "normal")

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -45,7 +45,8 @@ resource "openstack_networking_port_v2" "compute" {
     subnet_id = data.openstack_networking_subnet_v2.subnet[each.value.network].id
   }
 
-  security_group_ids = var.security_group_ids
+  port_security_enabled = lookup(each.value, "port_security_enabled", true)
+  security_group_ids = lookup(each.value, "port_security_enabled", true) ? var.security_group_ids : []
 
   binding {
     vnic_type = lookup(var.vnic_types, each.value.network, "normal")

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
@@ -13,8 +13,9 @@ variable "cluster_networks" {
     type = list(map(string))
     description = <<-EOT
         List of mappings defining networks. Mapping key/values:
-            network: Name of existing network
-            subnet: Name of existing subnet
+            network: Required. Name of existing network
+            subnet: Required. Name of existing subnet
+            port_security_enabled: Optional. Bool, default true
     EOT
 }
 


### PR DESCRIPTION
For e.g. IB networks it is necessary to not enable port security and therefore, not to try to apply security groups.