### PR TITLE
Allow specifying instance root volume type

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/compute.tf
@@ -18,6 +18,7 @@ module "compute" {
   vnic_types = lookup(each.value, "vnic_types", var.vnic_types)
   volume_backed_instances = lookup(each.value, "volume_backed_instances", var.volume_backed_instances)
   root_volume_size = lookup(each.value, "root_volume_size", var.root_volume_size)
+  root_volume_type = lookup(each.value, "root_volume_type", var.root_volume_type)
   gateway_ip = lookup(each.value, "gateway_ip", var.gateway_ip)
   nodename_template = lookup(each.value, "nodename_template", var.cluster_nodename_template)
 

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
@@ -48,6 +48,7 @@ resource "openstack_compute_instance_v2" "control" {
       source_type  = "image"
       destination_type = var.volume_backed_instances ? "volume" : "local"
       volume_size = var.volume_backed_instances ? var.root_volume_size : null
+      volume_type = var.volume_backed_instances ? var.root_volume_type : null
       boot_index = 0
       delete_on_termination = true
   }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
@@ -18,6 +18,7 @@ module "login" {
   vnic_types = lookup(each.value, "vnic_types", var.vnic_types)
   volume_backed_instances = lookup(each.value, "volume_backed_instances", var.volume_backed_instances)
   root_volume_size = lookup(each.value, "root_volume_size", var.root_volume_size)
+  root_volume_type = lookup(each.value, "root_volume_type", var.root_volume_type)
   gateway_ip = lookup(each.value, "gateway_ip", var.gateway_ip)
   nodename_template = lookup(each.value, "nodename_template", var.cluster_nodename_template)
   

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -82,6 +82,7 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
       source_type  = "image"
       destination_type = "volume"
       volume_size = var.root_volume_size
+      volume_type = var.root_volume_type
       boot_index = 0
       delete_on_termination = true
     }
@@ -136,6 +137,7 @@ resource "openstack_compute_instance_v2" "compute" {
       source_type  = "image"
       destination_type = "volume"
       volume_size = var.root_volume_size
+      volume_type = var.root_volume_type
       boot_index = 0
       delete_on_termination = true
     }

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/variables.tf
@@ -49,6 +49,11 @@ variable "root_volume_size" {
     default = 40
 }
 
+variable "root_volume_type" {
+    type = string
+    default = null
+}
+
 variable "extra_volumes" {
     description = <<-EOF
         Mapping defining additional volumes to create and attach.

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
@@ -228,6 +228,12 @@ variable "root_volume_size" {
     default = 40
 }
 
+variable "root_volume_type" {
+    description = "Type of root volume, if using volume backed instances. Default gives default volume type"
+    type = string
+    default = null
+}
+
 variable "gateway_ip" {
     description = "Address to add default route via"
     type = string

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
@@ -229,7 +229,7 @@ variable "root_volume_size" {
 }
 
 variable "root_volume_type" {
-    description = "Type of root volume, if using volume backed instances. Default gives default volume type"
+    description = "Type of root volume, if using volume backed instances. If unset, the target cloud default volume type is used."
     type = string
     default = null
 }


### PR DESCRIPTION
Adds new OpenTofu variable `root_volume_type` and overrides for compute and login node groups.

Useful on Leafcloud for testing large "extra build" images, where default volume type is encrypted.