### PR TITLE
Disable nightly builds

### DIFF
--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -10,8 +10,8 @@ on:
             - LEAFCLOUD
             - SMS
             - ARCUS
-  schedule:
-    - cron: '0 0 * * *'  # Run at midnight on default branch
+  # schedule:
+  #   - cron: '0 0 * * *'  # Run at midnight on default branch
 
 jobs:
   openstack:


### PR DESCRIPTION
We don't use nightly builds for fatimages anymore, removing the nightly schedule to not waste resources.

Still allowing workflow dispatch as we might revisit at some point.