### PR TITLE
Enable creating users with local homedirs

### DIFF
--- a/ansible/roles/basic_users/defaults/main.yml
+++ b/ansible/roles/basic_users/defaults/main.yml
@@ -1,6 +1,6 @@
-basic_users_homedir_host: "{{ groups['control'] | first }}" # no way, generally, to find the nfs_server
-basic_users_homedir_host_path: /exports/home
-# _basic_users_manage_homedir: "{{ ansible_hostname == basic_users_homedir_host }}"
+basic_users_homedir_server: "{{ groups['control'] | first }}" # no way, generally, to find the nfs_server
+basic_users_homedir_server_path: /exports/home
+basic_users_homedir_client: "{{ groups['login'] | first }}"  
 basic_users_userdefaults:
   state: present # need this here so don't have to add default() everywhere
   generate_ssh_key:  true

--- a/ansible/roles/basic_users/tasks/main.yml
+++ b/ansible/roles/basic_users/tasks/main.yml
@@ -49,88 +49,90 @@
     state: started
   when: _stop_sssd is changed
 
-# This task runs (only) on the home directory server, if in the group, so it can
-# handle root squashed exports
+# This task runs only on the home directory server so it can handle
+# root-squashed exports
 - name: Create home directories
   # doesn't delete with state=absent, same as ansible.builtin.user
   ansible.builtin.copy:
     remote_src: true
     src: "{{ item.skeleton | default('/etc/skel/') }}"
-    dest: "{{ item.home | default( basic_users_homedir_host_path + '/' + item.name ) }}"
+    dest: "{{ item.home | default( basic_users_homedir_server_path + '/' + item.name ) }}"
     owner: "{{ item.name }}"
     group: "{{ item.name }}"
     mode: u=rwX,go=
-  delegate_to: "{{ basic_users_homedir_host }}"
-  run_once: true
   loop: "{{ basic_users_users }}"
   loop_control:
     label: "{{ item.name }}"
   when:
     - item.state | default('present') == 'present'
     - item.create_home | default(true) | bool
+    - inventory_hostname == basic_users_homedir_server
 
-# The following tasks deliberately run on a (single) *client* node, so that
-# home directory paths are easily constructed, becoming each user so that root
-# squash doesn't matter
-- delegate_to: "{{ groups['basic_users'] | difference([basic_users_homedir_host]) | first }}"
-  run_once: true
-  block:
-    - name: Create ~/.ssh directories
-      file:
-        state: directory
-        path: ~/.ssh/
-        owner: "{{ item.name }}"
-        group: "{{ item.name }}"
-        mode: u=rwX,go=
-      become_user: "{{ item.name }}"
-      loop: "{{ basic_users_users }}"
-      loop_control:
-        label: "{{ item.name }}"
-      when:
-        - item.state | default('present') == 'present'
+# The following tasks run on a single *client* node, so that home directory
+# paths are easily constructed, becoming each user so that root-squash
+# doesn't matter
+- name: Create ~/.ssh directories
+  file:
+    state: directory
+    path: ~/.ssh/
+    owner: "{{ item.name }}"
+    group: "{{ item.name }}"
+    mode: u=rwX,go=
+  become_user: "{{ item.name }}"
+  loop: "{{ basic_users_users }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.state | default('present') == 'present'
+    - item.generate_ssh_key | default(true) | bool or item.public_key is defined
+    - inventory_hostname == basic_users_homedir_client
 
-    - name: Generate cluster ssh key
-      community.crypto.openssh_keypair:
-        path: "{{ item.ssh_key_file | default('~/.ssh/id_' + _ssh_key_type )}}" # NB: ssh_key_file is from ansible.builtin.user
-        type: "{{ _ssh_key_type }}"
-        comment: "{{ item.ssh_key_comment | default(item.name) }}"
-      vars:
-        _ssh_key_type: "{{ item.ssh_key_type | default('ed25519') }}"
-      become_user: "{{ item.name }}"
-      loop: "{{ basic_users_users }}"
-      loop_control:
-        label: "{{ item.name }}"
-      when:
-        - item.state | default('present') == 'present'
-        - item.generate_ssh_key | default(true) | bool
-      register: _cluster_ssh_keypair
+- name: Generate cluster ssh key
+  community.crypto.openssh_keypair:
+    path: "{{ item.ssh_key_file | default('~/.ssh/id_' + _ssh_key_type )}}" # NB: ssh_key_file is from ansible.builtin.user
+    type: "{{ _ssh_key_type }}"
+    comment: "{{ item.ssh_key_comment | default(item.name) }}"
+  vars:
+    _ssh_key_type: "{{ item.ssh_key_type | default('ed25519') }}"
+  become_user: "{{ item.name }}"
+  loop: "{{ basic_users_users }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.state | default('present') == 'present'
+    - item.generate_ssh_key | default(true)
+    - inventory_hostname == basic_users_homedir_client
+  register: _cluster_ssh_keypair
 
-    - name: Write generated cluster ssh key to authorized_keys
-      ansible.posix.authorized_key:
-        user: "{{ item.item.name }}"
-        state: present
-        manage_dir: false
-        key: "{{ item.public_key }}"
-        path: ~/.ssh/authorized_keys
-      become_user: "{{ item.item.name }}"
-      loop: "{{ _cluster_ssh_keypair.results }}"
-      loop_control:
-        label: "{{ item.item.name }}"
-      when:
-        - item.item.state | default('present') == 'present'
-        - "'public_key' in item"
+- name: Write generated cluster ssh key to authorized_keys
+  ansible.posix.authorized_key:
+    user: "{{ item.item.name }}"
+    state: present
+    manage_dir: false
+    key: "{{ item.public_key }}"
+    path: ~/.ssh/authorized_keys
+  become_user: "{{ item.item.name }}"
+  loop: "{{ _cluster_ssh_keypair.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when:
+    - item.item.state | default('present') == 'present'
+    - item.item.generate_ssh_key | default(true)
+    - inventory_hostname == basic_users_homedir_client
+    - item.public_key is defined # NB this is the *returned* public key
 
-    - name: Write supplied public key to authorized_keys
-      ansible.posix.authorized_key:
-        user: "{{ item.name }}"
-        state: present
-        manage_dir: false
-        key: "{{ item.public_key }}"
-        path: ~/.ssh/authorized_keys
-      become_user: "{{ item.name }}"
-      loop: "{{ basic_users_users }}"
-      loop_control:
-        label: "{{ item.name }}"
-      when:
-        - item.state | default('present') == 'present'
-        - item.public_key is defined
+- name: Write supplied public key to authorized_keys
+  ansible.posix.authorized_key:
+    user: "{{ item.name }}"
+    state: present
+    manage_dir: false
+    key: "{{ item.public_key }}"
+    path: ~/.ssh/authorized_keys
+  become_user: "{{ item.name }}"
+  loop: "{{ basic_users_users }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.state | default('present') == 'present'
+    - inventory_hostname == basic_users_homedir_client
+    - item.public_key is defined # NB this is the *provided* public key


### PR DESCRIPTION
Fixes #625 

Also should allow the role as-is by compute-init as `basic_users_homedir_server` and `basic_users_homedir_client` won't, by default, match the inventory_hostname when running via ansible-init. However if these are overriden to be `inventory_hostname` then both directory creation and ssh key management run on each host, allowing non-shared home directories to be used both for normal ansible and compute-init.