### PR TITLE
Add psi=1 to kernel command-line

### DIFF
--- a/ansible/fatimage.yml
+++ b/ansible/fatimage.yml
@@ -45,6 +45,22 @@
         pulp_site_target_distribution_version: "{{ hostvars[groups['pulp_site'][0]]['ansible_facts']['distribution_version'] }}"
       when: appliances_mode != 'configure'
 
+- hosts: builder
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Ensure psi=1 on boot
+      ansible.builtin.include_role:
+        name: stackhpc.linux.grubcmdline
+      vars:
+        kernel_cmdline: "{{ grubcmdline_kernel_cmdline }}"
+        kernel_cmdline_remove: "{{ grubcmdline_kernel_cmdline_remove }}"
+  handlers:
+    - name: reboot  # noqa: name[casing]
+      ansible.builtin.debug:
+        msg: no need to reboot when building
+
+
 - import_playbook: bootstrap.yml
 
 - hosts: doca

--- a/environments/common/inventory/group_vars/all/grubcmdline.yml
+++ b/environments/common/inventory/group_vars/all/grubcmdline.yml
@@ -1,0 +1,7 @@
+# Enable Pressure Stall Information (psi) for performance diagnostics.
+grubcmdline_kernel_cmdline:
+  - psi=1
+# note that if grubcmdline_kernel_cmdline_remove is empty, all arguments
+# not in grubcmdline_kernel_cmdline will be removed (they match the empty regex)
+grubcmdline_kernel_cmdline_remove:
+  - ^psi=


### PR DESCRIPTION
via /etc/default/grub, using the grubcmdline role.

Pressure Stall Information refines the system load indicator into more up to date (<1 minute) and detailed (cpu, ram, io) metrics.
Node Exporter will grab them if available.
The grafana Node Exporter dashboard will have to be updated to a newer version to display the information.