### PR TITLE
Upload CI images to Leafcloud S3 for image syncing

### DIFF
--- a/.github/bin/get-s3-image.sh
+++ b/.github/bin/get-s3-image.sh
@@ -17,7 +17,7 @@ if [ -n "$image_exists" ]; then
 else
     echo "Image $image_name not found in OpenStack. Getting it from S3."
 
-    wget https://object.arcus.openstack.hpc.cam.ac.uk/swift/v1/AUTH_3a06571936a0424bb40bc5c672c4ccb1/$bucket_name/$image_name --progress=dot:giga
+    wget https://leafcloud.store/swift/v1/AUTH_f39848421b2747148400ad8eeae8d536/$bucket_name/$image_name --progress=dot:giga
 
     echo "Uploading image $image_name to OpenStack..."
     openstack image create --file $image_name --disk-format qcow2 $image_name --progress

--- a/.github/workflows/s3-image-sync.yml
+++ b/.github/workflows/s3-image-sync.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Write s3cmd configuration
+        run: |
+          echo "${{ secrets['LEAFCLOUD_S3_CFG'] }}" > ~/.s3cfg
+        shell: bash
+
       - name: Install s3cmd
         run: |
           sudo apt-get update
@@ -64,6 +69,11 @@ jobs:
         run: |
           mkdir -p ~/.config/openstack/
           echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
+        shell: bash
+
+      - name: Write s3cmd configuration
+        run: |
+          echo "${{ secrets['LEAFCLOUD_S3_CFG'] }}" > ~/.s3cfg
         shell: bash
 
       - name: Install s3cmd and qemu-utils

--- a/.github/workflows/s3-image-sync.yml
+++ b/.github/workflows/s3-image-sync.yml
@@ -1,4 +1,4 @@
-name: Upload CI-tested images to Arcus S3 and sync clouds
+name: Upload CI-tested images to Leafcloud S3 and sync clouds
 on:
   workflow_dispatch:
   push:
@@ -18,11 +18,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-
-      - name: Write s3cmd configuration
-        run: |
-          echo "${{ secrets['ARCUS_S3_CFG'] }}" > ~/.s3cfg
-        shell: bash
 
       - name: Install s3cmd
         run: |
@@ -69,11 +64,6 @@ jobs:
         run: |
           mkdir -p ~/.config/openstack/
           echo "${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }}" > ~/.config/openstack/clouds.yaml
-        shell: bash
-
-      - name: Write s3cmd configuration
-        run: |
-          echo "${{ secrets['ARCUS_S3_CFG'] }}" > ~/.s3cfg
         shell: bash
 
       - name: Install s3cmd and qemu-utils


### PR DESCRIPTION
Move to using Leafcloud object store for syncing images between clouds.

Tested: https://github.com/stackhpc/ansible-slurm-appliance/actions/runs/16781138088