### PR TITLE
Allow modifying nodes fully-qualified name

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -91,9 +91,9 @@ jobs:
         run: dev/setup-env.sh
 
       - name: Install OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@v1.0.5
         with:
-          tofu_version: 1.6.2
+          tofu_version: 1.9.0
 
       - name: Initialise tofu
         run: tofu init

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
@@ -19,7 +19,8 @@ module "compute" {
   volume_backed_instances = lookup(each.value, "volume_backed_instances", var.volume_backed_instances)
   root_volume_size = lookup(each.value, "root_volume_size", var.root_volume_size)
   gateway_ip = lookup(each.value, "gateway_ip", var.gateway_ip)
-  
+  nodename_template = lookup(each.value, "nodename_template", var.cluster_nodename_template)
+
   # optionally set for group:
   networks = concat(var.cluster_networks, lookup(each.value, "extra_networks", []))
   extra_volumes = lookup(each.value, "extra_volumes", {})

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
@@ -3,9 +3,10 @@ locals {
   nodename = templatestring(
     var.cluster_nodename_template,
     {
-      node="control",
-      cluster_name=var.cluster_name,
-      cluster_domain_suffix=var.cluster_domain_suffix
+      node = "control",
+      cluster_name = var.cluster_name,
+      cluster_domain_suffix = var.cluster_domain_suffix,
+      environment_name = basename(var.environment_root)
     }
   )
 }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
@@ -24,7 +24,7 @@ resource "openstack_networking_port_v2" "control" {
 
 resource "openstack_compute_instance_v2" "control" {
   
-  name = "${var.cluster_name}-control"
+  name = split(".", templatestring(var.cluster_nodename_template, {node="control", cluster_name=var.cluster_name,cluster_domain_suffix=var.cluster_domain_suffix}))[0]
   image_id = var.cluster_image_id
   flavor_name = var.control_node_flavor
   key_pair = var.key_pair
@@ -65,7 +65,7 @@ resource "openstack_compute_instance_v2" "control" {
 
   user_data = <<-EOF
     #cloud-config
-    fqdn: ${var.cluster_name}-control.${var.cluster_name}.${var.cluster_domain_suffix}
+    fqdn: ${templatestring(var.cluster_nodename_template, {node="control", cluster_name=var.cluster_name,cluster_domain_suffix=var.cluster_domain_suffix})}
     
     bootcmd:
       %{for volume in local.control_volumes}

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
@@ -19,6 +19,7 @@ module "login" {
   volume_backed_instances = lookup(each.value, "volume_backed_instances", var.volume_backed_instances)
   root_volume_size = lookup(each.value, "root_volume_size", var.root_volume_size)
   gateway_ip = lookup(each.value, "gateway_ip", var.gateway_ip)
+  nodename_template = lookup(each.value, "nodename_template", var.cluster_nodename_template)
   
   # optionally set for group
   networks = concat(var.cluster_networks, lookup(each.value, "extra_networks", []))

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/main.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.7" # templatestring() function
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -57,7 +57,7 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
 
   for_each = var.ignore_image_changes ? toset(var.nodes) : []
 
-  name = "${var.cluster_name}-${each.key}"
+  name = split(".", templatestring(var.nodename_template, {node=each.key, cluster_name=var.cluster_name,cluster_domain_suffix=var.cluster_domain_suffix}))[0]
   image_id = var.image_id
   flavor_name = var.flavor
   key_pair = var.key_pair
@@ -94,7 +94,7 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
 
   user_data = <<-EOF
     #cloud-config
-    fqdn: ${var.cluster_name}-${each.key}.${var.cluster_name}.${var.cluster_domain_suffix}
+    fqdn: ${templatestring(var.nodename_template, {node=each.key, cluster_name=var.cluster_name,cluster_domain_suffix=var.cluster_domain_suffix})}
   EOF
 
   availability_zone = var.match_ironic_node ? "${var.availability_zone}::${var.baremetal_nodes[each.key]}" : null
@@ -111,7 +111,7 @@ resource "openstack_compute_instance_v2" "compute" {
 
   for_each = var.ignore_image_changes ? [] : toset(var.nodes)
   
-  name = "${var.cluster_name}-${each.key}"
+  name = split(".", templatestring(var.nodename_template, {node=each.key, cluster_name=var.cluster_name,cluster_domain_suffix=var.cluster_domain_suffix}))[0]
   image_id = var.image_id
   flavor_name = var.flavor
   key_pair = var.key_pair
@@ -148,7 +148,7 @@ resource "openstack_compute_instance_v2" "compute" {
 
   user_data = <<-EOF
     #cloud-config
-    fqdn: ${var.cluster_name}-${each.key}.${var.cluster_name}.${var.cluster_domain_suffix}
+    fqdn: ${templatestring(var.nodename_template, {node=each.key, cluster_name=var.cluster_name,cluster_domain_suffix=var.cluster_domain_suffix})}
   EOF
 
   availability_zone = var.match_ironic_node ? "${var.availability_zone}::${var.baremetal_nodes[each.key]}" : null

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -18,9 +18,10 @@ locals {
     for n in var.nodes: n => templatestring(
       var.nodename_template,
       {
-        node=n,
-        cluster_name=var.cluster_name,
-        cluster_domain_suffix=var.cluster_domain_suffix
+        node = n,
+        cluster_name = var.cluster_name,
+        cluster_domain_suffix = var.cluster_domain_suffix,
+        environment_name = basename(var.environment_root)
       }
     )
   }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
@@ -127,3 +127,8 @@ variable "gateway_ip" {
     type = string
     default = ""
 }
+
+variable "nodename_template" {
+    type = string
+    default = ""
+}

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
@@ -190,7 +190,8 @@ variable "cluster_nodename_template" {
             $${cluster_domain_suffix}: From var.cluster_domain_suffix
             $${node}: The current entry in the "nodes" parameter for nodes
             defined by var.compute and var.login, or "control" for the control
-            node.
+            node
+            $${environment_name}: The last element of the current environment's path
     EOT
     type = string
     default = "$${cluster_name}-$${node}.$${cluster_name}.$${cluster_domain_suffix}"

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
@@ -61,6 +61,7 @@ variable "login" {
         match_ironic_node: Set true to launch instances on the Ironic node of the same name as each cluster node
         availability_zone: Name of availability zone - ignored unless match_ironic_node is true (default: "nova")
         gateway_ip: Address to add default route via
+        nodename_template: Overrides variable cluster_nodename_template
   EOF
 }
 
@@ -97,6 +98,7 @@ variable "compute" {
             match_ironic_node: Set true to launch instances on the Ironic node of the same name as each cluster node
             availability_zone: Name of availability zone - ignored unless match_ironic_node is true (default: "nova")
             gateway_ip: Address to add default route via
+            nodename_template: Overrides variable cluster_nodename_template
     EOF
 }
 
@@ -178,4 +180,18 @@ variable "gateway_ip" {
     description = "Address to add default route via"
     type = string
     default = ""
+}
+
+variable "cluster_nodename_template" {
+    description = <<-EOT
+        Template for node fully-qualified names. The following interpolations
+        can be used:
+            $${cluster_name}: From var.cluster_name
+            $${cluster_domain_suffix}: From var.cluster_domain_suffix
+            $${node}: The current entry in the "nodes" parameter for nodes
+            defined by var.compute and var.login, or "control" for the control
+            node.
+    EOT
+    type = string
+    default = "$${cluster_name}-$${node}.$${cluster_name}.$${cluster_domain_suffix}"
 }


### PR DESCRIPTION
Adds an opentofu variable `cluster_nodename_template` plus overrides `nodename_template` for compute and login node groups, to allow defining the fully-qualified hostname for all nodes.

Note the appliance (and roles it uses) assume that the short hostname is resolvable (normally ensured by `etc_hosts` role), and that this matches the Ansible `inventory_hostname` and the slurm node name.