### PR TITLE
Make CaaS specific role: `persist_openhpc_secrets` idempotent

### DIFF
--- a/ansible/roles/persist_openhpc_secrets/tasks/main.yml
+++ b/ansible/roles/persist_openhpc_secrets/tasks/main.yml
@@ -14,14 +14,18 @@
   loop:
     - "{{ appliances_state_dir }}/ansible.facts.d"
     - "/etc/ansible/facts.d"
-    
+
+- name: Load existing OpenHPC secrets if present
+  ansible.builtin.setup:
+    filter: ansible_local
+  when: openhpc_secrets_stat.stat.exists
+
 - name: Write OpenHPC secrets
   template:
     src: openhpc_secrets.fact
     dest: "{{ appliances_state_dir }}/ansible.facts.d/openhpc_secrets.fact"
     owner: root
     mode: 0600
-  when: "not openhpc_secrets_stat.stat.exists"
 
 - name: Symlink persistent facts to facts_path
   file:
@@ -30,6 +34,6 @@
     dest: /etc/ansible/facts.d/openhpc_secrets.fact
     owner: root
     
-- name: Read facts
+- name: Refresh facts to pick up any new secrets
   ansible.builtin.setup:
     filter: ansible_local

--- a/ansible/roles/persist_openhpc_secrets/templates/openhpc_secrets.fact
+++ b/ansible/roles/persist_openhpc_secrets/templates/openhpc_secrets.fact
@@ -5,6 +5,6 @@
   "vault_elasticsearch_kibana_password": "{{ lookup('password', '/dev/null') }}",
   "vault_mysql_root_password": "{{ lookup('password', '/dev/null') }}",
   "vault_mysql_slurm_password": "{{ lookup('password', '/dev/null') }}",
-  "vault_openhpc_mungekey": "{{ lookup('pipe', 'dd if=/dev/urandom bs=1 count=1024 2>/dev/null | base64') | regex_replace('\s+', '') }}"
+  "vault_openhpc_mungekey": "{{ lookup('pipe', 'dd if=/dev/urandom bs=1 count=1024 2>/dev/null | base64') | regex_replace('\s+', '') }}",
   "vault_alertmanager_admin_password": "{{ lookup('password', '/dev/null') }}"
 }

--- a/ansible/roles/persist_openhpc_secrets/templates/openhpc_secrets.fact
+++ b/ansible/roles/persist_openhpc_secrets/templates/openhpc_secrets.fact
@@ -6,4 +6,5 @@
   "vault_mysql_root_password": "{{ lookup('password', '/dev/null') }}",
   "vault_mysql_slurm_password": "{{ lookup('password', '/dev/null') }}",
   "vault_openhpc_mungekey": "{{ lookup('pipe', 'dd if=/dev/urandom bs=1 count=1024 2>/dev/null | base64') | regex_replace('\s+', '') }}"
+  "vault_alertmanager_admin_password": "{{ lookup('password', '/dev/null') }}"
 }

--- a/ansible/roles/persist_openhpc_secrets/templates/openhpc_secrets.fact
+++ b/ansible/roles/persist_openhpc_secrets/templates/openhpc_secrets.fact
@@ -1,10 +1,10 @@
 {
-  "vault_azimuth_user_password": "{{ lookup('password', '/dev/null') }}",
-  "vault_grafana_admin_password": "{{ lookup('password', '/dev/null') }}",
-  "vault_elasticsearch_admin_password": "{{ lookup('password', '/dev/null') }}",
-  "vault_elasticsearch_kibana_password": "{{ lookup('password', '/dev/null') }}",
-  "vault_mysql_root_password": "{{ lookup('password', '/dev/null') }}",
-  "vault_mysql_slurm_password": "{{ lookup('password', '/dev/null') }}",
-  "vault_openhpc_mungekey": "{{ lookup('pipe', 'dd if=/dev/urandom bs=1 count=1024 2>/dev/null | base64') | regex_replace('\s+', '') }}",
-  "vault_alertmanager_admin_password": "{{ lookup('password', '/dev/null') }}"
+  "vault_azimuth_user_password": "{{ ansible_local.openhpc_secrets.vault_azimuth_user_password | default(lookup('password', '/dev/null')) }}",
+  "vault_grafana_admin_password": "{{ ansible_local.openhpc_secrets.vault_grafana_admin_password | default(lookup('password', '/dev/null')) }}",
+  "vault_elasticsearch_admin_password": "{{ ansible_local.openhpc_secrets.vault_elasticsearch_admin_password | default(lookup('password', '/dev/null')) }}",
+  "vault_elasticsearch_kibana_password": "{{ ansible_local.openhpc_secrets.vault_elasticsearch_kibana_password | default(lookup('password', '/dev/null')) }}",
+  "vault_mysql_root_password": "{{ ansible_local.openhpc_secrets.vault_mysql_root_password | default(lookup('password', '/dev/null')) }}",
+  "vault_mysql_slurm_password": "{{ ansible_local.openhpc_secrets.vault_mysql_slurm_password | default(lookup('password', '/dev/null')) }}",
+  "vault_openhpc_mungekey": "{{ ansible_local.openhpc_secrets.vault_openhpc_mungekey | default(lookup('pipe', 'dd if=/dev/urandom bs=1 count=1024 2>/dev/null | base64') | regex_replace('\\s+', '')) }}",
+  "vault_alertmanager_admin_password": "{{ ansible_local.openhpc_secrets.vault_alertmanager_admin_password | default(lookup('password', '/dev/null')) }}"
 }

--- a/environments/.caas/inventory/group_vars/all/cluster.yml
+++ b/environments/.caas/inventory/group_vars/all/cluster.yml
@@ -11,6 +11,7 @@ vault_elasticsearch_kibana_password: "{{ hostvars[groups['control'][0]].ansible_
 vault_mysql_root_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_mysql_root_password }}"
 vault_mysql_slurm_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_mysql_slurm_password }}"
 vault_openhpc_mungekey: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_openhpc_mungekey }}"
+vault_alertmanager_admin_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_alertmanager_admin_password }}"
 
 # Override this to cope with the case where the podman group just doesn't exist
 appliances_local_users_podman_enable: "{{ groups.get('podman', []) | length > 0 }}"


### PR DESCRIPTION
CaaS env now inherits from both common and site envs

As a result of this we hit a problem where alertmanager is now turned on by default but there’s no secret for it. Also secret is added to `persist_openhpc_secrets`.

Aligning CaaS to site also re-raises the issue of CaaS secrets not being idempotent. This is resolved by:

- Fixing upgrade by changing the persist_openhpc_secrets role to read the facts file if it exists
- template it out again, with the template being changed to be idempotent for values a la the approach in https://github.com/stackhpc/ansible-slurm-appliance/blob/main/ansible/roles/passwords/defaults/main.yml
- then read it again (getting any new passwords)