### PR TITLE
Default hpctests_group to hpctests_user

### DIFF
--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 hpctests_user: "{{ ansible_user }}"
-hpctests_group: "{{ ansible_user }}"
+hpctests_group: "{{ hpctests_user }}"
 hpctests_rootdir: "/home/{{ hpctests_user }}/hpctests"
 hpctests_pre_cmd: ''
 hpctests_pingmatrix_modules: [gnu12 openmpi4]


### PR DESCRIPTION
https://github.com/stackhpc/ansible-slurm-appliance/pull/659 added `hpctests_group` but in a way which broke sites which set `hpctests_user` but not `hpctests_group`, which includes the default cookiecutter-produced environment and caas. This fixes that PR to be backwards-compatible.