### PR TITLE
Fix convenience variables for proxy

### DIFF
--- a/ansible/roles/proxy/tasks/main.yml
+++ b/ansible/roles/proxy/tasks/main.yml
@@ -1,9 +1,10 @@
 - name: Validate http_proxy definition
   ansible.builtin.assert:
-    that: proxy_http_proxy != '' # this is default if squid not active
+    that: proxy_http_proxy != ''
     fail_msg: >-
       Variable proxy_http_proxy cannot be the empty string for hosts in the
-      proxy group. See environment/common/inventory/group_vars/all/proxy.yml.
+      proxy group. See environments/common/inventory/group_vars/all/proxy.yml
+      for convenience variables to set this.
 - name: Define configuration in /etc/environment
   tags: proxy
   lineinfile:

--- a/environments/common/inventory/group_vars/all/proxy.yml
+++ b/environments/common/inventory/group_vars/all/proxy.yml
@@ -20,7 +20,7 @@ proxy_remove: false
 
 # full http proxy string - override if the above don't provide enough control:
 proxy_http_proxy: >-
-  {% if groups['squid'] | length > 0 %}
+  {% if proxy_http_address != '' %}
   http://
   {%- if proxy_basic_password -%}
   {{ proxy_basic_user }}:{{ proxy_basic_password }}@

--- a/environments/common/inventory/group_vars/all/proxy.yml
+++ b/environments/common/inventory/group_vars/all/proxy.yml
@@ -20,12 +20,12 @@ proxy_remove: false
 
 # full http proxy string - override if the above don't provide enough control:
 proxy_http_proxy: >-
-  {% if proxy_http_address != '' %}
+  {%- if proxy_http_address != '' -%}
   http://
   {%- if proxy_basic_password -%}
   {{ proxy_basic_user }}:{{ proxy_basic_password }}@
   {%- endif -%}
   {{ proxy_http_address }}:{{ proxy_http_port }}
-  {% else %}
-  
-  {% endif %}
+  {%- else %}
+
+  {%- endif %}


### PR DESCRIPTION
PR #717 added some convenience proxy vars, but the logic wasn't quite correct. This:
- Makes it so simply defining `proxy_http_address` is enough to produce a correct `proxy_http_proxy` variable (which in turn is all that is required to produce a working proxy config if the other defaults are sufficent).
- Fixes a whitespace issue.