### PR TITLE
Fix fatimage build without alertmanager secret

### DIFF
--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-250422-1328-1a6eff86",
-        "RL9": "openhpc-RL9-250422-1328-1a6eff86"
+        "RL8": "openhpc-RL8-250423-1606-b61e2f1a",
+        "RL9": "openhpc-RL9-250423-1606-b61e2f1a"
     }
 }

--- a/environments/common/inventory/group_vars/all/prometheus.yml
+++ b/environments/common/inventory/group_vars/all/prometheus.yml
@@ -15,7 +15,9 @@ prometheus_alertmanager_config_default:
       - "{{ alertmanager_address }}:{{ alertmanager_port }}"
     basic_auth:
       username: alertmanager
-      password: "{{ vault_alertmanager_admin_password }}"
+      # cloudalchemy.prometheus/preflight checks this config so it must be
+      # templatable even during build when it is not used
+      password: "{{ vault_alertmanager_admin_password | default('UNDEFINED') }}"
 
 prometheus_alertmanager_config_extra: []
 prometheus_alertmanager_config: "{{ (prometheus_alertmanager_config_default if groups['alertmanager'] else []) + prometheus_alertmanager_config_extra }}"


### PR DESCRIPTION
`cloudalchemy.prometheus:preflight.yml` checks `prometheus_alertmanager_config`, which means it must be templatable even during build when it is not used. Build in CI does not generate secrets, (deliberately, so we check it is not injecting them at all) so `vault_alertmanager_admin_password` was not defined. 