### PR TITLE
Make dnf repos available during site post-hook

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -27,7 +27,6 @@
 - import_playbook: slurm.yml
 - import_playbook: portal.yml
 - import_playbook: monitoring.yml
-- import_playbook: final.yml
 
 - name: Run post.yml hook
   vars:
@@ -36,5 +35,7 @@
     hook_path: "{{ appliances_environment_root }}/hooks/post.yml"
   import_playbook: "{{ hook_path if hook_path | exists else 'noop.yml' }}"
   when: hook_path | exists
+
+- import_playbook: final.yml
 
 ...


### PR DESCRIPTION
Note this is consistent with fatimage.yml.

Fixes https://github.com/stackhpc/ansible-slurm-appliance/issues/708.