### PR TITLE
Support additional nodegroups

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tf
@@ -6,6 +6,7 @@ resource "local_file" "hosts" {
                             "control": openstack_compute_instance_v2.control
                             "login_groups": module.login
                             "compute_groups": module.compute
+                            "additional_groups": module.additional
                             "state_dir": var.state_dir
                             "cluster_home_volume": var.home_volume_provisioning != "none"
                           },

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/login.tf
@@ -22,7 +22,7 @@ module "login" {
   gateway_ip = lookup(each.value, "gateway_ip", var.gateway_ip)
   nodename_template = lookup(each.value, "nodename_template", var.cluster_nodename_template)
   
-  # optionally set for group
+  # optionally set for group:
   networks = concat(var.cluster_networks, lookup(each.value, "extra_networks", []))
   # here null means "use module var default"
   extra_volumes = lookup(each.value, "extra_volumes", null)

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/variables.tf
@@ -125,9 +125,31 @@ variable "compute" {
             availability_zone: Name of availability zone - ignored unless match_ironic_node is true (default: "nova")
             gateway_ip: Address to add default route via
             nodename_template: Overrides variable cluster_nodename_template
+
+        Nodes are added to the following inventory groups:
+        - $group_name
+        - $cluster_name + '_' + $group_name - this is used for the stackhpc.openhpc role
+        - 'compute'
     EOF
 
     type = any # can't do any better; TF type constraints can't cope with heterogeneous inner mappings
+}
+
+variable "additional_nodegroups" {
+    default = {}
+    description = <<-EOF
+        Mapping defining homogenous groups of nodes for arbitrary purposes.
+        These nodes are not in the compute or login inventory groups so they
+        will not run slurmd.
+
+        Keys are names of groups.
+        Values are a mapping as for the "login" variable.
+
+        Nodes are added to the following inventory groups:
+        - $group_name
+        - $cluster_name + '_' + $group_name
+        - 'additional'
+    EOF
 }
 
 variable "environment_root" {


### PR DESCRIPTION
Adds opentofu variable `additional_nodegroups` to support defining non-Slurm nodes in the cluster. E.g.:

```terraform
additional_nodegroups = {
    squid = {
        nodes = ["squid-0"]
        flavor = var.other_node_flavor
    }
}
```

Nodes are automatically added to an inventory group of the same name as the node group.

