### PR TITLE
Allow empty items in extra package and user lists

### DIFF
--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -79,7 +79,7 @@ appliances_local_users_default:
 
 # Overide this to add extra users whilst keeping the defaults.
 appliances_local_users_extra: [] # see format of appliances_local_users_default above
-appliances_local_users: "{{ appliances_local_users_default + appliances_local_users_extra }}"
+appliances_local_users: "{{ (appliances_local_users_default + appliances_local_users_extra) | select | list }}"
 
 ################## bootstrap: extra package installs ######################################
 
@@ -97,7 +97,7 @@ appliances_extra_packages_default:
  
 appliances_extra_packages_other: []
   
-appliances_extra_packages: "{{ appliances_extra_packages_default + appliances_extra_packages_other }}"
+appliances_extra_packages: "{{ (appliances_extra_packages_default + appliances_extra_packages_other) | select | list }}"
 
 ###################### ark repo timestamps ###################################################
 

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -28,7 +28,7 @@ openhpc_packages_default:
   - apptainer
   - podman-compose
 openhpc_packages_extra: []
-openhpc_packages: "{{ openhpc_packages_default + openhpc_packages_extra }}"
+openhpc_packages: "{{ (openhpc_packages_default + openhpc_packages_extra) | select | list }}"
 openhpc_munge_key: "{{ vault_openhpc_mungekey | b64decode }}"
 openhpc_login_only_nodes: login
 openhpc_config_default:


### PR DESCRIPTION
This enables defining extra packages and users based on some conditions. For example:

    appliances_extra_packages_other:
      - "{{ 'cuda-toolkit' if 'cuda' in group_names }}"