### PR TITLE
Add fix for Lustre bug LU-18085

### DIFF
--- a/ansible/roles/lustre/README.md
+++ b/ansible/roles/lustre/README.md
@@ -7,8 +7,7 @@ Install and configure a Lustre client. This builds RPM packages from source.
 **NB:** Currently this only supports RockyLinux 9.
 
 ## Role Variables
-
-- `lustre_version`: Optional str. Version of lustre to build, default `2.15.6` which is the first version with EL9.5 support
+The following variables control configuration of Lustre clients.
 - `lustre_lnet_label`: Optional str. The "lnet label" part of the host's NID, e.g. `tcp0`. Only the `tcp` protocol type is currently supported. Default `tcp`.
 - `lustre_mgs_nid`: Required str. The NID(s) for the MGS, e.g. `192.168.227.11@tcp1` (separate mutiple MGS NIDs using `:`).
 - `lustre_mounts`: Required list. Define Lustre filesystems and mountpoints as a list of dicts with keys:
@@ -19,7 +18,11 @@ Install and configure a Lustre client. This builds RPM packages from source.
 - `lustre_mount_state`. Optional default mount state for all mounts, as for [ansible.posix.mount](https://docs.ansible.com/ansible/latest/collections/ansible/posix/mount_module.html#parameter-state). Default is `mounted`.
 - `lustre_mount_options`. Optional default mount options. Default values are systemd defaults from [Lustre client docs](http://wiki.lustre.org/Mounting_a_Lustre_File_System_on_Client_Nodes).
 
-The following variables control the package build and and install and should not generally be required:
+The following variables control the package build and and install:
+- `lustre_version`: Optional str. Version of lustre to build, default `2.15.6/lu-18085`
+  which is the first version with EL9.5 support, plus a fix for https://jira.whamcloud.com/browse/LU-18085.
+- `lustre_repo`: Optional str. URL for Lustre repo. Default is a StackHPC repo
+  incorporating the above fix.
 - `lustre_build_packages`: Optional list. Prerequisite packages required to build Lustre. See `defaults/main.yml`.
 - `lustre_build_dir`: Optional str. Path to build lustre at, default `/tmp/lustre-release`.
 - `lustre_configure_opts`: Optional list. Options to `./configure` command. Default builds client rpms supporting Mellanox OFED, without support for GSS keys.

--- a/ansible/roles/lustre/defaults/main.yml
+++ b/ansible/roles/lustre/defaults/main.yml
@@ -1,4 +1,5 @@
-lustre_version: '2.15.6' # https://www.lustre.org/lustre-2-15-6-released/
+lustre_repo: https://github.com/stackhpc/lustre-release.git
+lustre_version: '2.15.6/lu-18085' # Fixes https://jira.whamcloud.com/browse/LU-18085
 lustre_lnet_label: tcp
 #lustre_mgs_nid:
 lustre_mounts: []

--- a/ansible/roles/lustre/tasks/install.yml
+++ b/ansible/roles/lustre/tasks/install.yml
@@ -4,9 +4,8 @@
   register: _lustre_dnf_build_packages
  
 - name: Clone lustre git repo
-  # https://git.whamcloud.com/?p=fs/lustre-release.git;a=summary
   ansible.builtin.git:
-    repo: "{{ lustre_git_repo }}"
+    repo: "{{ lustre_repo }}"
     dest: "{{ lustre_build_dir }}"
     version: "{{ lustre_version }}"
 


### PR DESCRIPTION
Fixes https://jira.whamcloud.com/browse/LU-18085 affecting Lustre on RockyLinux 9.5, using  a StackHPC repo containing the fix.

Once a later version is released the whamcloud repo for that version should contain the fix.

Client on RL9 system has confirmed benchmarks using the original version of this PR before upstreaming have succeeded.