### PR TITLE
Fix: Support networks not owned by openstack project

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
@@ -14,8 +14,8 @@ resource "openstack_networking_port_v2" "control" {
     subnet_id = data.openstack_networking_subnet_v2.cluster_subnet[each.key].id
   }
 
-  port_security_enabled = lookup(each.value, "port_security_enabled", true)
-  security_group_ids = lookup(each.value, "port_security_enabled", true) ? [for o in data.openstack_networking_secgroup_v2.nonlogin: o.id] : []
+  port_security_enabled = lookup(each.value, "port_security_enabled", null)
+  security_group_ids = lookup(each.value, "port_security_enabled", null) != false ? [for o in data.openstack_networking_secgroup_v2.nonlogin: o.id] : []
 
   binding {
     vnic_type = lookup(var.vnic_types, each.key, "normal")

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -45,8 +45,8 @@ resource "openstack_networking_port_v2" "compute" {
     subnet_id = data.openstack_networking_subnet_v2.subnet[each.value.network].id
   }
 
-  port_security_enabled = lookup(each.value, "port_security_enabled", true)
-  security_group_ids = lookup(each.value, "port_security_enabled", true) ? var.security_group_ids : []
+  port_security_enabled = lookup(each.value, "port_security_enabled", null)
+  security_group_ids = lookup(each.value, "port_security_enabled", null) != false ? var.security_group_ids : []
 
   binding {
     vnic_type = lookup(var.vnic_types, each.value.network, "normal")

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
@@ -15,7 +15,7 @@ variable "cluster_networks" {
         List of mappings defining networks. Mapping key/values:
             network: Required. Name of existing network
             subnet: Required. Name of existing subnet
-            port_security_enabled: Optional. Bool, default true
+            port_security_enabled: Optional. Bool, default null (for networks not owned by project)
     EOT
 }
 


### PR DESCRIPTION
Follow on for https://github.com/stackhpc/ansible-slurm-appliance/pull/592.

In projects which don't own their networks, port security cannot be manipulated.

Fix sets `port_security_enabled` default to `null`. When `null`, security groups are applied.