### PR TITLE
Fix documentation of sssd_install_ldap variable

### DIFF
--- a/ansible/roles/sssd/README.md
+++ b/ansible/roles/sssd/README.md
@@ -8,8 +8,8 @@ Install and configure [sssd](https://sssd.io/docs/introduction.html).
 The only required configuration is to create a [sssd.conf](https://www.mankier.com/5/sssd.conf) template at the location specified by `sssd_conf_src`.
 
 - `sssd_packages`: Optional list. Packages to install.
-- `sssd_ldap_install`: Optional bool. Whether to install packages enabling SSSD to authenticate against LDAP. Default `false`.
-- `sssd_ldap_packages`: Optional list. Packages to install when using `sssd_ldap_install`.
+- `sssd_install_ldap`: Optional bool. Whether to install packages enabling SSSD to authenticate against LDAP. Default `false`.
+- `sssd_ldap_packages`: Optional list. Packages to install when using `sssd_install_ldap`.
 - `sssd_enable_mkhomedir`: Optional bool. Whether to enable creation of home directories on login. Default `false`.
 - `sssd_mkhomedir_packages`: Optional list. Packages to install when using `sssd_enable_mkhomedir`.
 - `sssd_conf_src`: Optional string. Path to `sssd.conf` template. Default (which must be created) is `{{ appliances_environment_root }}/files/sssd.conf.j2`.


### PR DESCRIPTION
The sssd README was documenting the variable as `sssd_ldap_install` when it is actually `sssd_install_ldap`.