### PR TITLE
[draft] bootstrap: restore removing cockpit via dnf module

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -207,10 +207,10 @@
   become: true
   tags: cockpit
   tasks:
-    - name: Remove RHEL cockpit # noqa: no-changed-when
-      ansible.builtin.command: dnf -y remove cockpit-ws
-      register: dnf_remove_output
-      ignore_errors: true # Avoid failing if a lock or other error happens
+    - name: Remove RHEL cockpit
+      ansible.builtin.dnf:
+        name: cockpit-ws
+        state: absent
 
 - hosts: firewalld
   gather_facts: false


### PR DESCRIPTION
This reverts a change made in #440 to debug errors in rocky update workflow