### PR TITLE
Export state directory to OnDemand nodes in CaaS environment

### DIFF
--- a/ansible/roles/zenith_proxy/tasks/main.yml
+++ b/ansible/roles/zenith_proxy/tasks/main.yml
@@ -61,6 +61,8 @@
     group: "{{ zenith_proxy_podman_user }}"
     mode: "0755"
   become: true
+  delegate_to: "{{ groups['control'] | first }}"
+  run_once: true
 
 - name: Initialise Zenith client
   # Use a foreground command rather than the podman_container module as I could not

--- a/environments/.caas/inventory/group_vars/all/nfs.yml
+++ b/environments/.caas/inventory/group_vars/all/nfs.yml
@@ -5,8 +5,18 @@ caas_nfs_home:
   - comment: Export /exports/home from Slurm control node as /home
     nfs_enable:
       server: "{{ inventory_hostname in groups['control'] }}"
-      clients: "{{ inventory_hostname in groups['cluster'] }}"
+      clients: "{{ inventory_hostname in groups['cluster'] and inventory_hostname not in groups['control'] }}"
     nfs_export: "/exports/home" # assumes default site TF is being used
     nfs_client_mnt_point: "/home"
+    nfs_export_options: "rw,secure,root_squash"
 
-nfs_configurations: "{{ caas_nfs_home if not cluster_home_manila_share | bool else [] }}"
+caas_ood_zenith_state_dir:
+  - comment: Export /var/lib/state from Slurm control node
+    nfs_enable:
+      server: "{{ inventory_hostname in groups['control'] }}"
+      clients: "{{ inventory_hostname in groups['openondemand'] }}"
+    nfs_export: "/var/lib/state"
+    nfs_client_mnt_point: "/var/lib/state"
+    nfs_export_options: "rw,secure,root_squash"
+
+nfs_configurations: "{{ caas_ood_zenith_state_dir + ( caas_nfs_home if not cluster_home_manila_share | bool else [] ) }}"


### PR DESCRIPTION
Functional revert of https://github.com/stackhpc/ansible-slurm-appliance/commit/fa028f9acc986372e0dcd2b9f0d949fc0066c19b which caused a bug where Zenith SSH keys are regenerated after a reimage. Modified `zenith_proxy` role to cope with root-squashed state directory