### PR TITLE
Restore ability to leave dnf repos enabled

### DIFF
--- a/ansible/final.yml
+++ b/ansible/final.yml
@@ -6,6 +6,7 @@
       ansible.builtin.include_role:
         name: dnf_repos
         tasks_from: disable_repos.yml
+      when: not dnf_repos_enabled | default(false) | bool
 
 - name: Setup NFS export for compute_init
   hosts: compute_init:!builder


### PR DESCRIPTION
This was accidently removed when refactoring ansible/disable-repos.yml into ansible/final.yml in https://github.com/stackhpc/ansible-slurm-appliance/pull/654.

Required for Arcus CaaS Slurm (currently aiming for v1.160 which has this though).

No image build required.