### PR TITLE
Bump fatimage after MIG PR656 merge

### DIFF
--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
     "cluster_image": {
-        "RL8": "openhpc-RL8-250620-1251-d606a45c",
-        "RL9": "openhpc-RL9-250620-1251-d606a45c"
+        "RL8": "openhpc-RL8-250624-0854-75099868",
+        "RL9": "openhpc-RL9-250624-0854-75099868"
     }
 }


### PR DESCRIPTION
Before #656 was merged it was updated from main, but without a new image build. This provides that image build.