### PR TITLE
Fix environment creation from skeleton

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/inventory/group_vars/all/alertmanager.yml
+++ b/environments/skeleton/{{cookiecutter.environment}}/inventory/group_vars/all/alertmanager.yml
@@ -1,6 +1,6 @@
 # Uncomment below and add Slack bot app creds in the adjacent file
-# vault_alertmanager.ym for Slack integration:
+# vault_alertmanager.yml for Slack integration:
 #
 # alertmanager_slack_integration:
 #   channel: '#alerts'
-#   app_creds: "{{ vault_alertmanager_slack_integration_app_creds }}"
+#   app_creds: "{% raw %}{{ vault_alertmanager_slack_integration_app_creds }}{% endraw %}"


### PR DESCRIPTION
Running `cookiecutter skeleton` fails with:

    Unable to create file 'inventory/group_vars/all/alertmanager.yml'
    Error message: 'vault_alertmanager_slack_integration_app_creds' is undefined

This is caused by cookiecutter templating which needs to be escaped.

Fix a typo as well.