### PR TITLE
Lustre: Harden mount options

### DIFF
--- a/ansible/roles/lustre/defaults/main.yml
+++ b/ansible/roles/lustre/defaults/main.yml
@@ -3,7 +3,7 @@ lustre_lnet_label: tcp
 #lustre_mgs_nid:
 lustre_mounts: []
 lustre_mount_state: mounted
-lustre_mount_options: 'defaults,_netdev,noauto,x-systemd.automount,x-systemd.requires=lnet.service'
+lustre_mount_options: 'defaults,_netdev,noauto,x-systemd.automount,x-systemd.requires=lnet.service,nosuid,nodev'
 
 # below variables are for build and should not generally require changes
 lustre_git_repo: "git://git.whamcloud.com/fs/lustre-release.git"


### PR DESCRIPTION
Prevents users from being able to escalate privileges with setuid binaries.