### PR TITLE
Remove summary from AI PR review to make it more useful

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,3 @@
+code_review:
+  pull_request_opened:
+    summary: false


### PR DESCRIPTION
The default summary is very verbose and distracting.