### PR TITLE
Fixup additional_nodes inventory group

### DIFF
--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -17,9 +17,14 @@ compute
 # Login group to use for running mpi-based testing.
 login
 
+[additional]
+# Additional nodes to include in "cluster" group
+# Automatically populated from OpenTofu variable additional_nodegroups
+
 [cluster:children]
 # All nodes in the appliance - add e.g. service nodes not running Slurm here.
 openhpc
+additional
 
 [builder]
 # Do not add hosts here manually - used as part of Packer image build pipeline. See packer/README.md.


### PR DESCRIPTION
#704 added support for additional node groups. This PR fixes these missing from the `cluster` nodegroup. Note they are not part of the `openhpc` group as they do not run slurm daemons.