### PR TITLE
CaaS pre-hook fix for galaxy requirements validation

### DIFF
--- a/environments/.caas/hooks/pre.yml
+++ b/environments/.caas/hooks/pre.yml
@@ -63,3 +63,14 @@
           - dnf_repos
       loop: "{{ groups['cluster'] }}"
       when: dnf_repos_enabled | default(false) | bool
+
+# Workaround for setup-env.sh not running in CaaS CI, so:
+# https://github.com/stackhpc/ansible-slurm-appliance/blob/ba9699267449fba58cd9c04c451759a914fd7144/ansible/validate.yml#L16
+# doesn't break CI
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Prepare requirements.yml.last for galaxy validation
+      copy:
+        src: "{{ appliances_repository_root }}/requirements.yml"
+        dest: "{{ appliances_repository_root }}/requirements.yml.last"

--- a/environments/.caas/hooks/pre.yml
+++ b/environments/.caas/hooks/pre.yml
@@ -64,9 +64,9 @@
       loop: "{{ groups['cluster'] }}"
       when: dnf_repos_enabled | default(false) | bool
 
-# Workaround for setup-env.sh not running in CaaS CI, so:
+# Workaround for setup-env.sh not running in CaaS environment, so:
 # https://github.com/stackhpc/ansible-slurm-appliance/blob/ba9699267449fba58cd9c04c451759a914fd7144/ansible/validate.yml#L16
-# doesn't break CI
+# doesn't break CaaS platforms
 - hosts: localhost
   gather_facts: no
   tasks:


### PR DESCRIPTION
CaaS doesn't use setup-env.sh which, since https://github.com/stackhpc/ansible-slurm-appliance/pull/700, is used to validate galaxy requirements.yml install.

Workaround uses pre-hook to copy requirements.yml to requirements.yml.last so this galaxy validate step doesn't error.

