### PR TITLE
Support using a trunk port for node networking

### DIFF
--- a/environments/site/tofu/compute.tf
+++ b/environments/site/tofu/compute.tf
@@ -35,6 +35,10 @@ module "compute" {
   availability_zone    = lookup(each.value, "availability_zone", null)
   ip_addresses         = lookup(each.value, "ip_addresses", null)
   server_group_id      = lookup(each.value, "server_group_id", null)
+  trunk_parent_network_id = lookup(each.value, "trunk_parent_network_id", null)
+  trunk_subport_network_id = lookup(each.value, "trunk_subport_network_id", null)
+  trunk_subport_vlan_id = lookup(each.value, "trunk_subport_vlan_id", null)
+  use_trunk = lookup(each.value, "use_trunk", false)
 
   # computed
   # not using openstack_compute_instance_v2.control.access_ip_v4 to avoid
@@ -65,7 +69,11 @@ module "compute" {
     "nodename_template",
     "additional_cloud_config",
     "additional_cloud_config_vars",
-    "server_group_id"
+    "server_group_id",
+    "trunk_parent_network_id",
+    "trunk_subport_network_id",
+    "trunk_subport_vlan_id",
+    "use_trunk"
   ]
 
 }

--- a/environments/site/tofu/inventory.tpl
+++ b/environments/site/tofu/inventory.tpl
@@ -53,6 +53,9 @@ ${cluster_name}_${group_name}:
             instance_id: ${ node.id }
             networks: ${jsonencode({for n in node.network: n.name => {"fixed_ip_v4": n.fixed_ip_v4, "fixed_ip_v6": n.fixed_ip_v6}})}
             node_fqdn: ${compute_groups[group_name]["fqdns"][nodename]}
+            trunk_subport_network_id: ${compute_groups[group_name]["trunk_subports"][nodename] != {} ? compute_groups[group_name]["trunk_subports"][nodename][nodename]["network_id"] : "no"}
+            trunk_subport_fixed_ip_v4: ${compute_groups[group_name]["trunk_subports"][nodename] != {} ? compute_groups[group_name]["trunk_subports"][nodename][nodename]["all_fixed_ips"][0] : "no"}
+            trunk_subport_vlan_id: ${compute_groups[group_name]["trunks"][nodename] != {} ? tolist(compute_groups[group_name]["trunks"][nodename][nodename]["sub_port"])[0]["segmentation_id"] : "no"} 
 %{ endfor ~}
     vars:
         # NB: this is the target image, not necessarily what is provisioned

--- a/environments/site/tofu/node_group/network.tf
+++ b/environments/site/tofu/node_group/network.tf
@@ -12,3 +12,34 @@ data "openstack_networking_subnet_v2" "subnet" {
 
   name = each.value.subnet
 }
+
+resource "openstack_networking_port_v2" "trunk-parent" {
+  for_each = var.use_trunk ? toset(var.nodes) : []
+  name = "${split(".", local.fqdns[each.key])[0]}-trunk-parent"
+  network_id = var.trunk_parent_network_id
+  lifecycle {
+    ignore_changes = [extra_dhcp_option]
+  }
+}
+
+resource "openstack_networking_port_v2" "trunk-subport" {
+  for_each = var.use_trunk ? toset(var.nodes) : []
+  name = "${split(".", local.fqdns[each.key])[0]}-trunk-subport"
+  network_id = var.trunk_subport_network_id
+  lifecycle {
+    ignore_changes = [extra_dhcp_option]
+  }
+}
+
+resource "openstack_networking_trunk_v2" "trunk" {
+  for_each = var.use_trunk ? toset(var.nodes) : []
+  name = "${split(".", local.fqdns[each.key])[0]}-trunk"
+  admin_state_up = "true"
+  port_id        = openstack_networking_port_v2.trunk-parent[each.key].id
+
+  sub_port {
+    port_id           = openstack_networking_port_v2.trunk-subport[each.key].id
+    segmentation_id   = var.trunk_subport_vlan_id
+    segmentation_type = "vlan"
+  }
+}

--- a/environments/site/tofu/node_group/network.tf
+++ b/environments/site/tofu/node_group/network.tf
@@ -13,7 +13,7 @@ data "openstack_networking_subnet_v2" "subnet" {
   name = each.value.subnet
 }
 
-resource "openstack_networking_port_v2" "trunk-parent" {
+resource "openstack_networking_port_v2" "trunk_parent" {
   for_each = var.use_trunk ? toset(var.nodes) : []
   name = "${split(".", local.fqdns[each.key])[0]}-trunk-parent"
   network_id = var.trunk_parent_network_id
@@ -22,7 +22,7 @@ resource "openstack_networking_port_v2" "trunk-parent" {
   }
 }
 
-resource "openstack_networking_port_v2" "trunk-subport" {
+resource "openstack_networking_port_v2" "trunk_subport" {
   for_each = var.use_trunk ? toset(var.nodes) : []
   name = "${split(".", local.fqdns[each.key])[0]}-trunk-subport"
   network_id = var.trunk_subport_network_id
@@ -35,10 +35,10 @@ resource "openstack_networking_trunk_v2" "trunk" {
   for_each = var.use_trunk ? toset(var.nodes) : []
   name = "${split(".", local.fqdns[each.key])[0]}-trunk"
   admin_state_up = "true"
-  port_id        = openstack_networking_port_v2.trunk-parent[each.key].id
+  port_id        = openstack_networking_port_v2.trunk_parent[each.key].id
 
   sub_port {
-    port_id           = openstack_networking_port_v2.trunk-subport[each.key].id
+    port_id           = openstack_networking_port_v2.trunk_subport[each.key].id
     segmentation_id   = var.trunk_subport_vlan_id
     segmentation_type = "vlan"
   }

--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -40,7 +40,7 @@ locals {
 
   trunk_subports = {
     for n in var.nodes :
-    n => var.use_trunk ? openstack_networking_port_v2.trunk-subport : {}
+    n => var.use_trunk ? openstack_networking_port_v2.trunk_subport : {}
   }
 }
 

--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -32,6 +32,16 @@ locals {
   }
 
   baremetal_az = var.availability_zone != null ? var.availability_zone : "nova"
+
+  trunks = {
+    for n in var.nodes :
+    n => var.use_trunk ? openstack_networking_trunk_v2.trunk : {}
+  }
+
+  trunk_subports = {
+    for n in var.nodes :
+    n => var.use_trunk ? openstack_networking_port_v2.trunk-subport : {}
+  }
 }
 
 resource "openstack_blockstorage_volume_v3" "compute" {
@@ -237,4 +247,12 @@ output "fqdns" {
 
 output "nodegroup_fips" {
   value = local.nodegroup_fips
+}
+
+output "trunk_subports" {
+  value = local.trunk_subports
+}
+
+output "trunks" {
+  value = local.trunks
 }

--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -110,8 +110,8 @@ resource "openstack_compute_instance_v2" "compute_fixed_image" {
   dynamic "network" {
     for_each = { for net in var.networks : net.network => net }
     content {
-      port           = openstack_networking_port_v2.compute["${each.key}-${network.key}"].id
-      access_network = network.key == var.networks[0].network
+      port           = var.use_trunk ? openstack_networking_trunk_v2.trunk["${each.key}"].port_id : openstack_networking_port_v2.compute["${each.key}-${network.key}"].id
+      access_network = var.use_trunk ? true : network.key == var.networks[0].network
     }
   }
 
@@ -178,8 +178,8 @@ resource "openstack_compute_instance_v2" "compute" {
   dynamic "network" {
     for_each = { for net in var.networks : net.network => net }
     content {
-      port           = openstack_networking_port_v2.compute["${each.key}-${network.key}"].id
-      access_network = network.key == var.networks[0].network
+      port           = var.use_trunk ? openstack_networking_trunk_v2.trunk["${each.key}"].port_id : openstack_networking_port_v2.compute["${each.key}-${network.key}"].id
+      access_network = var.use_trunk ? true : network.key == var.networks[0].network
     }
   }
 

--- a/environments/site/tofu/node_group/variables.tf
+++ b/environments/site/tofu/node_group/variables.tf
@@ -217,7 +217,7 @@ variable "server_group_id" {
 
 variable "trunk_parent_network_id" {
   type    = string
-  description = "ID of the network to use as the parent port of the trunk."
+  description = "ID of the network to use as the parent port of the trunk. This controls the access (native) VLAN ID implicitly."
   default = null
 }
 

--- a/environments/site/tofu/node_group/variables.tf
+++ b/environments/site/tofu/node_group/variables.tf
@@ -214,3 +214,28 @@ variable "server_group_id" {
   type    = string
   default = null
 }
+
+variable "trunk_parent_network_id" {
+  type    = string
+  description = "ID of the network to use as the parent port of the trunk."
+  default = null
+}
+
+variable "trunk_subport_network_id" {
+  type    = string
+  description = "ID of the network to use as the subport of the trunk."
+  default = null
+}
+
+variable "trunk_subport_vlan_id" {
+  type    = string
+  description = "VLAN ID of the network used as the subport of the trunk."
+  default = null
+}
+
+variable "use_trunk" {
+  type    = bool
+  description = "Whether to use a trunk port for the node's networking. trunk_parent_network_id, trunk_subport_network_id, and trunk_subport_vlan_id must also be set."
+  default = false
+  nullable = false
+}

--- a/environments/site/tofu/variables.tf
+++ b/environments/site/tofu/variables.tf
@@ -86,7 +86,7 @@ variable "login" {
       gateway_ip: Address to add default route via
       nodename_template: Overrides variable cluster_nodename_template
       server_group_id: String ID of server group to use for scheduler hint
-      trunk_parent_network_id: ID of the network to use as the parent port of the trunk
+      trunk_parent_network_id: ID of the network to use as the parent port of the trunk. This controls the access (native) VLAN ID implicitly
       trunk_subport_network_id: ID of the network to use as the subport of the trunk
       trunk_subport_vlan_id: VLAN ID of the network used as the subport of the trunk
       use_trunk: Whether to use a trunk port for the node's networking. trunk_parent_network_id, trunk_subport_network_id, and trunk_subport_vlan_id must also be set
@@ -156,7 +156,7 @@ variable "compute" {
       gateway_ip: Address to add default route via
       nodename_template: Overrides variable cluster_nodename_template
       server_group_id: String ID of server group to use for scheduler hint
-      trunk_parent_network_id: ID of the network to use as the parent port of the trunk
+      trunk_parent_network_id: ID of the network to use as the parent port of the trunk. This controls the access (native) VLAN ID implicitly
       trunk_subport_network_id: ID of the network to use as the subport of the trunk
       trunk_subport_vlan_id: VLAN ID of the network used as the subport of the trunk
       use_trunk: Whether to use a trunk port for the node's networking. trunk_parent_network_id, trunk_subport_network_id, and trunk_subport_vlan_id must also be set

--- a/environments/site/tofu/variables.tf
+++ b/environments/site/tofu/variables.tf
@@ -86,6 +86,10 @@ variable "login" {
       gateway_ip: Address to add default route via
       nodename_template: Overrides variable cluster_nodename_template
       server_group_id: String ID of server group to use for scheduler hint
+      trunk_parent_network_id: ID of the network to use as the parent port of the trunk
+      trunk_subport_network_id: ID of the network to use as the subport of the trunk
+      trunk_subport_vlan_id: VLAN ID of the network used as the subport of the trunk
+      use_trunk: Whether to use a trunk port for the node's networking. trunk_parent_network_id, trunk_subport_network_id, and trunk_subport_vlan_id must also be set
   EOF
 
   type = any
@@ -152,6 +156,10 @@ variable "compute" {
       gateway_ip: Address to add default route via
       nodename_template: Overrides variable cluster_nodename_template
       server_group_id: String ID of server group to use for scheduler hint
+      trunk_parent_network_id: ID of the network to use as the parent port of the trunk
+      trunk_subport_network_id: ID of the network to use as the subport of the trunk
+      trunk_subport_vlan_id: VLAN ID of the network used as the subport of the trunk
+      use_trunk: Whether to use a trunk port for the node's networking. trunk_parent_network_id, trunk_subport_network_id, and trunk_subport_vlan_id must also be set
 
     Nodes are added to the following inventory groups:
     - $group_name


### PR DESCRIPTION
Locked behind the use_trunk flag. Unless this is set to true, the default networking is used.

I did want to do away with the use_trunk flag and just have it determined from the other vars being set, but it wasn't happy with that.
```
The "for_each" set includes values derived from resource attributes
```

There's still room for improvements here, these were just outside the scope of my initial support:
- Supporting multiple subports in the trunk
- Supporting the control node
- Docs

Would also be great to support one shared definition that can be used by mutliple node groups, no idea if this is doable though.