### PR TITLE
Fix creation of hpctests directory

### DIFF
--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 hpctests_user: "{{ ansible_user }}"
+hpctests_group: "{{ ansible_user }}"
 hpctests_rootdir: "/home/{{ hpctests_user }}/hpctests"
 hpctests_pre_cmd: ''
 hpctests_pingmatrix_modules: [gnu12 openmpi4]

--- a/ansible/roles/hpctests/tasks/setup.yml
+++ b/ansible/roles/hpctests/tasks/setup.yml
@@ -26,7 +26,7 @@
     path: "{{ hpctests_rootdir }}"
     state: directory
     owner: "{{ hpctests_user }}"
-    group: "{{ hpctests_user }}"
+    group: "{{ hpctests_group }}"
 
 - name: Set fact for UCX_NET_DEVICES
   set_fact:


### PR DESCRIPTION
The hpctests role creates a directory that is user-owned and group-owned by hpctests_user, which defaults to ansible_user. However, this group is not guaranteed to exist, especially in LDAP environments where groups dedicated to a single user are often not used.

Support customising the value via the hpctests_group variable, while still defaulting to hpctests_user.