### PR TITLE
Fix tuned hpc-compute with hugepages and verify applied profile

### DIFF
--- a/ansible/roles/tuned/tasks/configure.yml
+++ b/ansible/roles/tuned/tasks/configure.yml
@@ -12,9 +12,17 @@
   register: _tuned_profile_current
   changed_when: false
 
-- name: Set tuned-adm profile
+- name: Set TuneD profile
   ansible.builtin.command:
     cmd: "tuned-adm profile {{ tuned_profile }}"
-  when: 
+  when:
+    - tuned_started | bool
+    - tuned_profile not in _tuned_profile_current.stdout
+
+- name: Verify TuneD profile
+  ansible.builtin.command:
+    cmd: tuned-adm verify
+  changed_when: false
+  when:
     - tuned_started | bool
     - tuned_profile not in _tuned_profile_current.stdout

--- a/ansible/roles/tuned/tasks/install.yml
+++ b/ansible/roles/tuned/tasks/install.yml
@@ -3,3 +3,14 @@
   ansible.builtin.dnf:
     name: tuned
     state: present
+
+- name: Fix TuneD hpc-compute profile for hugepages
+  # See https://github.com/redhat-performance/tuned/issues/752
+  # This is done on install, not configure, so that it is available even
+  # for compute-init nodes
+  community.general.ini_file:
+    path: /usr/lib/tuned/hpc-compute/tuned.conf
+    section: sysctl
+    option: vm.min_free_kbytes
+    value: '>135168'
+    no_extra_spaces: true

--- a/environments/.stackhpc/inventory/extra_groups
+++ b/environments/.stackhpc/inventory/extra_groups
@@ -29,7 +29,10 @@ cluster
 
 [tuned:children]
 # Install tuned into fat image
+# NB: builder has tuned_enabled and tuned_started false so does not configure it
 builder
+# Also test tuned during site playbook
+cluster
 
 [squid:children]
 # Install squid into fat image

--- a/environments/.stackhpc/inventory/group_vars/all/tuned.yml
+++ b/environments/.stackhpc/inventory/group_vars/all/tuned.yml
@@ -1,0 +1,2 @@
+# Set profile which is not default (on VMs) for testing
+tuned_profile: hpc-compute


### PR DESCRIPTION
- Fixes [a bug](https://github.com/redhat-performance/tuned/issues/752) with tuned hpc-compute profile (the default for baremetal nodes) when hugepages is enabled.
- Adds verification when changing the selected tuned profile
- Tests the `tuned` role in stackhpc environment
