### PR TITLE
Output baremetal instances from terraform

### DIFF
--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tf
@@ -7,6 +7,7 @@ resource "local_file" "hosts" {
                             "control_fqdn": local.control_fqdn
                             "login_groups": module.login
                             "compute_groups": module.compute
+                            "baremetal_compute_instances": flatten([for group in keys(module.compute) : keys(module.compute[group]["compute_instances"]) if module.compute[group]["is_baremetal"]])
                             "additional_groups": module.additional
                             "state_dir": var.state_dir
                             "cluster_home_volume": var.home_volume_provisioning != "none"

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tpl
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/inventory.tpl
@@ -4,6 +4,7 @@ all:
         cluster_domain_suffix: ${cluster_domain_suffix}
         cluster_home_volume: ${cluster_home_volume}
         cluster_compute_groups: ${jsonencode(keys(compute_groups))}
+        topology_baremetal_instances: ${jsonencode(baremetal_compute_instances)}
 
 control:
     hosts:

--- a/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
+++ b/environments/skeleton/{{cookiecutter.environment}}/tofu/node_group/nodes.tf
@@ -186,6 +186,10 @@ output "compute_instances" {
   value = local.compute_instances
 }
 
+output "is_baremetal" {
+  value = var.match_ironic_node
+}
+
 output "image_id" {
   value = var.image_id
 }


### PR DESCRIPTION
Added templating to hosts file to include a list of compute instances which are mapped to Ironic nodes. The motivation for this was to be able to distinguish between VMs and baremetal instances for inter-host topology aware scheduling (`host_id` refers unique hypervisors in the VM case, but can just refer to Ironic service in baremetal case) but we've decided to exclude baremetal instances in the initial iteration of this