### PR TITLE
Don't set topology plugin if topology group not enabled

### DIFF
--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -51,24 +51,27 @@ openhpc_state_save_location: "{{ appliances_state_dir + '/slurmctld' if applianc
 # NB: override in environments/site/inventory/group_vars/all/openhpc.yml, not here:
 openhpc_config_extra: {}
 
-# default additional slurm.conf parameters for the appliance:
+# additional default slurm.conf parameters for the appliance:
 openhpc_config_default:
   TaskPlugin: task/cgroup,task/affinity
   ReturnToService: 2 # workaround for templating bug TODO: Remove once on stackhpc.openhpc v1.2.0
-  TopologyPlugin: "topology/{{ 'tree' if (topology_nodes | length) > 0 else 'flat' }}"
 
-# default additional slurm.conf parameters when "rebuild" enabled:
+# additional default slurm.conf parameters when "rebuild" enabled:
 openhpc_config_rebuild:
   RebootProgram: /opt/slurm-tools/bin/slurm-openstack-rebuild
   SlurmctldParameters:
     - reboot_from_controller
   ResumeTimeout: 300
 
-# default additional slurm.conf parameters when "nhc" enabled:
+# additional default slurm.conf parameters when "nhc" enabled:
 openhpc_config_nhc:
   HealthCheckProgram: /usr/sbin/nhc
   HealthCheckInterval: 300
   HealthCheckNodeState: NONDRAINED_IDLE
+
+# additional default slurm.conf parameters when "topology" enabled:
+openhpc_config_topology:
+  TopologyPlugin: topology/tree
 
 # indirection to allow automatic construction of slurm.conf parameters:
 openhpc_config_groups:
@@ -76,6 +79,8 @@ openhpc_config_groups:
     config: "{{ openhpc_config_rebuild }}"
   - enabled: "{{ groups['nhc'] | length > 0 }}"
     config: "{{ openhpc_config_nhc }}"
+  - enabled: "{{ groups['topology'] | length > 0 }}"
+    config: "{{ openhpc_config_topology }}"
   - enabled: true
     config: "{{ openhpc_config_extra }}"
 


### PR DESCRIPTION
The `flat` topolgy plugin doesn't work:

```
$ systemctl status slurmctld
error: Couldn't find the specified plugin name for topology/flat looking at all files
slurmctld: error: cannot find topo plugin for topology/flat
slurmctld: error: cannot create topo context for topology/flat
slurmctld: fatal: Failed to initialize topology plugin
error: cannot find topo plugin for topology/flat
error: cannot create topo context for topology/flat
fatal: Failed to initialize topology plugin
```

Exposed in CI by https://github.com/stackhpc/ansible-slurm-appliance/pull/751 which turned off `topology` by default.