### PR TITLE
Fix RStudio and Code Server apps

### DIFF
--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -121,7 +121,7 @@
       when: "'openhpc' in group_names"
 
     # - import_playbook: portal.yml
-    - name: Open Ondemand server (packages)
+    - name: Open OnDemand server (packages)
       ansible.builtin.include_role:
         name: osc.ood
         tasks_from: install-package.yml
@@ -129,24 +129,36 @@
       when: "'openondemand' in group_names"
     # # FUTURE: install-apps.yml - this is git clones
 
-    - name: Open Ondemand server (apps)
+    - name: Open OnDemand server (apps)
       ansible.builtin.include_role:
         name: osc.ood
         tasks_from: install-apps.yml
         vars_from: "Rocky/{{ ansible_distribution_major_version }}.yml"
       when: "'openondemand' in group_names"
 
-    - name: Open Ondemand remote desktop
+    - name: Open OnDemand remote desktop
       ansible.builtin.import_role:
         name: openondemand
         tasks_from: vnc_compute.yml
       when: "'openondemand_desktop' in group_names"
 
-    - name: Open Ondemand jupyter node
+    - name: Open OnDemand Jupyter Notebook
       ansible.builtin.import_role:
         name: openondemand
         tasks_from: jupyter_compute.yml
       when: "'openondemand_jupyter' in group_names"
+
+    - name: Open OnDemand RStudio
+      ansible.builtin.import_role:
+        name: openondemand
+        tasks_from: rstudio_compute.yml
+      when: "'openondemand_rstudio' in group_names"
+
+    - name: Open OnDemand Code Server
+      ansible.builtin.import_role:
+        name: openondemand
+        tasks_from: codeserver_compute.yml
+      when: "'openondemand_codeserver' in group_names"
 
     - name: Install Apache PAM module # Extracted from start of roles/openondemand/tasks/pam_auth.yml to ensure only installed during build
       ansible.builtin.dnf:

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-250918-0840-930223fb",
-    "RL9": "openhpc-RL9-250918-0840-930223fb"
+    "RL8": "openhpc-RL8-250923-2026-3a86f35c",
+    "RL9": "openhpc-RL9-250923-2026-3a86f35c"
   }
 }

--- a/environments/common/inventory/group_vars/all/openondemand.yml
+++ b/environments/common/inventory/group_vars/all/openondemand.yml
@@ -199,7 +199,7 @@ openondemand_apps_rstudio_default:
       widget: select
       options:
         - "RStudio v{{ openondemand_rstudio_version }}"
-        - "rstudio-server/{{ openondemand_rstudio_version }}}"
+        - "rstudio-server/{{ openondemand_rstudio_version }}"
     extra_modules_script:
       label: Extra modules script
       help: If you'd like to load additional modules alongside RStudio-Server, put the 'module load ...' commands into a text file (one 'module load...' per line) and specify its path here # noqa: yaml[line-length]

--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -125,7 +125,7 @@ variable "volume_type" {
 
 variable "volume_size" {
   type = number
-  default = 15
+  default = 18
 }
 
 variable "image_disk_format" {


### PR DESCRIPTION
They were both missing from the fat image build. Also fix a syntax error with the RStudio version.