### PR TITLE
Prevent nfs being mounted by tunnelling/forwarding through login node

### DIFF
--- a/ansible/roles/sshd/README.md
+++ b/ansible/roles/sshd/README.md
@@ -5,5 +5,6 @@ Configure sshd.
 ## Role variables
 
 - `sshd_password_authentication`: Optional bool. Whether to enable password login. Default `false`.
+- `sshd_disable_forwarding`: Optional bool. Whether to disable all forwarding features (X11, ssh-agent, TCP and StreamLocal). Default `true`.
 - `sshd_conf_src`: Optional string. Path to sshd configuration template. Default is in-role template.
 - `sshd_conf_dest`: Optional string. Path to destination for sshd configuration file. Default is `/etc/ssh/sshd_config.d/10-ansible.conf` which overides `50-{cloud-init,redhat}` files, if present.

--- a/ansible/roles/sshd/defaults/main.yml
+++ b/ansible/roles/sshd/defaults/main.yml
@@ -1,3 +1,4 @@
 sshd_password_authentication: false
+sshd_disable_forwarding: true
 sshd_conf_src: sshd.conf.j2
 sshd_conf_dest: /etc/ssh/sshd_config.d/10-ansible.conf

--- a/ansible/roles/sshd/templates/sshd.conf.j2
+++ b/ansible/roles/sshd/templates/sshd.conf.j2
@@ -1,2 +1,3 @@
 # {{ ansible_managed }}
 PasswordAuthentication {{ 'yes' if sshd_password_authentication | bool else 'no' }}
+DisableForwarding {{ 'yes' if sshd_disable_forwarding | bool else 'no' }}

--- a/docs/networks.md
+++ b/docs/networks.md
@@ -14,6 +14,15 @@ as an SSH proxy to access the other nodes, this can create problems in recoverin
 the cluster if the login node is unavailable and can make Ansible problems harder
 to debug.
 
+> [!WARNING]
+> If home directories are on a shared filesystem with no authentication (such
+> as the default NFS share) then the network(s) the fileserver is attached to
+> form a security boundary. If an untrusted user can access these networks they
+> could mount the home directories setting any desired uid/gid.
+>
+> Ensure there is no external access to these networks and that no untrusted
+> instances are attached to them.
+
 This page describes supported configurations and how to implement them using
 the OpenTofu variables. These will normally be set in
 `environments/site/tofu/terraform.tfvars` for the site base environment. If they

--- a/environments/.stackhpc/inventory/group_vars/all/nfs.yml
+++ b/environments/.stackhpc/inventory/group_vars/all/nfs.yml
@@ -1,10 +1,3 @@
----
-
-# See: https://github.com/stackhpc/ansible-role-cluster-nfs
-# for variable definitions
-
-nfs_server_default: "{{ groups['control'] | first }}" # avoid using hostvars for compute-init
-
 nfs_configurations:
   - comment: Export /exports/home from Slurm control node as /home
     nfs_enable:
@@ -16,6 +9,9 @@ nfs_configurations:
     nfs_export: "/exports/home" # assumes skeleton TF is being used
     nfs_client_mnt_point: "/home"
 
-# Set 'secure' to prevent tunneling nfs mounts
-# Cannot set 'root_squash' due to home directory creation
-nfs_export_options: 'rw,secure,no_root_squash'
+  # EXPERIMENTAL - not generally secure
+  - comment: Export /exports/cluster from Slurm control node
+    nfs_enable:
+        server: "{{ inventory_hostname in groups['control'] }}"
+        clients: false
+    nfs_export: "/exports/cluster"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 roles:
   - src: stackhpc.nfs
-    version: v23.12.1 # Tolerate state nfs file handles
+    version: v25.2.1
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
     version: v0.27.0
     name: stackhpc.openhpc


### PR DESCRIPTION
- Disables ssh forwarding and sets `secure` on nfs exports to prevent mounting shares by tunnelling/forwarding through login node.
- Also removes /exports/cluster mount from default NFS configuration for safety.