### PR TITLE
Manila/CephFS and NFS: harden mounts to prevent setuid and devices

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 roles:
   - src: https://github.com/stackhpc/ansible-role-cluster-nfs.git
-    version: v25.3.1
+    version: v25.3.2
     name: stackhpc.nfs
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
     version: v0.27.0
@@ -22,7 +22,7 @@ roles:
     version: v3.1.5
   - src: https://github.com/stackhpc/ansible-role-os-manila-mount.git
     name: stackhpc.os-manila-mount
-    version: v25.1.1
+    version: v25.3.1
   - src: mrlesmithjr.chrony
     version: v0.1.4
 


### PR DESCRIPTION
NB: No new image build has been done so these are not in the image for compute-init. That will be done later, with refactoring.