### PR TITLE
Pass templated fqdn to ansible

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/control.tf
@@ -4,7 +4,7 @@ locals {
     [for v in data.openstack_blockstorage_volume_v3.state: v],
     [for v in data.openstack_blockstorage_volume_v3.home: v]
   )
-  nodename = templatestring(
+  control_fqdn = templatestring(
     var.cluster_nodename_template,
     {
       node = "control",
@@ -38,7 +38,7 @@ resource "openstack_networking_port_v2" "control" {
 
 resource "openstack_compute_instance_v2" "control" {
   
-  name = split(".", local.nodename)[0]
+  name = split(".", local.control_fqdn)[0]
   image_id = var.cluster_image_id
   flavor_name = var.control_node_flavor
   key_pair = var.key_pair
@@ -80,7 +80,7 @@ resource "openstack_compute_instance_v2" "control" {
 
   user_data = <<-EOF
     #cloud-config
-    fqdn: ${local.nodename}
+    fqdn: ${local.control_fqdn}
     
     bootcmd:
       %{for volume in local.control_volumes}

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tf
@@ -4,7 +4,7 @@ resource "local_file" "hosts" {
                             "cluster_name": var.cluster_name,
                             "cluster_domain_suffix": var.cluster_domain_suffix
                             "control": openstack_compute_instance_v2.control
-                            "control_fqhn": local.control_fqdn
+                            "control_fqdn": local.control_fqdn
                             "login_groups": module.login
                             "compute_groups": module.compute
                             "state_dir": var.state_dir

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tf
@@ -2,8 +2,9 @@ resource "local_file" "hosts" {
   content  = templatefile("${path.module}/inventory.tpl",
                           {
                             "cluster_name": var.cluster_name,
-                            "cluster_domain_suffix": var.cluster_domain_suffix,
+                            "cluster_domain_suffix": var.cluster_domain_suffix
                             "control": openstack_compute_instance_v2.control
+                            "control_fqhn": local.control_fqdn
                             "login_groups": module.login
                             "compute_groups": module.compute
                             "state_dir": var.state_dir

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tpl
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tpl
@@ -11,18 +11,20 @@ control:
             ansible_host: ${control.access_ip_v4}
             instance_id: ${control.id}
             networks: ${jsonencode({for n in control.network: n.name => {"fixed_ip_v4": n.fixed_ip_v4, "fixed_ip_v6": n.fixed_ip_v6}})}
+            node_fqdn: ${control_fqhn}
     vars:
         appliances_state_dir: ${state_dir} # NB needs to be set on group not host otherwise it is ignored in packer build!
 
 %{ for group_name in keys(login_groups) ~}
 ${cluster_name}_${group_name}:
     hosts:
-%{ for node in login_groups[group_name]["compute_instances"] ~}
+%{ for nodename, node in login_groups[group_name]["compute_instances"] ~}
         ${ node.name }:
             ansible_host: ${node.access_ip_v4}
             instance_id: ${ node.id }
             image_id: ${ node.image_id }
             networks: ${jsonencode({for n in node.network: n.name => {"fixed_ip_v4": n.fixed_ip_v4, "fixed_ip_v6": n.fixed_ip_v6}})}
+            node_fqdn: ${login_groups[group_name]["fqdns"][nodename]}
 %{ endfor ~}
 %{ endfor ~}
 
@@ -35,11 +37,12 @@ login:
 %{ for group_name in keys(compute_groups) ~}
 ${cluster_name}_${group_name}:
     hosts:
-%{ for node in compute_groups[group_name]["compute_instances"] ~}
+%{ for nodename, node in compute_groups[group_name]["compute_instances"] ~}
         ${ node.name }:
             ansible_host: ${node.access_ip_v4}
             instance_id: ${ node.id }
             networks: ${jsonencode({for n in node.network: n.name => {"fixed_ip_v4": n.fixed_ip_v4, "fixed_ip_v6": n.fixed_ip_v6}})}
+            node_fqdn: ${compute_groups[group_name]["fqdns"][nodename]}
 %{ endfor ~}
     vars:
         # NB: this is the target image, not necessarily what is provisioned

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tpl
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tpl
@@ -11,7 +11,7 @@ control:
             ansible_host: ${control.access_ip_v4}
             instance_id: ${control.id}
             networks: ${jsonencode({for n in control.network: n.name => {"fixed_ip_v4": n.fixed_ip_v4, "fixed_ip_v6": n.fixed_ip_v6}})}
-            node_fqdn: ${control_fqhn}
+            node_fqdn: ${control_fqdn}
     vars:
         appliances_state_dir: ${state_dir} # NB needs to be set on group not host otherwise it is ignored in packer build!
 


### PR DESCRIPTION
Creates a hostvar `node_fqdn` as used by freeipa role, using OpenTofu variables `cluster_nodename_template` and `nodename_template` nodegroup override.

Fixes #701.