### PR TITLE
Use (group) syntax in access.conf

### DIFF
--- a/ansible/roles/compute_init/files/compute-init.yml
+++ b/ansible/roles/compute_init/files/compute-init.yml
@@ -346,7 +346,7 @@
       ansible.builtin.blockinfile:
         path: /etc/security/access.conf
         block: |
-          +:adm:ALL
+          +:(adm):ALL
           -:ALL:ALL
 
     - name: Ensure slurmd service state

--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -50,7 +50,7 @@
       ansible.builtin.blockinfile:
         path: /etc/security/access.conf
         block: |
-          +:adm:ALL
+          +:(adm):ALL
           -:ALL:ALL
  # vagrant uses (deprecated) ansible_ssh_user
 


### PR DESCRIPTION
From access.conf(5):

    The second field, the users/group field, should be a list of one or
    more login names, group names, or ALL (which always matches). To
    differentiate user entries from group entries, group entries should
    be written with brackets, e.g. (group).