### PR TITLE
Fix .caas secrets not persisting post-reimage and skip tofu vars validation for .caas

### DIFF
--- a/ansible/roles/persist_openhpc_secrets/tasks/main.yml
+++ b/ansible/roles/persist_openhpc_secrets/tasks/main.yml
@@ -15,6 +15,14 @@
     - "{{ appliances_state_dir }}/ansible.facts.d"
     - "/etc/ansible/facts.d"
 
+- name: Symlink to persisted facts if present
+  ansible.builtin.file:
+    state: link
+    src: "{{ appliances_state_dir }}/ansible.facts.d/openhpc_secrets.fact"
+    dest: /etc/ansible/facts.d/openhpc_secrets.fact
+    owner: root
+  when: openhpc_secrets_stat.stat.exists
+
 - name: Load existing OpenHPC secrets if present
   ansible.builtin.setup:
     filter: ansible_local

--- a/ansible/validate.yml
+++ b/ansible/validate.yml
@@ -77,6 +77,7 @@
           - cluster_home_volume is defined
           - cluster_compute_groups is defined
         fail_msg: "One or more expected variables are missing: is OpenTofu inventory template up to date?"
+      when: not appliances_caas_skip_validate_vars
 
 - name: Ensure control node is in inventory
   hosts: all

--- a/environments/.caas/inventory/group_vars/all/defaults.yml
+++ b/environments/.caas/inventory/group_vars/all/defaults.yml
@@ -1,0 +1,1 @@
+appliances_caas_skip_validate_vars: true

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -8,6 +8,7 @@ appliances_cockpit_state: absent # RHEL cockpit installed but not enabled in gen
 # appliances_state_dir: # define an absolute path here to use for persistent state: NB: This is defined as /var/lib/state in inventory by the default Terraform
 appliances_mode: configure
 appliances_pulp_url: https://ark.stackhpc.com
+appliances_caas_skip_validate_vars: false
 
 # Address(ip/dns) for internal communication between services. This is
 # normally traffic you do no want to expose to users.


### PR DESCRIPTION
Fixes bug where, after reimaging the cluster, persisted .caas secrets aren't symlinked to the ansible facts directory until after facts are loaded for writing secrets, causing secrets to be regenerated.

Also skips validation task for checking tofu templated vars exist. The vars it checks for aren't currently used in the .caas case:
- `cluster_domain_suffix` is used in `freeIPA` and `resolv_conf` roles, neither of which are active in .caas
- `cluster_home_volume` is set to true in the normal appliance if the `home_volume_provisioning` tofu var isn't set to `"none"`. The `home_volume_provisioning` var doesn't exist in the .caas tofu as the home volume is always tofu managed. NFS options controlled by `cluster_home_volume` default to true if it is unset, so this still works
- `cluster_compute_groups` gets templated into `openhpc_nodegroups` and `openhpc_rebuild_partition.nodegroups` in the normal appliance, but .caas templates `openhpc_nodegroups` with Azimuth values and `openhpc_rebuild_partition.nodegroups` isn't (currently) relevant to .caas
so it was opted to skip the validation task rather than adding misleading dummy values for those variables