### PR TITLE
Allow enabling package installs for caas clusters via extravars

### DIFF
--- a/ansible/disable-repos.yml
+++ b/ansible/disable-repos.yml
@@ -5,3 +5,4 @@
       ansible.builtin.include_role:
         name: dnf_repos
         tasks_from: disable_repos.yml
+      when: not dnf_repos_enabled | default(false) | bool

--- a/environments/.caas/hooks/pre.yml
+++ b/environments/.caas/hooks/pre.yml
@@ -51,3 +51,15 @@
   tasks:
     - name: Reset persistent SSH connections
       meta: reset_connection
+
+- hosts: localhost
+  gather_facts: no
+  become: no
+  tasks:
+    - name: Add hosts to dnf_repos group to enable repofiles
+      ansible.builtin.add_host:
+        name: "{{ item }}"
+        groups:
+          - dnf_repos
+      loop: "{{ groups['cluster'] }}"
+      when: dnf_repos_enabled | default(false) | bool


### PR DESCRIPTION
Allows caas to be configured from Azimuth extravars to enable package installs. Requires the following to be set:

```yaml
dnf_repos_enabled: true
dnf_repos_username: $CLIENT_USERNAME
dnf_repos_password: $CLIENT_PASSWORD
dnf_repos_allow_insecure_creds: true
```

> [!WARNING]
> This will expose Ark credentials to the `azimuth` user.