### PR TITLE
Incorporate workflow_run into the CI so that triggered workflows are easier restarted

### DIFF
--- a/.github/workflows/extra-trigger.yml
+++ b/.github/workflows/extra-trigger.yml
@@ -1,0 +1,20 @@
+---
+name: Trigger - Test extra build 
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  packages: read
+  # To report GitHub Actions status checks
+  statuses: write
+
+jobs:
+  extra:
+    runs-on: ubuntu-latest
+    steps:
+      # No-op job to trigger workflow 'extra.yml' via workflow_run
+      - uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -7,10 +7,13 @@
 name: Test extra build
 on:
   workflow_dispatch:
+  #workflow_run:
+  #  workflows: ["Trigger - Test extra build"]
+  #  types: [completed,requested]
   workflow_run:
-    workflows: ["extra"]
-    types:
-      - completed
+    workflows: ["Test on push and pull request"]
+    #types: [completed,requested]
+    types: [completed]
 
 permissions:
   contents: read
@@ -19,6 +22,12 @@ permissions:
   statuses: write
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "event name is:" ${{ github.event_name }} 
+      - run: echo "event type is:" ${{ github.event.action }} 
+
   doca:
     name: extra-build
     runs-on: ubuntu-22.04

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -6,8 +6,11 @@
 
 name: Test extra build
 on:
-  workflow_call:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["extra"]
+    types:
+      - completed
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,10 +127,13 @@ jobs:
     needs: files_changed
     if: |
       needs.files_changed.outputs.stackhpc == 'true'
-    runs-on: ubuntu-latest
+    #uses: ./.github/workflows/stackhpc-trigger.yml
+    # TEST - remove from here and uncomment the above
     steps:
-      # No-op job to trigger workflow 'stackhpc.yml' via workflow_run
-      - uses: mattdesl/no-op@32ec85ff176f761f607087006bda993440da5fe4
+      - uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'
+    runs-on: ubuntu-latest
 
   extra:
     name: Test extra build
@@ -138,10 +141,13 @@ jobs:
     if: |
       github.event_name != 'pull_request' && needs.files_changed.outputs.extra_on_push == 'true' ||
       github.event_name == 'pull_request' && needs.files_changed.outputs.extra_on_pull_request == 'true'
-    runs-on: ubuntu-latest
+    #uses: ./.github/workflows/extra-trigger.yml
+    # TEST - remove from here and uncomment the above
     steps:
-      # No-op job to trigger workflow 'extra.yml' via workflow_run
-      - uses: mattdesl/no-op@32ec85ff176f761f607087006bda993440da5fe4
+      - uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'
+    runs-on: ubuntu-latest
 
   trivyscan:
     name: Trivy scan image for vulnerabilities
@@ -149,7 +155,10 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       needs.files_changed.outputs.trivyscan == 'true'
-    runs-on: ubuntu-latest
+    #uses: ./.github/workflows/trivyscan-trigger.yml
+    # TEST - remove from here and uncomment the above
     steps:
-      # No-op job to trigger workflow 'trivyscan.yml' via workflow_run
-      - uses: mattdesl/no-op@32ec85ff176f761f607087006bda993440da5fe4
+      - uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'
+    runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,8 +127,10 @@ jobs:
     needs: files_changed
     if: |
       needs.files_changed.outputs.stackhpc == 'true'
-    uses: ./.github/workflows/stackhpc.yml
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      # No-op job to trigger workflow 'stackhpc.yml' via workflow_run
+      - uses: mattdesl/no-op@32ec85ff176f761f607087006bda993440da5fe4
 
   extra:
     name: Test extra build
@@ -136,8 +138,10 @@ jobs:
     if: |
       github.event_name != 'pull_request' && needs.files_changed.outputs.extra_on_push == 'true' ||
       github.event_name == 'pull_request' && needs.files_changed.outputs.extra_on_pull_request == 'true'
-    uses: ./.github/workflows/extra.yml
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      # No-op job to trigger workflow 'extra.yml' via workflow_run
+      - uses: mattdesl/no-op@32ec85ff176f761f607087006bda993440da5fe4
 
   trivyscan:
     name: Trivy scan image for vulnerabilities
@@ -145,5 +149,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       needs.files_changed.outputs.trivyscan == 'true'
-    uses: ./.github/workflows/trivyscan.yml
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      # No-op job to trigger workflow 'trivyscan.yml' via workflow_run
+      - uses: mattdesl/no-op@32ec85ff176f761f607087006bda993440da5fe4

--- a/.github/workflows/stackhpc-trigger.yml
+++ b/.github/workflows/stackhpc-trigger.yml
@@ -1,0 +1,20 @@
+---
+name: Trigger - Test deployment and reimage on OpenStack 
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  packages: read
+  # To report GitHub Actions status checks
+  statuses: write
+
+jobs:
+  stackhpc:
+    runs-on: ubuntu-latest
+    steps:
+      # No-op job to trigger workflow 'stackhpc.yml' via workflow_run
+      - uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'

--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -7,10 +7,13 @@
 name: Test deployment and reimage on OpenStack
 on:
   workflow_dispatch:
+  #workflow_run:
+  #  workflows: ["Trigger - Test deployment and reimage on OpenStack"]
+  #  types: [completed,requested]
   workflow_run:
-    workflows: ["stackhpc"]
-    types:
-      - completed
+    workflows: ["Test on push and pull request"]
+    #types: [completed,requested]
+    types: [completed]
 
 permissions:
   contents: read
@@ -19,6 +22,12 @@ permissions:
   statuses: write
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "event name is:" ${{ github.event_name }} 
+      - run: echo "event type is:" ${{ github.event.action }} 
+
   openstack:
     name: openstack-ci
     runs-on: ubuntu-22.04

--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -6,8 +6,11 @@
 
 name: Test deployment and reimage on OpenStack
 on:
-  workflow_call:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["stackhpc"]
+    types:
+      - completed
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+---
+name: Test
+
+# This is a test workflow to see if we can introduce a new workflow (outside of the default branch)
+# and have it trigger from the main CI.
+# If it triggers, what will github.event_name be set to?
+# Ideally we want to know whether we've triggered downstream from a push or a pull request.
+
+on:
+  workflow_call:
+  workflow_run:
+    workflows: ["Test on push and pull request"]
+    types: [completed,requested]
+
+permissions:
+  contents: read
+  packages: read
+  # To report GitHub Actions status checks
+  statuses: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "event name is:" ${{ github.event_name }} 
+      - run: echo "event type is:" ${{ github.event.action }} 

--- a/.github/workflows/trivyscan-trigger.yml
+++ b/.github/workflows/trivyscan-trigger.yml
@@ -1,0 +1,20 @@
+---
+name: Trigger - Trivy scan image for vulnerabilities 
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  packages: read
+  # To report GitHub Actions status checks
+  statuses: write
+
+jobs:
+  trivyscan:
+    runs-on: ubuntu-latest
+    steps:
+      # No-op job to trigger workflow 'trivyscan.yml' via workflow_run
+      - uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'

--- a/.github/workflows/trivyscan.yml
+++ b/.github/workflows/trivyscan.yml
@@ -7,10 +7,13 @@
 name: Trivy scan image for vulnerabilities
 on:
   workflow_dispatch:
+  #workflow_run:
+  #  workflows: ["Trigger - Trivy scan image for vulnerabilities"]
+  #  types: [completed,requested]
   workflow_run:
-    workflows: ["trivyscan"]
-    types:
-      - completed
+    workflows: ["Test on push and pull request"]
+    #types: [completed,requested]
+    types: [completed]
 
 permissions:
   contents: read
@@ -19,6 +22,12 @@ permissions:
   statuses: write
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "event name is:" ${{ github.event_name }} 
+      - run: echo "event type is:" ${{ github.event.action }} 
+
   scan:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/trivyscan.yml
+++ b/.github/workflows/trivyscan.yml
@@ -6,8 +6,11 @@
 
 name: Trivy scan image for vulnerabilities
 on:
-  workflow_call:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["trivyscan"]
+    types:
+      - completed
 
 permissions:
   contents: read

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
-    "cluster_image": {
-        "RL8": "openhpc-RL8-250918-0840-930223fb",
-        "RL9": "openhpc-RL9-250918-0840-930223fb"
-    }
+  "cluster_image": {
+    "RL8": "openhpc-RL8-250918-0840-930223fb",
+    "RL9": "openhpc-RL9-250918-0840-930223fb"
+  }
 }

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
-  "cluster_image": {
-    "RL8": "openhpc-RL8-250918-0840-930223fb",
-    "RL9": "openhpc-RL9-250918-0840-930223fb"
-  }
+    "cluster_image": {
+        "RL8": "openhpc-RL8-250918-0840-930223fb",
+        "RL9": "openhpc-RL9-250918-0840-930223fb"
+    }
 }


### PR DESCRIPTION
We don't want to have to wait until the complete CI workflow has finished before we can re-run any failed parts.
The workflow_run trigger slightly decouples the `stackhpc`, `extra`, and `trivyscan` workflows from the `main` CI workflow in a way that makes them easier to restart whilst `main` is still running.