### PR TITLE
Allow use of Ironic node name as instance name

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
@@ -27,6 +27,7 @@ module "compute" {
   ignore_image_changes = lookup(each.value, "ignore_image_changes", false)
   match_ironic_node = lookup(each.value, "match_ironic_node", false)
   availability_zone = lookup(each.value, "availability_zone", "nova")
+  use_ironic_node_name = lookup(each.value, "use_ironic_node_name", false)
 
   # computed
   # not using openstack_compute_instance_v2.control.access_ip_v4 to avoid

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -57,7 +57,7 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
 
   for_each = var.ignore_image_changes ? toset(var.nodes) : []
 
-  name = "${var.cluster_name}-${each.key}"
+  name = var.use_ironic_node_name ? "${each.key}" : "${var.cluster_name}-${each.key}"
   image_id = var.image_id
   flavor_name = var.flavor
   key_pair = var.key_pair
@@ -111,7 +111,7 @@ resource "openstack_compute_instance_v2" "compute" {
 
   for_each = var.ignore_image_changes ? [] : toset(var.nodes)
   
-  name = "${var.cluster_name}-${each.key}"
+  name = var.use_ironic_node_name ? "${each.key}" : "${var.cluster_name}-${each.key}"
   image_id = var.image_id
   flavor_name = var.flavor
   key_pair = var.key_pair

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
@@ -112,6 +112,12 @@ variable "match_ironic_node" {
     default = false
 }
 
+variable "use_ironic_node_name" {
+    type = bool
+    description = "Whether to name instances the same as the matching Ironic node (no cluster name)"
+    default = false
+}
+
 variable "availability_zone" {
     type = string
     description = "Name of availability zone - ignored unless match_ironic_node is true"


### PR DESCRIPTION
This can be used in bare metal deployments where we may want the instance hostname to be exactly the same as the node name.