### PR TITLE
Fix NHC downing nodes due to /efi being mounted twice

### DIFF
--- a/ansible/roles/nhc/templates/nhc.conf.j2
+++ b/ansible/roles/nhc/templates/nhc.conf.j2
@@ -4,7 +4,9 @@
 * || HOSTNAME="$HOSTNAME_S"
 
 ## Filesystem checks
-{% for mount in ansible_mounts %}
+{% for mount in ansible_mounts | rejectattr('mount', 'eq', '/efi') %}
+{# /efi is mounted both directly and via systemd1 autofs, which NHC can't cope with #}
+{# use `awk '{print $5 " " $10 " " $4 " " $9}' /proc/self/mountinfo | sort -k1` to check that is the only case #}
 {% set mount_mode = 'rw' if 'rw' in mount.options.split(',') else 'ro' %}
 {{ ansible_fqdn }} || check_fs_mount_{{ mount_mode }} -t "{{ mount.fstype }}" -s "{{ mount.device }}" -f "{{ mount.mount }}"
 {% endfor %}


### PR DESCRIPTION
`/efi` is mounted both directly and via systemd-1 autofs. NHC logic can't cope with this and assumes that this means the mount is broken and drains the node.

This PR fixes this by filtering out `/efi` mountpoints. This is the only mountpoint with this problem.

**NB:**
- CI will NOT succeed in this PR because the problem is in the previous release.
- No image build is required as the NHC config template is not built into the image.