### PR TITLE
replace whitespace with ASCII octal \040

### DIFF
--- a/ansible/roles/nhc/templates/nhc.conf.j2
+++ b/ansible/roles/nhc/templates/nhc.conf.j2
@@ -8,7 +8,7 @@
 {# /efi is mounted both directly and via systemd1 autofs, which NHC can't cope with #}
 {# use `awk '{print $5 " " $10 " " $4 " " $9}' /proc/self/mountinfo | sort -k1` to check that is the only case #}
 {% set mount_mode = 'rw' if 'rw' in mount.options.split(',') else 'ro' %}
-{{ ansible_fqdn }} || check_fs_mount_{{ mount_mode }} -t "{{ mount.fstype }}" -s "{{ mount.device }}" -f "{{ mount.mount }}"
+{{ ansible_fqdn }} || check_fs_mount_{{ mount_mode }} -t "{{ mount.fstype }}" -s "{{ mount.device | replace(' ', '\\040') }}" -f "{{ mount.mount }}"
 {% endfor %}
 
 ## Ethernet interface checks


### PR DESCRIPTION
When mounting a cifs mount that included white space in the source path the slurm NHC (Node Health Check) fails. This resulted in all the nodes being pun into drain:
The slrum warning output was something like:
> NHC: check_fs_mount:
> /mnt/gen_epi mounted from //10.10.10.10/3.040Projects/sequencing040list
> (should match //10.10.10.10/3. Projects/sequencing list)

Ansible mount in `/etc/fstab` formats white space as ASCII code `\040 ` including the `\`.
`/etc/fstab` (and the CIFS kernel client) does not accept pre-escaped `\040` in the `src` path. So the `replace(' ', '\\040')`  was added to `ansible/roles/nhc/templates/nhc.conf.j2`