### PR TITLE
Support passing freeipa server cert on client enrolment

### DIFF
--- a/ansible/roles/freeipa/README.md
+++ b/ansible/roles/freeipa/README.md
@@ -38,6 +38,7 @@ Support FreeIPA in the appliance. In production use it is expected the FreeIPA s
 - `freeipa_host_password`. Required for initial enrolment only, FreeIPA host password as described above.
 - `freeipa_setup_dns`: Optional, whether to use the FreeIPA server as the client's nameserver. Defaults to `true` when `freeipa_server` contains a host, otherwise `false`.
 - `freeipa_ca_cert_file`: Optional, path **on the ansible deploy host** to FreeIPA server cert. Else this will be downloaded (insecurely) from the FreeIPA server over http.
+
 See also use of `appliances_state_dir` on the control node as described above.
 
 # FreeIPA Server

--- a/ansible/roles/freeipa/README.md
+++ b/ansible/roles/freeipa/README.md
@@ -37,7 +37,7 @@ Support FreeIPA in the appliance. In production use it is expected the FreeIPA s
 
 - `freeipa_host_password`. Required for initial enrolment only, FreeIPA host password as described above.
 - `freeipa_setup_dns`: Optional, whether to use the FreeIPA server as the client's nameserver. Defaults to `true` when `freeipa_server` contains a host, otherwise `false`.
-
+- `freeipa_ca_cert_file`: Optional, path **on the ansible deploy host** to FreeIPA server cert. Else this will be downloaded (insecurely) from the FreeIPA server over http.
 See also use of `appliances_state_dir` on the control node as described above.
 
 # FreeIPA Server

--- a/ansible/roles/freeipa/defaults/main.yml
+++ b/ansible/roles/freeipa/defaults/main.yml
@@ -10,5 +10,5 @@ freeipa_user_defaults:
   ipa_pass: "{{ freeipa_admin_password | quote }}"
   ipa_user: admin
 freeipa_users: [] # see community.general.ipa_user
-
+freeipa_ca_cert_file: ''
 _freeipa_keytab_backup_path: "{{ hostvars[groups['control'].0].appliances_state_dir  }}/freeipa/{{ inventory_hostname }}/krb5.keytab"

--- a/ansible/roles/freeipa/tasks/enrol.yml
+++ b/ansible/roles/freeipa/tasks/enrol.yml
@@ -16,6 +16,15 @@
     mode: ug=rw,o=
   when: '"content" in _slurp_persisted_keytab'
 
+- name: Copy CA Cert to host
+  ansible.builtin.copy:
+    src: "{{ freeipa_ca_cert_file }}"
+    dest: /etc/ipa/ca.crt
+    mode: u=rw,go=r
+    owner: root
+    group: root
+  when: freeipa_ca_cert_file != ''
+
 - name: Re-enrol with FreeIPA using backed-up keytab
   # Re-enrolment requires --force-join and --password, or --keytab
   # Re-rolement means:
@@ -31,6 +40,9 @@
         --mkhomedir
         --enable-dns-updates
         --keytab /tmp/krb5.keytab
+        {% if freeipa_ca_cert_file != '' %}
+        --ca-cert-file=/etc/ipa/ca.crt
+        {% endif %}
   when: '"content" in _slurp_persisted_keytab'
   register: ipa_client_install_keytab
   changed_when: ipa_client_install_keytab.rc == 0
@@ -47,6 +59,9 @@
         --mkhomedir
         --enable-dns-updates
         --password '{{ freeipa_host_password }}'
+        {% if freeipa_ca_cert_file != '' %}
+        --ca-cert-file=/etc/ipa/ca.crt
+        {% endif %}
   when:
     - '"content" not in _slurp_persisted_keytab'
     - freeipa_host_password is defined


### PR DESCRIPTION
By default this is downloaded over http, which is insecure, and may be blocked in some environments.

Not tested in CI.
No new image build required.