### PR TITLE
Perform Slurm database upgrade if necessary

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -230,6 +230,16 @@ jobs:
         env:
           DEMO_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
 
+      - name: Delete possible volume snapshot from slurm upgrade
+        run: |
+          . venv/bin/activate
+          . environments/.stackhpc/activate  
+          if [ -n "$SNAPSHOT" ]
+          then
+              echo Deleting $SNAPSHOT
+              openstack volume snapshot delete $SNAPSHOT
+          fi
+
       - name: Delete infrastructure
         run: |
           . venv/bin/activate

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-250506-1259-abb6394b",
-        "RL9": "openhpc-RL9-250506-1259-abb6394b"
+        "RL8": "openhpc-RL8-250513-1045-ca44f898",
+        "RL9": "openhpc-RL9-250513-1046-ca44f898"
     }
 }

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-250513-1045-ca44f898",
-        "RL9": "openhpc-RL9-250513-1046-ca44f898"
+        "RL8": "openhpc-RL8-250514-1502-5a923b2c",
+        "RL9": "openhpc-RL9-250514-1502-5a923b2c"
     }
 }

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -20,7 +20,6 @@ openhpc_slurm_partitions:
 openhpc_packages_default:
   # system packages
   - podman
-  - mysql
   # OpenHPC packages
   - slurm-libpmi-ohpc # to allow intel mpi to work properly
   - ohpc-gnu12-openmpi4-perf-tools # for hpctests

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -57,3 +57,8 @@ ohpc_openhpc_repos:
 ohpc_default_extra_repos:
   "9": []
   "8": []
+
+# systemd.service.unit.TimeoutStartSec to wait for slurmdbd startup
+# Set long enought to avoid problems with a major version upgrade
+# Currently implemented in environments/common/inventory/group_vars/all/systemd.yml
+openhpc_slurmdbd_timeout_start_sec: '45 minutes'

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -20,6 +20,7 @@ openhpc_slurm_partitions:
 openhpc_packages_default:
   # system packages
   - podman
+  - mysql
   # OpenHPC packages
   - slurm-libpmi-ohpc # to allow intel mpi to work properly
   - ohpc-gnu12-openmpi4-perf-tools # for hpctests

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -58,7 +58,12 @@ ohpc_default_extra_repos:
   "9": []
   "8": []
 
-# systemd.service.unit.TimeoutStartSec to wait for slurmdbd startup
-# Set long enought to avoid problems with a major version upgrade
-# Currently implemented in environments/common/inventory/group_vars/all/systemd.yml
-openhpc_slurmdbd_timeout_start_sec: '45 minutes'
+# configure slurm database pre-upgrade backups:
+openhpc_slurm_accounting_storage_service: mysql
+openhpc_slurm_accounting_storage_backup_cmd: >-
+  openstack volume snapshot create
+  --volume {{ openhpc_cluster_name }}-state
+  --force
+  {{ openhpc_cluster_name }}-state-{{ ansible_date_time.iso8601_basic_short }}
+openhpc_slurm_accounting_storage_backup_host: localhost
+openhpc_slurm_accounting_storage_backup_become: false

--- a/environments/common/inventory/group_vars/all/systemd.yml
+++ b/environments/common/inventory/group_vars/all/systemd.yml
@@ -14,13 +14,7 @@ systemd_dropins:
     content: "{{ _systemd_requiresmount_statedir }}"
   slurmdbd:
     group: openhpc
-    content: |
-      {{ _systemd_requiresmount_statedir }}
-      
-      [Service]
-      # Allow slurmdbd to complete major version upgrades
-      TimeoutStartSec={{ openhpc_slurmdbd_timeout_start_sec }}
-
+    content: "{{ _systemd_requiresmount_statedir }}"
   slurmctld:
     group: openhpc
     content: "{{ _systemd_requiresmount_statedir }}"

--- a/environments/common/inventory/group_vars/all/systemd.yml
+++ b/environments/common/inventory/group_vars/all/systemd.yml
@@ -1,9 +1,11 @@
 _systemd_requiresmount_statedir: |
+  {% if appliances_state_dir is defined %}
   [Unit]
   RequiresMountsFor={{ appliances_state_dir | default('') }}
+  {% endif %}
 
-_systemd_dropins_statedir:
-  # mysql not included as role handles state dir correctly
+systemd_dropins:
+  # NB: mysql does not need _systemd_requiresmount_statedir as role handles state dir correctly
   opensearch:
     group: opensearch
     content: "{{ _systemd_requiresmount_statedir }}"
@@ -12,12 +14,16 @@ _systemd_dropins_statedir:
     content: "{{ _systemd_requiresmount_statedir }}"
   slurmdbd:
     group: openhpc
-    content: "{{ _systemd_requiresmount_statedir }}"
+    content: |
+      {{ _systemd_requiresmount_statedir }}
+      
+      [Service]
+      # Allow slurmdbd to complete major version upgrades
+      TimeoutStartSec={{ openhpc_slurmdbd_timeout_start_sec }}
+
   slurmctld:
     group: openhpc
     content: "{{ _systemd_requiresmount_statedir }}"
   prometheus:
     group: prometheus
     content: "{{ _systemd_requiresmount_statedir }}"
-
-systemd_dropins: "{{ _systemd_dropins_statedir if appliances_state_dir is defined else {} }}"

--- a/environments/common/inventory/group_vars/all/timestamps.yml
+++ b/environments/common/inventory/group_vars/all/timestamps.yml
@@ -63,10 +63,10 @@ appliances_pulp_repos:
   openhpc_updates:
     '8':
       path: OpenHPC/2/updates/EL_8
-      timestamp: 20241218T154614
+      timestamp: 20250512T003315
     '9':
       path: OpenHPC/3/updates/EL_9
-      timestamp: 20241218T154614
+      timestamp: 20250510T003301
   grafana:
     '8':
       path: grafana/oss/rpm

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: v25.3.2
     name: stackhpc.nfs
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: 'feat/upgrade-db' # local - TODO: bump on release
+    version: 362e3fc # feat/upgrade-db TODO: bump on release
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: stackhpc

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: v25.3.2
     name: stackhpc.nfs
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: 362e3fc # feat/upgrade-db TODO: bump on release
+    version: v0.30.0
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: stackhpc

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: v25.3.2
     name: stackhpc.nfs
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v0.28.0
+    version: 'feat/upgrade-db' # local - TODO: bump on release
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: stackhpc


### PR DESCRIPTION
Integrates https://github.com/stackhpc/ansible-role-openhpc/pull/186 to upgrade Slurm database if necessary. A snapshot of the state volume is taken before upgrading, timestamped with the current date/time.