### PR TITLE
Enable auth to be configured for squid

### DIFF
--- a/ansible/roles/squid/README.md
+++ b/ansible/roles/squid/README.md
@@ -20,20 +20,15 @@ Where noted these map to squid parameters of the same name without the `squid_` 
 - `squid_maximum_object_size_in_memory`: Optional str. Upper size limit for objects in memory cache, default '64 MB'. See squid parameter.
 - `squid_maximum_object_size`: Optional str. Upper size limit for objects in disk cache, default '200 MB'. See squid parameter.
 - `squid_http_port`: Optional str. Socket addresses to listen for client requests, default '3128'. See squid parameter.
-- `squid_acls`: Optional str, can be multiline. Define access lists. Default `acl anywhere src all`, i.e. rely on OpenStack security groups (or other firewall if deployed). See squid parameter `acl`. NB: The default template also defines acls for `SSL_ports` and `Safe_ports` as is common practice.
-- `squid_http_access`: Optional str, can be multiline. Allow/deny access based on access lists. Default:
+- `squid_acls`: Optional list of strs. Define access lists. Default: `['acl anywhere src all']`, i.e. allow connection from anywhere, relying on OpenStack security groups (or other firewall if deployed). See squid parameter `acl`. NB: The default template also defines acls for `SSL_ports` and `Safe_ports` as is common practice.
+- `squid_http_access`: Optional str, can be multiline. Allow/deny access based on access lists. The default will:
+  - Deny requests to certain unsafe ports (see `squid.conf.j2`)
+  - Deny CONNECT to other than secure SSL ports
+  - Only allow cachemgr access from localhost
+  - Allow access for all ACLs defined in `squid_acls`
+  - Allow access for localhost
+  - Deny all other access
 
-        # Deny requests to certain unsafe ports
-        http_access deny !Safe_ports
-        # Deny CONNECT to other than secure SSL ports
-        http_access deny CONNECT !SSL_ports
-        # Only allow cachemgr access from localhost
-        http_access allow localhost manager
-        http_access deny manager
-        # Rules allowing http access
-        http_access allow anywhere
-        http_access allow localhost
-        # Finally deny all other access to this proxy
-        http_access deny all
-        
   See squid parameter.
+
+- `squid_auth_param`: Optional str, can be multiline. Parameters for authentication schemes. Default empty string.

--- a/ansible/roles/squid/defaults/main.yml
+++ b/ansible/roles/squid/defaults/main.yml
@@ -8,7 +8,8 @@ squid_cache_disk: "{{ undef(hint='squid_cache_disk (in MB) required, e.g. \"1024
 squid_maximum_object_size_in_memory: '64 MB'
 squid_maximum_object_size: '200 MB'
 squid_http_port: 3128
-squid_acls: acl anywhere src all # rely on openstack security groups
+squid_acls:
+  - acl anywhere src all # rely on openstack security groups
 squid_http_access: |
   # Deny requests to certain unsafe ports
   http_access deny !Safe_ports
@@ -18,7 +19,10 @@ squid_http_access: |
   http_access allow localhost manager
   http_access deny manager
   # Rules allowing http access
-  http_access allow anywhere
+  {% for acl in squid_acls %}
+  http_access allow {{ (acl | split)[1] }}
+  {% endfor %}
   http_access allow localhost
   # Finally deny all other access to this proxy
   http_access deny all
+squid_auth_param: ''

--- a/ansible/roles/squid/templates/squid.conf.j2
+++ b/ansible/roles/squid/templates/squid.conf.j2
@@ -4,8 +4,14 @@
 # - https://github.com/drosskopp/squid-cache/blob/main/squid.conf
 #
 
+# Configure authentication parameters
+# NB: required before ACL definitions using them
+{{ squid_auth_param }}
+
 # Define ACLs:
-{{ squid_acls }}
+{% for acl in squid_acls %}
+{{ acl }}
+{% endfor %}
 
 acl SSL_ports port 443
 acl Safe_ports port 80		# http


### PR DESCRIPTION
- Fixes an issue where `http_access` did not depend on defined ACLs for squid
- Adds `squid_auth_param` to allow setting auth parameter configuration for squid

This allows configuration squid auth, e.g. for basic auth:

```yaml
# environments/$ENV/inventory/group_vars/all/squid.yml:
squid_acls:
    - acl ncsa_users proxy_auth REQUIRED
squid_auth_param: |
    auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/passwords
    auth_param basic children 5
    auth_param basic credentialsttl 1 minute
```
See the [squid docs](https://wiki.squid-cache.org/ConfigExamples/Authenticate/Ncsa) for more information.