### PR TITLE
Identify temporary vulnerability exclusions in sections in .grype.yaml

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -2,6 +2,29 @@
 # ignore rules for grype, with justification
 ignore:
 
+# {{{ BEGIN VULNERABILITIES WE ARE STILL MONITORING
+# Please add temporary/undecided vulnerability exclusions there,
+# as opposed to vulnerabilities that we are confident we can exclude.
+
+# go compiler bug introduces potential unverified memory access wr loops with induction variables on under or overflow
+  - vulnerability: CVE-2026-27143
+
+# system dep, what can we do?
+  - vulnerability: CVE-2025-68121
+    package:
+      name: podman
+  - vulnerability: CVE-2025-68121
+    package:
+      location: /usr/bin/podman
+  - vulnerability: CVE-2025-68121
+    package:
+      location: "/usr/libexec/podman/**"
+
+# }}} END VULNERABILITIES WE ARE STILL MONITORING
+
+# Please place vulnerabilities we have decided upon here.
+# Don't add a blanket ignore for a location but use the `exclude:` field at the end of this file.
+
 # go crypto/tls vulnerability: programs not used with TLS
   - vulnerability: CVE-2025-68121
     package:
@@ -43,20 +66,6 @@ ignore:
     package:
       location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
 
-# go compiler bug introduces potential unverified memory access wr loops with induction variables on under or overflow
-  - vulnerability: CVE-2026-27143
-
-# system dep, what can we do?
-  - vulnerability: CVE-2025-68121
-    package:
-      name: podman
-  - vulnerability: CVE-2025-68121
-    package:
-      location: /usr/bin/podman
-  - vulnerability: CVE-2025-68121
-    package:
-      location: "/usr/libexec/podman/**"
-
 # go crypto/tls vulnerability: programs run by users not admins
   - vulnerability: CVE-2025-68121
     package:
@@ -82,11 +91,6 @@ ignore:
       location: /var/lib/podman/.local/share/containers/storage/overlay/6042fe893e2746bb7637efe59d35909d895c9060b43950db261e692ad3dfb834/diff/usr/bin/python2.7
   - package: # opensearch
       location: /var/lib/podman/.local/share/containers/storage/overlay/6042fe893e2746bb7637efe59d35909d895c9060b43950db261e692ad3dfb834/diff/usr/lib64/libpython2.7.so.1.0
-
-# kernel rescue image: won't be booted
-# CVE-2021-43267, CVE-2021-47378, ...
-  - package:
-      location: /boot/vmlinuz-0-rescue-*
 
 # CVE-2023-24531 `go env` command is not used
   - vulnerability: CVE-2023-24531
@@ -186,6 +190,19 @@ ignore:
     package:
       location: /var/www/ood/apps/sys/dashboard/Gemfile.lock
 
-# Exclude podman images from scan, pending MySQL+OpenSearch+Filebeat upgrade
 exclude:
+# {{{ BEGIN TEMPORARY EXCLUSIONS
+# Please add temporary/undecided path exclusions there.
+
+# Exclude podman images from scan, pending MySQL+OpenSearch+Filebeat upgrade
   - /var/lib/podman/.local/share/**
+
+# }}} END TEMPORARY EXCLUSIONS
+
+# Please add permanent exclusions here.
+# If a file can be excluded because it's not used, just remove it
+# from the image in `cleanup.yml`, or replace it with a no-op script like we did for
+# rclone.
+
+# kernel rescue image: won't be booted
+  - /boot/vmlinuz-0-rescue-*

--- a/dev/remove-tmp-grype-exclusions.py
+++ b/dev/remove-tmp-grype-exclusions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Remove identified sections from .grype.yaml
+"""
+
+import argparse
+import logging
+import re
+import sys
+
+IGNORED_SECTIONS = set(
+    [
+        "VULNERABILITIES WE ARE STILL MONITORING",
+        "TEMPORARY EXCLUSIONS",
+    ]
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Remove identified sections from .grype.yaml",
+        epilog="Redirect output to a new file, like .grype.clean.yaml and call grype with it...",
+    )
+    parser.add_argument(
+        "grype_yaml",
+        type=argparse.FileType("r", encoding="utf-8"),
+        help=".grype.yaml to modify",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose output")
+
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO, stream=sys.stderr
+    )
+
+    section = None
+    ignore = False
+    for line in args.grype_yaml:
+        if section is None:
+            if m := re.fullmatch(r"""# \{\{\{ BEGIN (.+)\n""", line):
+                section = m.group(1)
+                if ignore := section in IGNORED_SECTIONS:
+                    logging.debug(
+                        "Found starting line for section %s, ignoring until end",
+                        section,
+                    )
+                else:
+                    logging.debug(
+                        "Found starting line for section %s, not ignoring", section
+                    )
+            else:
+                sys.stdout.write(line)
+        elif m := re.fullmatch(r"""# \}\}\} END %s\n""" % re.escape(section), line):
+            logging.debug(
+                "Found ending line for section %s, will output next lines", section
+            )
+            section = None
+            ignore = False
+        elif not ignore:
+            logging.debug(
+                "In non-ignored section %s, outputting line %s", section, line
+            )
+            sys.stdout.write(line)
+        else:
+            logging.debug("In section %s. Ignoring line %s", section, line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
We intend to allow some vulnerabilities temporarily, while keeping a close eye on them.
By allowing a vulnerability as soon as it has been analyzed, we the CI status can get back to _green_ and we will be sure to notice new vulnerabilities thereafter.
If we don't allow vulnerabilities temporarily the Check will be "red" more often due to them and we might fail to notice new vulnerabilities.

We shall put those vulnerability ignore lists in `VULNERABILITIES WE ARE STILL MONITORING` and temporary path exclusions in `TEMPORARY EXCLUSIONS`.

We also intend to run scheduled jobs that will run grype without those temporary allow lists, to keep an eye on them and remove them from the list when not needed.

I've not created the scheduled run yet, but made a simple program to remove temporary exclusions from the file.
We would use it like `./dev/remove-tmp-grype-exclusions.py .grype.yaml > .grype.clean.yaml && grype -c .grype.clean.yaml ...`