### PR TITLE
slurm.conf common env updated

### DIFF
--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -55,6 +55,8 @@ openhpc_config_extra: {}
 openhpc_config_default:
   TaskPlugin: task/cgroup,task/affinity
   ReturnToService: 2 # workaround for templating bug TODO: Remove once on stackhpc.openhpc v1.2.0
+  ProctrackType: proctrack/cgroup
+  JobAcctGatherType: jobacct_gather/cgroup
 
 # additional default slurm.conf parameters when "rebuild" enabled:
 openhpc_config_rebuild:

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -54,7 +54,6 @@ openhpc_config_extra: {}
 # additional default slurm.conf parameters for the appliance:
 openhpc_config_default:
   TaskPlugin: task/cgroup,task/affinity
-  ReturnToService: 2 # workaround for templating bug TODO: Remove once on stackhpc.openhpc v1.2.0
   ProctrackType: proctrack/cgroup
   JobAcctGatherType: jobacct_gather/cgroup
 


### PR DESCRIPTION
Addresses https://github.com/stackhpc/ansible-slurm-appliance/issues/620

```
JobAcctGatherType: jobacct_gather/cgroup
```
Is in use at a clients, apparently with no problems, so setting here

```
ProctrackType: proctrack/cgroup
```
can't be set it in the stackhpc.openhpc role b/c of its CI running containerised, so it's set at the appliance level