### PR TITLE
Update dnf repo snapshots

### DIFF
--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -29,7 +29,7 @@ dnf_repos_default:
   appstream:
     '8.10':
       pulp_path: rocky/8.10/AppStream/x86_64/os
-      pulp_timestamp: 20250614T013846
+      pulp_timestamp: 20250918T034501
       repo_file: Rocky-AppStream
     '9.4':
       pulp_path: rocky/9.4/AppStream/x86_64/os
@@ -41,12 +41,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.6':
       pulp_path: rocky/9.6/AppStream/x86_64/os
-      pulp_timestamp: 20250902T060015
+      pulp_timestamp: 20250910T025857
       repo_file: rocky
   appstream-source:
     '8.10':
       pulp_path: rocky/8.10/AppStream/source/os
-      pulp_timestamp: 20250910T023401
+      pulp_timestamp: 20250918T040529
       repo_file: Rocky-AppStream
     '9.6':
       pulp_path: rocky/9.6/AppStream/source/os
@@ -55,7 +55,7 @@ dnf_repos_default:
   baseos:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/x86_64/os
-      pulp_timestamp: 20250614T013846
+      pulp_timestamp: 20250918T034501
       repo_file: Rocky-BaseOS
     '9.4':
       pulp_path: rocky/9.4/BaseOS/x86_64/os
@@ -67,12 +67,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.6':
       pulp_path: rocky/9.6/BaseOS/x86_64/os
-      pulp_timestamp: 20250902T094855
+      pulp_timestamp: 20250910T041629
       repo_file: rocky
   baseos-source:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/source/os/
-      pulp_timestamp: 20250909T040446
+      pulp_timestamp: 20250918T040529
       repo_file: Rocky-BaseOS
     '9.6':
       pulp_path: rocky/9.6/BaseOS/source/os/
@@ -81,7 +81,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20250614T013846
+      pulp_timestamp: 20250918T034501
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -94,7 +94,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.6':
       pulp_path: rocky/9.6/CRB/x86_64/os
-      pulp_timestamp: 20250902T060015
+      pulp_timestamp: 20250910T025857
       repo_file: rocky
   crb-source:
     '9.6':
@@ -104,20 +104,20 @@ dnf_repos_default:
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
-      pulp_timestamp: 20250615T234151
+      pulp_timestamp: 20250919T001943
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/x86_64
-      pulp_timestamp: 20250908T001730
+      pulp_timestamp: 20250919T001943
       repo_file: epel
   epel-source:
     '8':
       pulp_path: epel/8/Everything/source
-      pulp_timestamp: 20250912T002900
+      pulp_timestamp: 20250919T001943
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/source
-      pulp_timestamp: 20250912T002900
+      pulp_timestamp: 20250919T001943
       repo_file: epel
   extras:
     '8.10':
@@ -148,10 +148,10 @@ dnf_repos_default:
   grafana:
     '8':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20250730T011314
+      pulp_timestamp: 20250917T024714
       repo_file: grafana
       timestamp: 20250615T005738
     '9':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20250906T025340
+      pulp_timestamp: 20250917T024714
       repo_file: grafana

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -43,6 +43,15 @@ dnf_repos_default:
       pulp_path: rocky/9.6/AppStream/x86_64/os
       pulp_timestamp: 20250902T060015
       repo_file: rocky
+  appstream-source:
+    '8.10':
+      pulp_path: rocky/8.10/AppStream/source/os
+      pulp_timestamp: 20250910T023401
+      repo_file: Rocky-AppStream
+    '9.6':
+      pulp_path: rocky/9.6/AppStream/source/os
+      pulp_timestamp: 20250910T035252
+      repo_file: rocky
   baseos:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/x86_64/os
@@ -59,6 +68,15 @@ dnf_repos_default:
     '9.6':
       pulp_path: rocky/9.6/BaseOS/x86_64/os
       pulp_timestamp: 20250902T094855
+      repo_file: rocky
+  baseos-source:
+    '8.10':
+      pulp_path: rocky/8.10/BaseOS/source/os/
+      pulp_timestamp: 20250909T040446
+      repo_file: Rocky-BaseOS
+    '9.6':
+      pulp_path: rocky/9.6/BaseOS/source/os/
+      pulp_timestamp: 20250910T035252
       repo_file: rocky
   crb:
     '8.10':
@@ -78,6 +96,11 @@ dnf_repos_default:
       pulp_path: rocky/9.6/CRB/x86_64/os
       pulp_timestamp: 20250902T060015
       repo_file: rocky
+  crb-source:
+    '9.6':
+      pulp_path: rocky/9.6/CRB/source/os
+      pulp_timestamp: 20250910T035252
+      repo_file: rocky
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
@@ -86,6 +109,15 @@ dnf_repos_default:
     '9':
       pulp_path: epel/9/Everything/x86_64
       pulp_timestamp: 20250908T001730
+      repo_file: epel
+  epel-source:
+    '8':
+      pulp_path: epel/8/Everything/source
+      pulp_timestamp: 20250912T002900
+      repo_file: epel
+    '9':
+      pulp_path: epel/9/Everything/source
+      pulp_timestamp: 20250912T002900
       repo_file: epel
   extras:
     '8.10':
@@ -103,6 +135,15 @@ dnf_repos_default:
     '9.6':
       pulp_path: rocky/9.6/extras/x86_64/os
       pulp_timestamp: 20250726T040613
+      repo_file: rocky-extras
+  extras-source:
+    '8.10':
+      pulp_path: rocky/8.10/extras/source/os
+      pulp_timestamp: 20250828T161842
+      repo_file: Rocky-Extras
+    '9.6':
+      pulp_path: rocky/9.6/extras/source/os
+      pulp_timestamp: 20250828T161842
       repo_file: rocky-extras
   grafana:
     '8':


### PR DESCRIPTION
Also uses source repos from Ark (used for openhpc package rebuilds).

Replaces #783