### PR TITLE
Bump openstack cli to get working FIP commands

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible==6.7.0 # cloudalchemy.prometheus uses ansible.builtin.include, removed in ansible-core==2.16 => ansible==9
 openstacksdk
-python-openstackclient==6.6.1 # v7.0.0 has a bug re. rebuild
+python-openstackclient==8.0.0
 python-manilaclient
 python-ironicclient
 jmespath


### PR DESCRIPTION
Fixes an error when running `openstack floating ip ...` commands from the CLI, e.g.

```
$ openstack floating ip show 4b073dc3-0c2c-40b8-a844-d00907e26796
Invalid formatter provided.
```

8.0.0 appears to rebuild correctly.