### PR TITLE
Use checksum verification for CernVM-FS GPG key

### DIFF
--- a/ansible/roles/eessi/defaults/main.yaml
+++ b/ansible/roles/eessi/defaults/main.yaml
@@ -9,3 +9,5 @@ cvmfs_config_default:
 cvmfs_config_overrides: {}
 
 cvmfs_config: "{{ cvmfs_config_default | combine(cvmfs_config_overrides) }}"
+
+cvmfs_gpg_checksum: "sha256:4ac81adff957565277cfa6a4a330cdc2ce5a8fdd73b8760d1a5a32bef71c4bd6"

--- a/ansible/roles/eessi/tasks/main.yaml
+++ b/ansible/roles/eessi/tasks/main.yaml
@@ -1,8 +1,9 @@
 ---
 - name: Download Cern GPG key
   ansible.builtin.get_url:
-    url: http://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM 
+    url: http://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
     dest: ./cvmfs-key.gpg
+    checksum: "{{ cvmfs_gpg_checksum }}"
 
 - name: Import downloaded GPG key
   command: rpm --import cvmfs-key.gpg
@@ -24,7 +25,7 @@
 
 # Alternative version using official repo - still no GPG key :(
 # - name: Add EESSI repo
-#   dnf: 
+#   dnf:
 #     name: http://repo.eessi-infra.org/eessi/rhel/8/noarch/eessi-release-0-1.noarch.rpm
 
 # - name: Install EESSI CVMFS config
@@ -39,7 +40,7 @@
     value: "{{ item.value }}"
     no_extra_spaces: true
   loop: "{{ cvmfs_config | dict2items }}"
-    
+
 
 # NOTE: Not clear how to make this idempotent
 - name: Ensure CVMFS config is setup


### PR DESCRIPTION
The cvmrepo repository is sometimes down. This avoids fetching the GPG key each time if it was already done, preventing Ansible failures.

It also verifies that the key is the expected one instead of blindly trusting any GPG key.

This should not require much maintenance since the key appears to be the same since it was generated in 2010.