### PR TITLE
Update openhpc role to allow removing slurm.conf parameters

### DIFF
--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -44,11 +44,9 @@ openhpc_packages_extra: []
 openhpc_packages: "{{ (openhpc_packages_default + openhpc_packages_extra) | select | list }}"
 openhpc_munge_key: "{{ vault_openhpc_mungekey | b64decode }}"
 openhpc_login_only_nodes: login
+openhpc_slurm_configless: true
 openhpc_config_default:
-  SlurmctldParameters:
-    - enable_configless
   TaskPlugin: task/cgroup,task/affinity
-  ReturnToService: 2 # is stackhpc.openhpc default, but templating bug means it is needed here too
 openhpc_config_rebuild:
   RebootProgram: /opt/slurm-tools/bin/slurm-openstack-rebuild
   SlurmctldParameters:

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: v25.3.2
     name: stackhpc.nfs
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v1.0.0
+    version: feat/simpler-templating # TODO: bump to release
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: stackhpc


### PR DESCRIPTION
Enables setting 'omit' as a value in `openhpc_config` to remove a default parameter from slurm.conf entirely.
