### PR TITLE
Allow setting config_drive

### DIFF
--- a/environments/site/tofu/additional.tf
+++ b/environments/site/tofu/additional.tf
@@ -12,6 +12,7 @@ module "additional" {
   cluster_domain_suffix = var.cluster_domain_suffix
   key_pair = var.key_pair
   environment_root = var.environment_root
+  config_drive = var.config_drive
   
   # can be set for group, defaults to top-level value:
   image_id = lookup(each.value, "image_id", var.cluster_image_id)

--- a/environments/site/tofu/compute.tf
+++ b/environments/site/tofu/compute.tf
@@ -12,6 +12,7 @@ module "compute" {
   cluster_domain_suffix = var.cluster_domain_suffix
   key_pair = var.key_pair
   environment_root = var.environment_root
+  config_drive = var.config_drive
   
   # can be set for group, defaults to top-level value:
   image_id = lookup(each.value, "image_id", var.cluster_image_id)
@@ -60,7 +61,5 @@ module "compute" {
     "gateway_ip",
     "nodename_template",
   ]
-
-  config_drive = var.config_drive
   
 }

--- a/environments/site/tofu/compute.tf
+++ b/environments/site/tofu/compute.tf
@@ -60,4 +60,7 @@ module "compute" {
     "gateway_ip",
     "nodename_template",
   ]
+
+  config_drive = var.config_drive
+  
 }

--- a/environments/site/tofu/control.tf
+++ b/environments/site/tofu/control.tf
@@ -94,4 +94,6 @@ resource "openstack_compute_instance_v2" "control" {
       %{endif}
   EOF
 
+  config_drive = var.config_drive
+
 }

--- a/environments/site/tofu/login.tf
+++ b/environments/site/tofu/login.tf
@@ -64,4 +64,7 @@ module "login" {
     "gateway_ip",
     "nodename_template",
   ]
+
+  config_drive = var.config_drive
+  
 }

--- a/environments/site/tofu/login.tf
+++ b/environments/site/tofu/login.tf
@@ -12,6 +12,7 @@ module "login" {
   cluster_domain_suffix = var.cluster_domain_suffix
   key_pair = var.key_pair
   environment_root = var.environment_root
+  config_drive = var.config_drive
   
   # can be set for group, defaults to top-level value:
   image_id = lookup(each.value, "image_id", var.cluster_image_id)
@@ -64,7 +65,5 @@ module "login" {
     "gateway_ip",
     "nodename_template",
   ]
-
-  config_drive = var.config_drive
   
 }

--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -36,6 +36,7 @@ resource "openstack_blockstorage_volume_v3" "compute" {
     name = "${var.cluster_name}-${each.key}"
     description = "Compute node ${each.value.node} volume ${each.value.volume}"
     size = var.extra_volumes[each.value.volume].size
+    volume_type = var.extra_volumes[each.value.volume].volume_type
 }
 
 resource "openstack_compute_volume_attach_v2" "compute" {

--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -120,6 +120,8 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
 
   availability_zone = var.match_ironic_node ? "${local.baremetal_az}::${var.baremetal_nodes[each.key]}" : var.availability_zone
 
+  config_drive = var.config_drive
+
   lifecycle {
     ignore_changes = [
       image_id,
@@ -174,6 +176,8 @@ resource "openstack_compute_instance_v2" "compute" {
   EOF
 
   availability_zone = var.match_ironic_node ? "${local.baremetal_az}::${var.baremetal_nodes[each.key]}" : var.availability_zone
+
+  config_drive = var.config_drive
 
 }
 

--- a/environments/site/tofu/node_group/variables.tf
+++ b/environments/site/tofu/node_group/variables.tf
@@ -60,11 +60,13 @@ variable "extra_volumes" {
         Keys are unique volume name.
         Values are a mapping with:
             size: Size of volume in GB
+            volume_type: Optional. Type of volume, or cloud default
         **NB**: The order in /dev is not guaranteed to match the mapping
         EOF
     type = map(
         object({
             size = number
+            volume_type = optional(string)
         })
     )
     default = {}

--- a/environments/site/tofu/node_group/variables.tf
+++ b/environments/site/tofu/node_group/variables.tf
@@ -192,3 +192,12 @@ variable "allowed_keys" {
     type = list
     # don't provide a default here as allowed keys may depend on module use
 }
+
+variable "config_drive" {
+    description = <<-EOT
+        Whether to enable Nova config drives on all nodes, which will mount a drive containing
+        information that would usually be available through the metadata service.
+    EOT
+    type = bool
+    default = false
+}

--- a/environments/site/tofu/node_group/variables.tf
+++ b/environments/site/tofu/node_group/variables.tf
@@ -194,10 +194,5 @@ variable "allowed_keys" {
 }
 
 variable "config_drive" {
-    description = <<-EOT
-        Whether to enable Nova config drives on all nodes, which will mount a drive containing
-        information that would usually be available through the metadata service.
-    EOT
     type = bool
-    default = false
 }

--- a/environments/site/tofu/variables.tf
+++ b/environments/site/tofu/variables.tf
@@ -65,10 +65,11 @@ variable "login" {
             volume_backed_instances: Overrides variable volume_backed_instances
             root_volume_size: Overrides variable root_volume_size
             extra_volumes: Mapping defining additional volumes to create and attach
-                            Keys are unique volume name.
-                            Values are a mapping with:
+                           Keys are unique volume name.
+                           Values are a mapping with:
                                 size: Size of volume in GB
-                            **NB**: The order in /dev is not guaranteed to match the mapping
+                                volume_type: Optional. Type of volume, or cloud default
+                           **NB**: The order in /dev is not guaranteed to match the mapping
             fip_addresses: List of addresses of floating IPs to associate with
                            nodes, in the same order as nodes parameter. The
                            floating IPs must already be allocated to the project.
@@ -117,6 +118,7 @@ variable "compute" {
                            Keys are unique volume name.
                            Values are a mapping with:
                                 size: Size of volume in GB
+                                volume_type: Optional. Type of volume, or cloud default
                            **NB**: The order in /dev is not guaranteed to match the mapping
             ip_addresses: Mapping of list of fixed IP addresses for nodes, keyed
                           by network name, in same order as nodes parameter.

--- a/environments/site/tofu/variables.tf
+++ b/environments/site/tofu/variables.tf
@@ -320,5 +320,5 @@ variable "config_drive" {
         information usually provided through the metadata service.
     EOT
     type = bool
-    default = false
+    default = null
 }

--- a/environments/site/tofu/variables.tf
+++ b/environments/site/tofu/variables.tf
@@ -316,8 +316,8 @@ variable "cluster_nodename_template" {
 
 variable "config_drive" {
     description = <<-EOT
-        Whether to enable Nova config drives on all nodes, which will mount a drive containing
-        information that would usually be available through the metadata service.
+        Whether to enable Nova config drives on all nodes, which will attach a drive containing
+        information usually provided through the metadata service.
     EOT
     type = bool
     default = false

--- a/environments/site/tofu/variables.tf
+++ b/environments/site/tofu/variables.tf
@@ -313,3 +313,12 @@ variable "cluster_nodename_template" {
     type = string
     default = "$${cluster_name}-$${node}.$${cluster_name}.$${cluster_domain_suffix}"
 }
+
+variable "config_drive" {
+    description = <<-EOT
+        Whether to enable Nova config drives on all nodes, which will mount a drive containing
+        information that would usually be available through the metadata service.
+    EOT
+    type = bool
+    default = false
+}


### PR DESCRIPTION
Can now set config_drive in Tofu config. Set by top level `config_drive` variable and applied to all instances