### PR TITLE
Bump DOCA to 2.9.3

### DIFF
--- a/ansible/roles/doca/defaults/main.yml
+++ b/ansible/roles/doca/defaults/main.yml
@@ -1,3 +1,3 @@
-doca_version: '2.9.2' # 2.9 is LTS, last to support ConnectX-4, 3 years for bug fixes and CVE updates
+doca_version: '2.9.3' # 2.9 is LTS, last to support ConnectX-4, 3 years for bug fixes and CVE updates
 doca_profile: doca-ofed
 doca_repo_url: "https://linux.mellanox.com/public/repo/doca/{{ doca_version }}/rhel{{ ansible_distribution_version }}/{{ ansible_architecture }}/"

--- a/ansible/roles/ofed/defaults/main.yml
+++ b/ansible/roles/ofed/defaults/main.yml
@@ -1,4 +1,4 @@
-ofed_version: '24.10-2.1.8.0' # LTS
+ofed_version: '24.10-3.2.5.0' # LTS
 ofed_download_url: https://content.mellanox.com/ofed/MLNX_OFED-{{ ofed_version }}/MLNX_OFED_LINUX-{{ ofed_version }}-{{ ofed_distro }}{{ ofed_distro_version }}-{{ ofed_arch }}.tgz
 ofed_distro: rhel # NB: not expected to work on other distros due to installation differences
 ofed_distro_version: "{{ ansible_distribution_version }}" # e.g. '8.9'


### PR DESCRIPTION
This includes OFED v24.10-3.2.5.0 LTS. Bump OFED to the same version.