### PR TITLE
Rename compute-init playbook to allow numerical sort

### DIFF
--- a/ansible/roles/compute_init/tasks/install.yml
+++ b/ansible/roles/compute_init/tasks/install.yml
@@ -58,7 +58,7 @@
 - name: Add compute initialisation playbook
   copy:
     src: compute-init.yml
-    dest: /etc/ansible-init/playbooks/1-compute-init.yml
+    dest: /etc/ansible-init/playbooks/10-compute-init.yml
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
Change the numerical prefix of the compute-init playbook, so that it can be lexicographically sorted.