### PR TITLE
Update fatimages to include OnDemand codeserver password fix

### DIFF
--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-250925-1639-62d67ae3",
-    "RL9": "openhpc-RL9-250925-1639-62d67ae3"
+    "RL8": "openhpc-RL8-251001-1515-81a25814",
+    "RL9": "openhpc-RL9-251001-1424-81a25814"
   }
 }


### PR DESCRIPTION
Forgot to bump new fatimages for https://github.com/stackhpc/ansible-slurm-appliance/pull/806