### PR TITLE
bump CI image

### DIFF
--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-250408-0812-c3b68b9c",
-        "RL9": "openhpc-RL9-250408-0813-c3b68b9c"
+        "RL8": "openhpc-RL8-250408-1416-9ca2d7f9",
+        "RL9": "openhpc-RL9-250408-1416-9ca2d7f9"
     }
 }


### PR DESCRIPTION
testing whether the logic re. waiting for nfs in compute-init is borked.

Image build: https://github.com/stackhpc/ansible-slurm-appliance/actions/runs/14335855199