### PR TITLE
Fix image sync workflow for new larger fat images

### DIFF
--- a/.github/workflows/s3-image-sync.yml
+++ b/.github/workflows/s3-image-sync.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Convert image to QCOW2
         run: |
           . venv/bin/activate
-          qemu-img convert -f raw -O qcow2 -c "${{ env.RUNNER_IMAGE_DIR }}/${{ env.TARGET_IMAGE }}.raw" "${{ env.TARGET_IMAGE }}"
+          qemu-img convert -f raw -O qcow2 -c "${{ env.RUNNER_IMAGE_DIR }}/${{ env.TARGET_IMAGE }}.raw" "${{ env.RUNNER_IMAGE_DIR }}/${{ env.TARGET_IMAGE }}"
         shell: bash
 
       - name: Upload Image to S3

--- a/.github/workflows/s3-image-sync.yml
+++ b/.github/workflows/s3-image-sync.yml
@@ -9,6 +9,7 @@ on:
 env:
   S3_BUCKET: openhpc-images-prerelease
   IMAGE_PATH: environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+  RUNNER_IMAGE_DIR: /mnt/images
 
 permissions:
   contents: read
@@ -97,20 +98,22 @@ jobs:
         run: |
           . venv/bin/activate
           df -h
-          openstack image save --file "/mnt/${{ env.TARGET_IMAGE }}.raw" "${{ env.TARGET_IMAGE }}"
+          sudo mkdir ${{ env.RUNNER_IMAGE_DIR }}
+          sudo chmod ugo=rwX ${{ env.RUNNER_IMAGE_DIR }}
+          openstack image save --file "${{ env.RUNNER_IMAGE_DIR }}/${{ env.TARGET_IMAGE }}.raw" "${{ env.TARGET_IMAGE }}"
           df -h
         shell: bash
 
       - name: Convert image to QCOW2
         run: |
           . venv/bin/activate
-          qemu-img convert -f raw -O qcow2 -c "/mnt/${{ env.TARGET_IMAGE }}.raw" "${{ env.TARGET_IMAGE }}"
+          qemu-img convert -f raw -O qcow2 -c "${{ env.RUNNER_IMAGE_DIR }}/${{ env.TARGET_IMAGE }}.raw" "${{ env.TARGET_IMAGE }}"
         shell: bash
 
       - name: Upload Image to S3
         run: |
           echo "Uploading Image: ${{ env.TARGET_IMAGE }} to S3..."
-          s3cmd --multipart-chunk-size-mb=150 put "/mnt/${{ env.TARGET_IMAGE }}" s3://${{ env.S3_BUCKET }}
+          s3cmd --multipart-chunk-size-mb=150 put "${{ env.RUNNER_IMAGE_DIR }}/${{ env.TARGET_IMAGE }}" s3://${{ env.S3_BUCKET }}
         shell: bash
 
   image_sync:

--- a/.github/workflows/s3-image-sync.yml
+++ b/.github/workflows/s3-image-sync.yml
@@ -93,33 +93,24 @@ jobs:
           echo "TARGET_IMAGE=${TARGET_IMAGE}" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Clear up some space on runner
-        run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          sudo apt-get clean
-          df -h
-
       - name: Download image to runner
         run: |
           . venv/bin/activate
-          openstack image save --file "${{ env.TARGET_IMAGE }}.raw" "${{ env.TARGET_IMAGE }}"
+          df -h
+          openstack image save --file "/mnt/${{ env.TARGET_IMAGE }}.raw" "${{ env.TARGET_IMAGE }}"
           df -h
         shell: bash
 
       - name: Convert image to QCOW2
         run: |
           . venv/bin/activate
-          qemu-img convert -f raw -O qcow2 -c "${{ env.TARGET_IMAGE }}.raw" "${{ env.TARGET_IMAGE }}"
+          qemu-img convert -f raw -O qcow2 -c "/mnt/${{ env.TARGET_IMAGE }}.raw" "${{ env.TARGET_IMAGE }}"
         shell: bash
 
       - name: Upload Image to S3
         run: |
           echo "Uploading Image: ${{ env.TARGET_IMAGE }} to S3..."
-          s3cmd --multipart-chunk-size-mb=150 put ${{ env.TARGET_IMAGE }} s3://${{ env.S3_BUCKET }}
+          s3cmd --multipart-chunk-size-mb=150 put "/mnt/${{ env.TARGET_IMAGE }}" s3://${{ env.S3_BUCKET }}
         shell: bash
 
   image_sync:


### PR DESCRIPTION
Since https://github.com/stackhpc/ansible-slurm-appliance/pull/782 merged increasing the image size to 20GB, the GitHub hosted runner has been out of space when converting the .raw to .qcow2.

This uses the `/mnt` directory which appears to be on a mostly-empty 74GB disk as the working directory to avoid that issue.