### PR TITLE
Fix chrony for nodes w/o network access (yet)

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -58,6 +58,12 @@
   tasks:
     - import_role:
         name: mrlesmithjr.chrony
+        # skip install tasks as might not have network yet
+        tasks_from: config_chrony.yml
+      vars:
+        # workaround for set_facts.yml:
+        chrony_config: /etc/chrony.conf
+        chrony_service: chronyd
 
 - hosts: cluster
   gather_facts: false


### PR DESCRIPTION
Need chrony early in the process, and it is currently before squid is setup.
The chrony role uses dnf which is a no-op wrt the chrony package (as it is installed in genericcloud images), but because one repo (TurboVNC) is enabled by default this triggers a metadata download, which then fails if the node is proxing through squid.

Fix is simply to never run the install tasks.