### PR TITLE
Run cuda-samples in adhoc/cudatests.yml

### DIFF
--- a/ansible/adhoc/cudatests.yml
+++ b/ansible/adhoc/cudatests.yml
@@ -1,6 +1,5 @@
 ---
 - hosts: cuda
-  become: true
   gather_facts: true
   tags: cuda_bandwidth
   tasks:
@@ -8,3 +7,31 @@
       ansible.builtin.import_role:
         name: cuda
         tasks_from: bandwidth.yml
+
+- hosts: cuda
+  gather_facts: true
+  tags: cuda_samples
+  tasks:
+    - name: Compile cuda samples
+      ansible.builtin.import_role:
+        name: cuda
+        tasks_from: samples.yml
+    - name: Prepare output dir
+      ansible.builtin.tempfile:
+        path: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}"
+        prefix: "output-"
+        state: directory
+      register: cuda_samples_output_dir
+    - name: Show output dir
+      ansible.builtin.debug:
+        msg: "cuda samples will output files to: {{ cuda_samples_output_dir.path }}"
+    - name: Run cuda samples
+      ansible.builtin.command: >-
+        python3 ./run_tests.py
+          --config test_args.json
+          --dir build/bin
+          --output {{ cuda_samples_output_dir.path }}
+          --parallel {{ cuda_samples_run_tests_concurrency }}
+      args:
+        chdir: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}"
+      changed_when: true

--- a/ansible/adhoc/cudatests.yml
+++ b/ansible/adhoc/cudatests.yml
@@ -12,26 +12,7 @@
   gather_facts: true
   tags: cuda_samples
   tasks:
-    - name: Compile cuda samples
+    - name: Compile and run cuda samples
       ansible.builtin.import_role:
         name: cuda
         tasks_from: samples.yml
-    - name: Prepare output dir
-      ansible.builtin.tempfile:
-        path: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}"
-        prefix: "output-"
-        state: directory
-      register: cuda_samples_output_dir
-    - name: Show output dir
-      ansible.builtin.debug:
-        msg: "cuda samples will output files to: {{ cuda_samples_output_dir.path }}"
-    - name: Run cuda samples
-      ansible.builtin.command: >-
-        python3 ./run_tests.py
-          --config test_args.json
-          --dir build/bin
-          --output {{ cuda_samples_output_dir.path }}
-          --parallel {{ cuda_samples_run_tests_concurrency }}
-      args:
-        chdir: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}"
-      changed_when: true

--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -9,3 +9,31 @@ Install NVIDIA drivers and optionally CUDA packages. CUDA binaries are added to 
 - `cuda_packages`: Optional. Default provides CUDA Toolkit and GPUDirect Storage (GDS).
 - `cuda_package_version`: Optional. Default `latest` which will install the latest packages if not installed but won't upgrade already-installed packages. Use `'none'` to skip installing CUDA.
 - `cuda_persistenced_state`: Optional. State of systemd `nvidia-persistenced` service. Values as [ansible.builtin.systemd:state](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/systemd_module.html#parameter-state). Default `started`.
+
+## Running tests
+
+Tests can be run by `ansible-playbook ansible/adhoc/cudatests.yml`.
+By default all tests are run.
+
+### nvbandwidth
+
+Downloads, builds and runs <https://github.com/NVIDIA/nvbandwidth>.
+Select it with `--tags cuda_bandwidth`.
+
+Variables:
+
+- `cuda_bandwidth_version`: Optional. Version of nvbandwidth to download. Default `0.8`
+- `cuda_bandwidth_path`: Optional. Path to download nvbandwidth to. Default `/var/lib/{{ ansible_user }}/cuda_bandwidth`
+
+### cuda_samples
+
+Downloads, builds and runs <https://github.com/NVIDIA/cuda-samples>.
+Select it with `--tags cuda_samples`.
+
+Compilation with `cuda_samples_build_concurrency > 1` crashes on some problematic systems
+but should be fine in general.
+
+Variables:
+
+- `cuda_samples_build_concurrency`: Optional. `make -j` flag for build concurrency. Defaults to `ansible_processor_vcpus`.
+- `cuda_samples_run_tests_concurrency`: Optional. How many applications from cuda_samples to run in parallel. Defaults to `1`.

--- a/ansible/roles/cuda/defaults/main.yml
+++ b/ansible/roles/cuda/defaults/main.yml
@@ -14,9 +14,9 @@ cuda_packages_fabricmanager:
   - "nvidia-fabricmanager-{{ cuda_nvidia_driver_version }}"
 cuda_packages: "{{ cuda_packages_default + ( cuda_packages_fabricmanager if cuda_install_nvidiafabricmanger | bool else [] ) }}"
 # variables for cuda-samples
+cuda_samples_release_url: "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v{{ cuda_version_short }}.tar.gz"
 cuda_samples_build_concurrency: "{{ ansible_processor_vcpus }}"
 cuda_samples_path: "/var/lib/{{ ansible_user }}/cuda_samples"
-cuda_samples_release_url: "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v{{ cuda_version_short }}.tar.gz"
 cuda_samples_run_tests_concurrency: 1
 # cuda_devices: # discovered from deviceQuery run
 cuda_persistenced_state: started

--- a/ansible/roles/cuda/defaults/main.yml
+++ b/ansible/roles/cuda/defaults/main.yml
@@ -13,11 +13,11 @@ cuda_packages_default:
 cuda_packages_fabricmanager:
   - "nvidia-fabricmanager-{{ cuda_nvidia_driver_version }}"
 cuda_packages: "{{ cuda_packages_default + ( cuda_packages_fabricmanager if cuda_install_nvidiafabricmanger | bool else [] ) }}"
-cuda_samples_release_url: "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v{{ cuda_version_short }}.tar.gz"
+# variables for cuda-samples
+cuda_samples_build_concurrency: "{{ ansible_processor_vcpus }}"
 cuda_samples_path: "/var/lib/{{ ansible_user }}/cuda_samples"
-cuda_samples_programs:
-  - deviceQuery
-  - bandwidthTest
+cuda_samples_release_url: "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v{{ cuda_version_short }}.tar.gz"
+cuda_samples_run_tests_concurrency: 1
 # cuda_devices: # discovered from deviceQuery run
 cuda_persistenced_state: started
 cuda_install_nvidiafabricmanger: false

--- a/ansible/roles/cuda/tasks/samples.yml
+++ b/ansible/roles/cuda/tasks/samples.yml
@@ -28,3 +28,32 @@
     cmd: . /etc/profile.d/sh.local && cmake .. && make -j {{ cuda_samples_build_concurrency }} && make install
     chdir: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}/build"
     creates: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}/build/bin"
+
+- name: Prepare output dir
+  ansible.builtin.tempfile:
+    path: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}"
+    prefix: "output-"
+    state: directory
+  register: cuda_samples_output_dir
+
+- name: Show output dir
+  ansible.builtin.debug:
+    msg: "cuda samples will output files to: {{ cuda_samples_output_dir.path }}"
+
+- name: Run cuda samples
+  ansible.builtin.command: >-
+    python3 ./run_tests.py
+      --config test_args.json
+      --dir build/bin
+      --output {{ cuda_samples_output_dir.path }}
+      --parallel {{ cuda_samples_run_tests_concurrency }}
+  args:
+    chdir: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}"
+  changed_when: true
+  register: cuda_samples_run
+
+- name: Show cuda samples output
+  ansible.builtin.debug:
+    msg: |
+      {{ cuda_samples_run.stderr }}
+      {{ cuda_samples_run.stdout }}

--- a/ansible/roles/cuda/tasks/samples.yml
+++ b/ansible/roles/cuda/tasks/samples.yml
@@ -25,6 +25,6 @@
 - name: Build CUDA samples
   ansible.builtin.shell:
     # We need to source /etc/profile.d/sh.local to add CUDA to the PATH
-    cmd: . /etc/profile.d/sh.local && cmake .. && make -j {{ ansible_processor_vcpus }}
+    cmd: . /etc/profile.d/sh.local && cmake .. && make -j {{ cuda_samples_build_concurrency }} && make install
     chdir: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}/build"
-    creates: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}/build/Samples/1_Utilities/deviceQuery/deviceQuery"
+    creates: "{{ cuda_samples_path }}/cuda-samples-{{ cuda_version_short }}/build/bin"


### PR DESCRIPTION
Adding the ability to run all cuda-samples from the same playbook as nvbandwidth: ansible/adhoc/cudatests.

This runs 155 test runs for 147 executables of cuda-samples.

Running is not wrapped in slurm. It could be improved to be run in multiple tasks, with device constrained per task, to target each gpu on the system but it is left as a future improvement.

Compilation happens on all nodes: it crashes the system in a specific hardware instance so I think it's interesting to always compile.