### PR TITLE
Fix builds not in stackhpc env

### DIFF
--- a/environments/.stackhpc/inventory/group_vars/all/openondemand.yml
+++ b/environments/.stackhpc/inventory/group_vars/all/openondemand.yml
@@ -4,5 +4,3 @@ openondemand_desktop_partition: standard
 #openondemand_dashboard_support_url: 
 #openondemand_dashboard_docs_url:
 #openondemand_filesapp_paths:
-ondemand_package: ondemand-"{{ ondemand_package_version }}"
-ondemand_package_version: '3.1.10'

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -5,6 +5,9 @@
 
 # NB: Variables prefixed ood_ are all from https://github.com/OSC/ood-ansible
 
+ondemand_package_version: '3.1.10' # used in ansible/cleanup.yml
+ondemand_package: ondemand-"{{ ondemand_package_version }}" # osc.ood role var controlling installed package
+
 openondemand_servername: "{{ hostvars[groups['openondemand'].0].ansible_host if groups['openondemand'] else '' }}"
 
 openondemand_auth: basic_pam


### PR DESCRIPTION
Currently builds not using the stackhpc fail because https://github.com/stackhpc/ansible-slurm-appliance/pull/600 means that cleanup.yml needed the ondemand package version which was only defined for the stackhpc environment.