### PR TITLE
Add support for setting server group in scheduler hints

### DIFF
--- a/environments/site/tofu/additional.tf
+++ b/environments/site/tofu/additional.tf
@@ -35,6 +35,7 @@ module "additional" {
   security_group_ids = lookup(each.value, "security_group_ids", [for o in data.openstack_networking_secgroup_v2.nonlogin: o.id])
   additional_cloud_config = lookup(each.value, "additional_cloud_config", var.additional_cloud_config)
   additional_cloud_config_vars = lookup(each.value, "additional_cloud_config_vars", var.additional_cloud_config_vars)
+  server_group_id = lookup(each.value, "server_group_id", null)
 
   # can't be set for additional nodes
   compute_init_enable = []
@@ -68,6 +69,7 @@ module "additional" {
     "nodename_template",
     "security_group_ids",
     "additional_cloud_config",
-    "additional_cloud_config_vars"
+    "additional_cloud_config_vars",
+    "server_group_id"
   ]
 }

--- a/environments/site/tofu/compute.tf
+++ b/environments/site/tofu/compute.tf
@@ -34,6 +34,7 @@ module "compute" {
   match_ironic_node = lookup(each.value, "match_ironic_node", null)
   availability_zone = lookup(each.value, "availability_zone", null)
   ip_addresses = lookup(each.value, "ip_addresses", null)
+  server_group_id = lookup(each.value, "server_group_id", null)
 
   # computed
   # not using openstack_compute_instance_v2.control.access_ip_v4 to avoid
@@ -63,7 +64,8 @@ module "compute" {
     "gateway_ip",
     "nodename_template",
     "additional_cloud_config",
-    "additional_cloud_config_vars"
+    "additional_cloud_config_vars",
+    "server_group_id"
   ]
   
 }

--- a/environments/site/tofu/control.tf
+++ b/environments/site/tofu/control.tf
@@ -72,6 +72,13 @@ resource "openstack_compute_instance_v2" "control" {
     }
   }
 
+  dynamic "scheduler_hints" {
+    for_each = var.control_server_group_id != null ? [true] : []
+    content {
+      group = var.control_server_group_id
+    }
+  }
+
   metadata = {
     environment_root = var.environment_root
     access_ip = openstack_networking_port_v2.control[var.cluster_networks[0].network].all_fixed_ips[0]

--- a/environments/site/tofu/login.tf
+++ b/environments/site/tofu/login.tf
@@ -34,6 +34,7 @@ module "login" {
   match_ironic_node = lookup(each.value, "match_ironic_node", null)
   availability_zone = lookup(each.value, "availability_zone", null)
   ip_addresses = lookup(each.value, "ip_addresses", null)
+  server_group_id = lookup(each.value, "server_group_id", null)
 
   # can't be set for login
   compute_init_enable = []
@@ -68,7 +69,8 @@ module "login" {
     "nodename_template",
     "additional_cloud_config",
     "additional_cloud_config_vars",
-    "security_group_ids"
+    "security_group_ids",
+    "server_group_id"
   ]
   
 }

--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -103,6 +103,13 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
     }
   }
 
+  dynamic "scheduler_hints" {
+    for_each = var.server_group_id != null ? [true] : []
+    content {
+      group = var.server_group_id
+    }
+  }
+
   metadata = merge(
     {
         environment_root = var.environment_root
@@ -161,6 +168,13 @@ resource "openstack_compute_instance_v2" "compute" {
     content {
       port = openstack_networking_port_v2.compute["${each.key}-${network.key}"].id
       access_network = network.key == var.networks[0].network
+    }
+  }
+
+  dynamic "scheduler_hints" {
+    for_each = var.server_group_id != null ? [true] : []
+    content {
+      group = var.server_group_id
     }
   }
 

--- a/environments/site/tofu/node_group/variables.tf
+++ b/environments/site/tofu/node_group/variables.tf
@@ -208,3 +208,8 @@ variable "additional_cloud_config_vars" {
     default = {}
     nullable = false
 }
+
+variable "server_group_id" {
+    type = string
+    default = null
+}

--- a/environments/site/tofu/variables.tf
+++ b/environments/site/tofu/variables.tf
@@ -84,6 +84,7 @@ variable "login" {
                                if match_ironic_node is true, defered to OpenStack otherwise
             gateway_ip: Address to add default route via
             nodename_template: Overrides variable cluster_nodename_template
+            server_group_id: String ID of server group to use for scheduler hint
     EOF
 
     type = any
@@ -129,6 +130,7 @@ variable "compute" {
                                if match_ironic_node is true, defered to OpenStack otherwise
             gateway_ip: Address to add default route via
             nodename_template: Overrides variable cluster_nodename_template
+            server_group_id: String ID of server group to use for scheduler hint
 
         Nodes are added to the following inventory groups:
         - $group_name
@@ -339,4 +341,10 @@ variable "additional_cloud_config_vars" {
     description = "Map of values passed to the `additional_cloud_config` templatestring"
     type = map(any)
     default = {}
+}
+
+variable "control_server_group_id" {
+    description = "ID of server group to use for control node scheduler hint"
+    type = string
+    default = null
 }


### PR DESCRIPTION
Adds new OpenTofu variable `control_server_group_id` and node group parameter `server_group_id` to allow specifying a server group to set for scheduler hints. This allows controlling affinity/anti-affinity placement of cluster nodes on hypervisors.

If wishing to set these IDs from a data.openstack_compute_servergroup_v2 resource, note this was only added in v3.2 of the Terraform OpenStack provider, which is more recent than the current minimum requirement.