### PR TITLE
Bump all Pulp snapshots to latest versions in RL 8.x, RL 9.5

### DIFF
--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-250610-1435-d0ef926e",
-        "RL9": "openhpc-RL9-250610-1435-d0ef926e"
+        "RL8": "openhpc-RL8-250617-1558-2065722e",
+        "RL9": "openhpc-RL9-250617-1557-2065722e"
     }
 }

--- a/environments/common/inventory/group_vars/all/timestamps.yml
+++ b/environments/common/inventory/group_vars/all/timestamps.yml
@@ -2,57 +2,64 @@ appliances_pulp_repos:
   appstream:
     '8.10':
       path: rocky/8.10/AppStream/x86_64/os
-      timestamp: 20250328T030013
+      timestamp: 20250614T013846
     '9.4':
       path: rocky/9.4/AppStream/x86_64/os
       timestamp: 20241112T003151
     '9.5':
       path: rocky/9.5/AppStream/x86_64/os
-      timestamp: 20250328T031822
+      timestamp: 20250514T014704
   baseos:
     '8.10':
       path: rocky/8.10/BaseOS/x86_64/os
-      timestamp: 20250328T030013
+      timestamp: 20250614T013846
     '9.4':
       path: rocky/9.4/BaseOS/x86_64/os
       timestamp: 20241115T011711
     '9.5':
       path: rocky/9.5/BaseOS/x86_64/os
-      timestamp: 20250326T030636
+      timestamp: 20250513T031844
   ceph:
     '8':
       path: centos/8-stream/storage/x86_64/ceph-quincy
       timestamp: 20231104T015751
     '9':
       path: centos/9-stream/storage/x86_64/ceph-reef
-      timestamp: 20240923T233036
+      timestamp: 20250514T025809
   crb:
     '8.10':
       path: rocky/8.10/PowerTools/x86_64/os
-      timestamp: 20250328T030013
+      timestamp: 20250614T013846
     '9.4':
       path: rocky/9.4/CRB/x86_64/os
       timestamp: 20241115T003133
     '9.5':
       path: rocky/9.5/CRB/x86_64/os
-      timestamp: 20250325T031428
+      timestamp: 20250514T014704
   epel:
     '8':
       path: epel/8/Everything/x86_64
-      timestamp: 20250609T000109
+      timestamp: 20250615T234151
     '9':
       path: epel/9/Everything/x86_64
-      timestamp: 20250609T000109
+      timestamp: 20250615T000221
   extras:
     '8.10':
       path: rocky/8.10/extras/x86_64/os
-      timestamp: 20250327T030422
+      timestamp: 20250510T032327
     '9.4':
       path: rocky/9.4/extras/x86_64/os
       timestamp: 20241118T002802
     '9.5':
       path: rocky/9.5/extras/x86_64/os
-      timestamp: 20250328T031822
+      timestamp: 20250506T032818
+  grafana:
+    '8':
+      path: grafana/oss/rpm
+      timestamp: 20250615T005738
+    '9':
+      path: grafana/oss/rpm
+      timestamp: 20250615T005738
   openhpc_base:
     '8':
       path: OpenHPC/2/EL_8
@@ -67,10 +74,3 @@ appliances_pulp_repos:
     '9':
       path: OpenHPC/3/updates/EL_9
       timestamp: 20250510T003301
-  grafana:
-    '8':
-      path: grafana/oss/rpm
-      timestamp: 20250505T025259
-    '9':
-      path: grafana/oss/rpm
-      timestamp: 20250505T025259


### PR DESCRIPTION
This updates to the final release for Rocky Linux 9.5.