### PR TITLE
Run gpuburn as part of hpctests

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -254,7 +254,7 @@ jobs:
         run: |
           . venv/bin/activate
           . environments/.stackhpc/activate
-          ansible-playbook -vv ansible/adhoc/hpctests.yml
+          ansible-playbook -vv ansible/adhoc/hpctests.yml --skip-tags hpctests-gpu
 
       - name: Run EESSI tests
         run: |

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -42,7 +42,7 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
   **CAUTION: see note below**.
 - `hpctests_hpl_arch`: Optional, default 'linux64'. Arbitrary architecture name for HPL build. HPL is compiled on the first compute node of those selected (see `hpctests_nodes`), so this can be used to create different builds for different types of compute node.
 - `hpctests_cuda_compute_level`: Optional, default '8.0' which is good for A100 and newer. Cuda compute level used for gpuburn's compare kernel. Check <https://developer.nvidia.com/cuda/GPUs> for compatibility with target hardware.
-- `hpctests_gpuburn_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
+- `hpctests_gpu_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
 - `hpctests_gpuburn_minutes`: Optional, default 1. Duration in minutes of gpuburn's GPU load (the job takes slightly longer to run).
 - `hpctests_gpuburn_node_chunk_size`: Optional, default 1. How many nodes to run gpuburn on at a time
 
@@ -61,7 +61,7 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 > **[gpuburn]** `gpuburn` will bring GPU power consumption to the maximum. On bigger cards, this amounts to _700W_
 > times _gpu count_ of power draw per node. The default duration of `hpctests_gpuburn_minutes=1` will keep it to only one minute,
 > which should be acceptable. Making it longer will more accurately simulate a longer training but will stress power
-> supply and cooling. Use `hpctests_gpuburn_gres` to only run on a subset of GPUs per node.
+> supply and cooling. Use `hpctests_gpu_gres` to only run on a subset of GPUs per node.
 > Also note that the default `hpctests_gpuburn_node_chunk_size=1` will run gpuburn one host after the other.
 > Increasing `hpctests_gpuburn_node_chunk_size` will not only stress each node, but the whole power
 > and cooling delivery for the rack(s). Please use with caution.

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -9,6 +9,7 @@ Tests (with corresponding tags) are:
 - `pingpong`: Runs Intel MPI Benchmark's IMB-MPI1 pingpong between a pair of (scheduler-selected) nodes. Reports zero-size message latency and maximum bandwidth.
 - `pingmatrix`: Runs a similar pingpong test but between all pairs of nodes. Reports zero-size message latency & maximum bandwidth.
 - `hpl-solo`: Runs the HPL benchmark individually on all nodes. Reports Gflops.
+- `gpuburn`: Runs the [gpuburn](https://github.com/wilicc/gpu-burn/) utility to load-test GPUs. Reports Gflops.
 
 All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 
@@ -40,6 +41,9 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
   be selected to target using this fraction of each node's memory -
   **CAUTION: see note below**.
 - `hpctests_hpl_arch`: Optional, default 'linux64'. Arbitrary architecture name for HPL build. HPL is compiled on the first compute node of those selected (see `hpctests_nodes`), so this can be used to create different builds for different types of compute node.
+- `hpctests_cuda_compute_level`: Optional, default '8.0' which is good for A100 and newer. Cuda compute level used for gpuburn's compare kernel. Check <https://developer.nvidia.com/cuda/GPUs> for compatibility with target hardware.
+- `hpctests_gpuburn_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
+- `hpctests_gpuburn_minutes`: Optional, default 20. Duration in minutes of gpuburn's GPU load.
 
 ---
 

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -51,11 +51,21 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 
 **CAUTION**
 
-> The default of `hpctests_hpl_mem_frac=0.3` will not significantly load nodes.
+> **[hpl-solo]** The default of `hpctests_hpl_mem_frac=0.3` will not significantly load nodes.
 > Values up to ~0.8 may be appropriate for a stress test but ensure cloud
 > operators are aware in case this overloads e.g. power supplies or cooling.
 > Values > 0.8 require longer runtimes and increase the risk of out-of-memory
 > errors without normally significantly increasing the stress on the node
+
+**CAUTION**
+
+> **[gpuburn]** `gpuburn` will bring GPU power consumption to the maximum. On bigger cards, this amounts to _700W_
+> times _gpu count_ of power draw per node. The default duration of `hpctests_gpuburn_minutes=1` will keep it to only one minute,
+> which should be acceptable. Making it longer will more accurately simulate a longer training but will stress power
+> supply and cooling. Use `hpctests_gpuburn_gres` to only run on a subset of GPUs per node.
+> Also note that `hpctests_gpuburn_node_chunk_percent=10` will run gpuburn on only 10% of selected
+> nodes at a time. Bringing it to 100% to run on all nodes at once will not only stress a node, but the whole power
+> and cooling delivery for the rack(s). Please use with caution.
 
 The following variables should not generally be changed:
 

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -44,8 +44,7 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 - `hpctests_cuda_compute_level`: Optional, default '8.0' which is good for A100 and newer. Cuda compute level used for gpuburn's compare kernel. Check <https://developer.nvidia.com/cuda/GPUs> for compatibility with target hardware.
 - `hpctests_gpuburn_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
 - `hpctests_gpuburn_minutes`: Optional, default 1. Duration in minutes of gpuburn's GPU load (the job takes slightly longer to run).
-- `hpctests_gpuburn_node_chunk_percent`: Optional, default 10. Portion of all nodes to run gpuburn on at a time (by default, only run on 10% of the nodes at the time, rounded upward).
-- `hpctests_gpuburn_node_chunk_size`: Optional, default computed from hpctests_gpuburn_node_chunk_percent and hpctests_nodes and partition size. How many nodes to run gpuburn on at a time
+- `hpctests_gpuburn_node_chunk_size`: Optional, default 1. How many nodes to run gpuburn on at a time
 
 ---
 
@@ -63,8 +62,8 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 > times _gpu count_ of power draw per node. The default duration of `hpctests_gpuburn_minutes=1` will keep it to only one minute,
 > which should be acceptable. Making it longer will more accurately simulate a longer training but will stress power
 > supply and cooling. Use `hpctests_gpuburn_gres` to only run on a subset of GPUs per node.
-> Also note that `hpctests_gpuburn_node_chunk_percent=10` will run gpuburn on only 10% of selected
-> nodes at a time. Bringing it to 100% to run on all nodes at once will not only stress a node, but the whole power
+> Also note that the default `hpctests_gpuburn_node_chunk_size=1` will run gpuburn one host after the other.
+> Increasing `hpctests_gpuburn_node_chunk_size` will not only stress each node, but the whole power
 > and cooling delivery for the rack(s). Please use with caution.
 
 The following variables should not generally be changed:

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -43,7 +43,7 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 - `hpctests_hpl_arch`: Optional, default 'linux64'. Arbitrary architecture name for HPL build. HPL is compiled on the first compute node of those selected (see `hpctests_nodes`), so this can be used to create different builds for different types of compute node.
 - `hpctests_cuda_compute_level`: Optional, default '8.0' which is good for A100 and newer. Cuda compute level used for gpuburn's compare kernel. Check <https://developer.nvidia.com/cuda/GPUs> for compatibility with target hardware.
 - `hpctests_gpuburn_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
-- `hpctests_gpuburn_minutes`: Optional, default 20. Duration in minutes of gpuburn's GPU load.
+- `hpctests_gpuburn_minutes`: Optional, default 1. Duration in minutes of gpuburn's GPU load (the job takes slightly longer to run).
 - `hpctests_gpuburn_node_chunk_percent`: Optional, default 10. Portion of all nodes to run gpuburn on at a time (by default, only run on 10% of the nodes at the time, rounded upward).
 - `hpctests_gpuburn_node_chunk_size`: Optional, default computed from hpctests_gpuburn_node_chunk_percent and hpctests_nodes and partition size. How many nodes to run gpuburn on at a time
 

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -55,8 +55,7 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 > Values up to ~0.8 may be appropriate for a stress test but ensure cloud
 > operators are aware in case this overloads e.g. power supplies or cooling.
 > Values > 0.8 require longer runtimes and increase the risk of out-of-memory
-
-## errors without normally significantly increasing the stress on the node
+> errors without normally significantly increasing the stress on the node
 
 The following variables should not generally be changed:
 

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -44,6 +44,8 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 - `hpctests_cuda_compute_level`: Optional, default '8.0' which is good for A100 and newer. Cuda compute level used for gpuburn's compare kernel. Check <https://developer.nvidia.com/cuda/GPUs> for compatibility with target hardware.
 - `hpctests_gpuburn_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
 - `hpctests_gpuburn_minutes`: Optional, default 20. Duration in minutes of gpuburn's GPU load.
+- `hpctests_gpuburn_node_chunk_percent`: Optional, default 10. Portion of all nodes to run gpuburn on at a time (by default, only run on 10% of the nodes at the time, rounded upward).
+- `hpctests_gpuburn_node_chunk_size`: Optional, default computed from hpctests_gpuburn_node_chunk_percent and hpctests_nodes and partition size. How many nodes to run gpuburn on at a time
 
 ---
 

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -26,3 +26,5 @@ hpctests_hpl_arch: linux64
 # hpctests_reservation:
 # hpctests_account:
 # hpctests_qos:
+hpctests_cuda_compute_level: 8.0
+hpctests_gpuburn_minutes: 20

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -27,4 +27,6 @@ hpctests_hpl_arch: linux64
 # hpctests_account:
 # hpctests_qos:
 hpctests_cuda_compute_level: 8.0
+hpctests_gpuburn_node_chunk_percent: 10  # seems safe to run on 10% of the nodes by default
 hpctests_gpuburn_minutes: 20
+hpctests_gpuburn_version: "671f4be92477ce01cd9b536bc534a006dbee058f" # latest commit in master at this time

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -28,5 +28,5 @@ hpctests_hpl_arch: linux64
 # hpctests_qos:
 hpctests_cuda_compute_level: 8.0
 hpctests_gpuburn_node_chunk_percent: 10  # seems safe to run on 10% of the nodes by default
-hpctests_gpuburn_minutes: 20
+hpctests_gpuburn_minutes: 1
 hpctests_gpuburn_version: "671f4be92477ce01cd9b536bc534a006dbee058f" # latest commit in master at this time

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -27,6 +27,6 @@ hpctests_hpl_arch: linux64
 # hpctests_account:
 # hpctests_qos:
 hpctests_cuda_compute_level: 8.0
-hpctests_gpuburn_node_chunk_percent: 10  # seems safe to run on 10% of the nodes by default
+hpctests_gpuburn_node_chunk_size: 1 # only run on one node at a time to limit power draw, as a precaution
 hpctests_gpuburn_minutes: 1
 hpctests_gpuburn_version: "671f4be92477ce01cd9b536bc534a006dbee058f" # latest commit in master at this time

--- a/ansible/roles/hpctests/library/scontrol_node_info.py
+++ b/ansible/roles/hpctests/library/scontrol_node_info.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# pylint: disable=missing-module-docstring
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, StackHPC
+# Apache 2 License
+import json
+import re
+
+from ansible.module_utils.basic import AnsibleModule  # pylint: disable=import-error
+
+ANSIBLE_METADATA = {
+    "metadata_version": "0.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: scontrol_node_info
+short_description: Get information about Slurm nodes via scontrol
+version_added: "0.0"
+description: >
+    Gets all the available information from Slurm's `scontrol show nodes` command about specified nodes.
+    The returned `info` property is a dict with keys from scontrol --
+    All parameters and values a list of strings in specified node order.
+options
+    nodes:
+        description:
+            - Slurm nodenames for which information is required.
+        required: true
+        type: list
+requirements:
+    - "python >= 3.6"
+author:
+    - Steve Brasier, StackHPC
+"""
+
+EXAMPLES = """
+TODO
+"""
+
+
+def run_module():  # pylint: disable=missing-function-docstring
+    module_args = {
+        "nodes": {
+            "type": "list",
+            "required": True,
+        }
+    }
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+    result = {"changed": False}
+    if module.check_mode:
+        module.exit_json(**result)
+
+    _, stdout, _ = module.run_command(
+        ["scontrol", "show", "nodes", "--json", ",".join(module.params["nodes"])],
+        check_rc=True,
+    )  # `--nodes` doesn't filter enough, other partitions are still shown
+    info = json.loads(stdout)
+    for node_info in info.get("nodes", []):
+        node_info["gpus"] = {}
+        if "gres" in node_info:
+            gres = node_info["gres"]
+            for g in gres.split(","):
+                if m := re.match(r"""^gpu:(.+):([0-9]+)\(S:[0-9]+\)$""", g):
+                    resource, cnt = m.group(1), m.group(2)
+                    node_info["gpus"][resource] = int(cnt)
+    result["info"] = info.get("nodes", [])
+    module.exit_json(**result)
+
+
+def main():  # pylint: disable=missing-function-docstring
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/hpctests/library/scontrol_node_info.py
+++ b/ansible/roles/hpctests/library/scontrol_node_info.py
@@ -33,7 +33,7 @@ options
 requirements:
     - "python >= 3.6"
 author:
-    - Steve Brasier, StackHPC
+    - Eric Le Lay, StackHPC
 """
 
 EXAMPLES = """
@@ -64,7 +64,8 @@ def run_module():  # pylint: disable=missing-function-docstring
         if "gres" in node_info:
             gres = node_info["gres"]
             for g in gres.split(","):
-                if m := re.match(r"""^gpu:(.+):([0-9]+)\(S:[0-9]+\)$""", g):
+                m = re.match(r"""^gpu:(.+):([0-9]+)\(S:[0-9]+\)$""", g)
+                if m:
                     resource, cnt = m.group(1), m.group(2)
                     node_info["gpus"][resource] = int(cnt)
     result["info"] = info.get("nodes", [])

--- a/ansible/roles/hpctests/tasks/build-gpuburn.yml
+++ b/ansible/roles/hpctests/tasks/build-gpuburn.yml
@@ -1,0 +1,19 @@
+---
+- name: Make root directory
+  ansible.builtin.file:
+    path: "{{ hpctests_rootdir }}/gpuburn"
+    state: directory
+    mode: "0755"
+
+- name: Create build job script
+  ansible.builtin.template:
+    src: "gpuburn-build.sh.j2"
+    dest: "{{ hpctests_rootdir }}/gpuburn/gpuburn-build-{{ hpctests_hpl_arch }}.sh"
+    mode: "0644"
+
+- name: Build gpuburn executable
+  ansible.builtin.command:
+    cmd: "sbatch --wait gpuburn-build-{{ hpctests_hpl_arch }}.sh"
+    chdir: "{{ hpctests_rootdir }}/gpuburn"
+    # Also creates the compare.ptx file, specific to given hpctests_cuda_compute_level
+    creates: "{{ hpctests_gpuburn_install_dir }}/gpu_burn"

--- a/ansible/roles/hpctests/tasks/main.yml
+++ b/ansible/roles/hpctests/tasks/main.yml
@@ -37,3 +37,21 @@
     - hpl-solo
   block:
     - ansible.builtin.include_tasks: hpl-solo.yml
+
+- name: Build gpu_burn
+  become: true
+  become_user: "{{ hpctests_user }}"
+  tags:
+    - gpuburn
+    - hpctests-gpu
+  block:
+    - ansible.builtin.include_tasks: build-gpuburn.yml
+
+- name: Run gpu_burn on individual nodes
+  become: true
+  become_user: "{{ hpctests_user }}"
+  tags:
+    - gpuburn
+    - hpctests-gpu
+  block:
+    - ansible.builtin.include_tasks: run-gpuburn.yml

--- a/ansible/roles/hpctests/tasks/run-gpuburn.yml
+++ b/ansible/roles/hpctests/tasks/run-gpuburn.yml
@@ -23,6 +23,29 @@
   ansible.builtin.debug:
     msg: "Will run --gres={{ hpctests_gpuburn_gres }}"
 
+- name: Compute node chunk size
+  ansible.builtin.set_fact:
+    hpctests_gpuburn_node_chunk_size: >-
+      {{ ((hpctests_computes.stdout_lines | length) * (hpctests_gpuburn_node_chunk_percent | int) / 100) | round(method="ceil") | int }}
+  when: hpctests_gpuburn_node_chunk_size is  not defined
+
+- name: Ensure node chunk size is not zero
+  ansible.builtin.assert:
+    that: hpctests_gpuburn_node_chunk_size | int > 0
+    fail_msg: >
+      Can't run gpuburn on node chunks of size 0.
+      Please change hpctests_gpuburn_node_chunk_percent or specify
+      hpctests_gpuburn_node_chunk_size directly
+
+- name: Compute node chunk count
+  ansible.builtin.set_fact:
+    hpctests_gpuburn_node_chunk_count: >-
+      {{ ((hpctests_computes.stdout_lines | length) / (hpctests_gpuburn_node_chunk_size | int)) | round(method="ceil") | int }}
+
+- name: Show node chunks
+  ansible.builtin.debug:
+    msg: "Will run gpuburn on {{ hpctests_gpuburn_node_chunk_count }} chunks of {{ hpctests_gpuburn_node_chunk_size }} nodes at a time"
+
 - name: Create sbatch script
   ansible.builtin.template:
     src: gpuburn.sh.j2
@@ -40,9 +63,10 @@
     chdir: "{{ hpctests_rootdir }}/gpuburn"
   register: hpctests_gpuburn_sbatch
   vars:
-    timeout_h: "{{ ((hpctests_gpuburn_minutes | int) // 60) }}"
-    timeout_m: "{{ ((hpctests_gpuburn_minutes | int) % 60) }}"
-  async: "{{ ((hpctests_gpuburn_minutes | int)+ 1) * 60 }}" # give async an extra minute after slurm
+    timeout_minutes: "{{ (hpctests_gpuburn_minutes | int) * (hpctests_gpuburn_node_chunk_count | int) }}"
+    timeout_h: "{{ ((timeout_minutes | int) // 60) }}"
+    timeout_m: "{{ ((timeout_minutes | int) % 60) }}"
+  async: "{{ ((timeout_minutes | int) + 1) * 60 }}" # give async an extra minute after slurm
   poll: 15  # check every 15 seconds
 
 - name: Extract results

--- a/ansible/roles/hpctests/tasks/run-gpuburn.yml
+++ b/ansible/roles/hpctests/tasks/run-gpuburn.yml
@@ -1,0 +1,102 @@
+---
+- name: Assert gpuburn executable is present
+  block:
+    - ansible.builtin.stat:
+        path: "{{ hpctests_gpuburn_install_dir }}/gpu_burn"
+      register: gpuburn_exe_stat
+    - ansible.builtin.assert:
+        that:
+          - gpuburn_exe_stat.stat.exists and gpuburn_exe_stat.stat.executable
+        fail_msg: "Run build-gpuburn.yml to produce {{ hpctests_gpuburn_install_dir }}/gpu_burn"
+
+- name: Get Slurm node info
+  scontrol_node_info:
+    nodes: "{{ hpctests_computes.stdout_lines }}"
+  register: hpctests_nodeinfo
+
+- name: Select GPUs
+  ansible.builtin.set_fact:
+    hpctests_gpuburn_gres: "{% for gpu in (hpctests_nodeinfo.info[0].gpus | default({})) | dict2items %}{% if loop.index0 > 0 %},{% endif %}gpu:{{ gpu.key }}={{ gpu.value }}{% endfor %}"
+  when: hpctests_gpuburn_gres is not defined
+
+- name: Show selected GPUs
+  ansible.builtin.debug:
+    msg: "Will run --gres={{ hpctests_gpuburn_gres }}"
+
+- name: Create sbatch script
+  ansible.builtin.template:
+    src: gpuburn.sh.j2
+    dest: "{{ hpctests_rootdir }}/gpuburn/gpuburn.sh"
+    mode: "0755"
+
+- name: Remove previous outputs # noqa: no-changed-when
+  ansible.builtin.shell:
+    cmd: "rm -f {{ hpctests_rootdir }}/gpuburn/gpuburn.sh.*.out"
+
+- name: Run gpuburn # noqa: no-changed-when
+  ansible.builtin.command: >-
+    sbatch --wait --time={{ timeout_h }}:{{ timeout_m }}:30 ./gpuburn.sh
+  args:
+    chdir: "{{ hpctests_rootdir }}/gpuburn"
+  register: hpctests_gpuburn_sbatch
+  vars:
+    timeout_h: "{{ ((hpctests_gpuburn_minutes | int) // 60) }}"
+    timeout_m: "{{ ((hpctests_gpuburn_minutes | int) % 60) }}"
+  async: "{{ ((hpctests_gpuburn_minutes | int)+ 1) * 60 }}" # give async an extra minute after slurm
+  poll: 15  # check every 15 seconds
+
+- name: Extract results
+  # Example of gpuburn output. Notice the ^M = \0d characters because it redraws on screen:
+  # (snip)
+  # 100.0%  proc'd: 2363 (45303 Gflop/s) - 2363 (45066 Gflop/s)   errors: 0 - 0   temps: 41 C - 42 C ^M100.0%  proc'd: 2502 (45287 Gflop/s) - 2363 (45066 Gflop/s)   errors: 0 - 0   temps: 41 C - 42 C
+  # Killing processes with SIGTERM (soft kill)
+  # Using compare file: compare.ptx
+  # Burning for 60 seconds.
+  # Initialized device 1 with 81081 MB of memory (80484 MB available, using 72436 MB of it), using DOUBLES
+  # Results are 536870912 bytes each, thus performing 139 iterations
+  # Freed memory for dev 1
+  # Uninitted cublas
+  # Using compare file: compare.ptx
+  # Burning for 60 seconds.
+  # Initialized device 0 with 81081 MB of memory (80484 MB available, using 72436 MB of it), using DOUBLES
+  # Results are 536870912 bytes each, thus performing 139 iterations
+  # Freed memory for dev 0
+  # Uninitted cublas
+  # done
+  #
+  # Tested 2 GPUs:
+  #         GPU 0: OK
+  #         GPU 1: OK
+  tags: postpro
+  ansible.builtin.shell: |
+    set -o pipefail
+    for res in gpuburn.*.out; do
+      echo "=== $res ==="
+      grep SLURM_JOB_ID "$res"
+      grep -E '^GPU [0-9]*:' "$res"
+      grep 100.0% "$res" | tr '\r' '\n' | tail -1
+      awk '/Tested [0-9]+ GPUs:/ { ok=1 } (ok) { print }' < "$res"
+    done
+  args:
+    chdir: "{{ hpctests_rootdir }}/gpuburn"
+  changed_when: false
+  register: perf
+
+- name: Print results
+  tags: postpro
+  ansible.builtin.debug:
+    msg: |
+      {{ perf.stdout }}
+
+- name: Check gpuburn completed OK
+  tags: postpro
+  ansible.builtin.shell: |
+    set -o pipefail
+    for f in gpuburn.sh.*.out; do
+      awk '/Tested [0-9]+ GPUs:/ { ok=1 } (ok) { print }' < $f
+    done
+  args:
+    chdir: "{{ hpctests_rootdir }}/gpuburn"
+  changed_when: false
+  register: passed
+  failed_when: "'OK' not in passed.stdout"

--- a/ansible/roles/hpctests/tasks/run-gpuburn.yml
+++ b/ansible/roles/hpctests/tasks/run-gpuburn.yml
@@ -63,9 +63,9 @@
     chdir: "{{ hpctests_rootdir }}/gpuburn"
   register: hpctests_gpuburn_sbatch
   vars:
-    timeout_minutes: "{{ (hpctests_gpuburn_minutes | int) * (hpctests_gpuburn_node_chunk_count | int) }}"
-    timeout_h: "{{ ((timeout_minutes | int) // 60) }}"
-    timeout_m: "{{ ((timeout_minutes | int) % 60) }}"
+    timeout_minutes: "{{ ((hpctests_gpuburn_minutes | int) + 0.6) * (hpctests_gpuburn_node_chunk_count | int) }}"  # It takes 30s after burn to kill the kernels
+    timeout_h: "{{ ((timeout_minutes | float) // 60) | int }}"
+    timeout_m: "{{ ((timeout_minutes | float) % 60) | int }}"
   async: "{{ ((timeout_minutes | int) + 1) * 60 }}" # give async an extra minute after slurm
   poll: 15  # check every 15 seconds
 

--- a/ansible/roles/hpctests/tasks/run-gpuburn.yml
+++ b/ansible/roles/hpctests/tasks/run-gpuburn.yml
@@ -23,19 +23,12 @@
   ansible.builtin.debug:
     msg: "Will run --gres={{ hpctests_gpuburn_gres }}"
 
-- name: Compute node chunk size
-  ansible.builtin.set_fact:
-    hpctests_gpuburn_node_chunk_size: >-
-      {{ ((hpctests_computes.stdout_lines | length) * (hpctests_gpuburn_node_chunk_percent | int) / 100) | round(method="ceil") | int }}
-  when: hpctests_gpuburn_node_chunk_size is  not defined
-
 - name: Ensure node chunk size is not zero
   ansible.builtin.assert:
     that: hpctests_gpuburn_node_chunk_size | int > 0
     fail_msg: >
       Can't run gpuburn on node chunks of size 0.
-      Please change hpctests_gpuburn_node_chunk_percent or specify
-      hpctests_gpuburn_node_chunk_size directly
+      Please change hpctests_gpuburn_node_chunk_size
 
 - name: Compute node chunk count
   ansible.builtin.set_fact:

--- a/ansible/roles/hpctests/tasks/run-gpuburn.yml
+++ b/ansible/roles/hpctests/tasks/run-gpuburn.yml
@@ -45,6 +45,12 @@
     dest: "{{ hpctests_rootdir }}/gpuburn/gpuburn.sh"
     mode: "0755"
 
+- name: Create task script
+  ansible.builtin.template:
+    src: gpuburn-task.sh.j2
+    dest: "{{ hpctests_rootdir }}/gpuburn/gpuburn-task.sh"
+    mode: "0755"
+
 - name: Remove previous outputs # noqa: no-changed-when
   ansible.builtin.shell:
     cmd: "rm -f {{ hpctests_rootdir }}/gpuburn/gpuburn.sh.*.out"

--- a/ansible/roles/hpctests/tasks/run-gpuburn.yml
+++ b/ansible/roles/hpctests/tasks/run-gpuburn.yml
@@ -16,12 +16,12 @@
 
 - name: Select GPUs
   ansible.builtin.set_fact:
-    hpctests_gpuburn_gres: "{% for gpu in (hpctests_nodeinfo.info[0].gpus | default({})) | dict2items %}{% if loop.index0 > 0 %},{% endif %}gpu:{{ gpu.key }}={{ gpu.value }}{% endfor %}"
-  when: hpctests_gpuburn_gres is not defined
+    hpctests_gpu_gres: "{% for gpu in (hpctests_nodeinfo.info[0].gpus | default({})) | dict2items %}{% if loop.index0 > 0 %},{% endif %}gpu:{{ gpu.key }}={{ gpu.value }}{% endfor %}"
+  when: hpctests_gpu_gres is not defined
 
 - name: Show selected GPUs
   ansible.builtin.debug:
-    msg: "Will run --gres={{ hpctests_gpuburn_gres }}"
+    msg: "Will run --gres={{ hpctests_gpu_gres }}"
 
 - name: Ensure node chunk size is not zero
   ansible.builtin.assert:

--- a/ansible/roles/hpctests/tasks/run-gpuburn.yml
+++ b/ansible/roles/hpctests/tasks/run-gpuburn.yml
@@ -16,8 +16,12 @@
 
 - name: Select GPUs
   ansible.builtin.set_fact:
-    hpctests_gpu_gres: "{% for gpu in (hpctests_nodeinfo.info[0].gpus | default({})) | dict2items %}{% if loop.index0 > 0 %},{% endif %}gpu:{{ gpu.key }}={{ gpu.value }}{% endfor %}"
+    hpctests_gpu_gres: "{% for gpu in (hpctests_nodeinfo.info[0].gpus | default({})) | dict2items %}{% if loop.index0 > 0 %},{% endif %}gpu:{{ gpu.key }}:{{ gpu.value }}{% endfor %}"
   when: hpctests_gpu_gres is not defined
+
+- name: Compute GPU count per node
+  ansible.builtin.set_fact:
+    hpctests_gpus_per_node: "{{ hpctests_gpu_gres | split(',') | map('regex_replace', '^.*:([0-9]+)$', '\\1') | map('int') | sum }}"
 
 - name: Show selected GPUs
   ansible.builtin.debug:

--- a/ansible/roles/hpctests/tasks/setup.yml
+++ b/ansible/roles/hpctests/tasks/setup.yml
@@ -4,6 +4,12 @@
   register: _sinfo_partitions
   changed_when: false
 
+- name: Check given hpctests_partition
+  ansible.builtin.assert:
+    that: hpctests_partition in (_sinfo_partitions.stdout_lines | map('replace', '*', ''))
+    fail_msg: "Please check hpctests_partition: {{ hpctests_partition }} not in sinfo: {{ _sinfo_partitions.stdout_lines | join(' ') | replace('*', '')}}"
+  when: hpctests_partition is defined
+
 - name: Select default partition if hpctests_partition not given
   ansible.builtin.set_fact:
     hpctests_partition: "{{ (_sinfo_partitions.stdout_lines | select('contains', '*') | first)[:-1] }}"

--- a/ansible/roles/hpctests/templates/gpuburn-build.sh.j2
+++ b/ansible/roles/hpctests/templates/gpuburn-build.sh.j2
@@ -22,7 +22,7 @@ echo "compute level: {{ hpctests_cuda_compute_level }}"
 rm -r gpu-burn
 git clone https://github.com/wilicc/gpu-burn.git
 cd gpu-burn
-git checkout 671f4be92477ce01cd9b536bc534a006dbee058f # latest commit in master at this time
+git checkout "{{ hpctests_gpuburn_version }}"
 make "COMPUTE={{ hpctests_cuda_compute_level }}"
 mkdir -p "{{ hpctests_gpuburn_install_dir }}"
 cp -a gpu_burn "{{ hpctests_gpuburn_install_dir }}/"

--- a/ansible/roles/hpctests/templates/gpuburn-build.sh.j2
+++ b/ansible/roles/hpctests/templates/gpuburn-build.sh.j2
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#SBATCH --nodes=1
+#SBATCH --output=%x.%a.out
+#SBATCH --error=%x.%a.out
+#SBATCH --cpus-per-task=4
+#SBATCH --partition={{ hpctests_partition }}
+#SBATCH --time=00:30:00
+{%if hpctests_nodes is defined %}
+#SBATCH --nodelist={{ hpctests_computes.stdout_lines[0] }}
+{% endif %}
+{%if hpctests_account is defined %}
+#SBATCH --account={{ hpctests_account }}
+{% endif %}
+{%if hpctests_qos is defined %}
+#SBATCH --qos={{ hpctests_qos }}
+{% endif %}
+
+echo "arch: {{ hpctests_hpl_arch }}"
+echo "compute level: {{ hpctests_cuda_compute_level }}"
+{{ hpctests_pre_cmd }}
+# start from a clean state
+rm -r gpu-burn
+git clone https://github.com/wilicc/gpu-burn.git
+cd gpu-burn
+git checkout 671f4be92477ce01cd9b536bc534a006dbee058f # latest commit in master at this time
+make "COMPUTE={{ hpctests_cuda_compute_level }}"
+mkdir -p "{{ hpctests_gpuburn_install_dir }}"
+cp -a gpu_burn "{{ hpctests_gpuburn_install_dir }}/"
+cp -a compare.ptx "{{ hpctests_gpuburn_install_dir }}/"
+# shellcheck gets confused by jinja templating...
+#shellcheck disable=SC1056

--- a/ansible/roles/hpctests/templates/gpuburn-task.sh.j2
+++ b/ansible/roles/hpctests/templates/gpuburn-task.sh.j2
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+echo "PCI bus IDs visible via nvidia-smi:"
+nvidia-smi --query-gpu=pci.bus_id --format=csv
+echo "==========="
+
+if [[ "$CUDA_VISIBLE_DEVICES" =~ ^[0-9]+$ ]] && [ "$(nvidia-smi --query-gpu=pci.bus_id --format=csv,noheader | wc -l)" = 1 ]; then
+  echo "Resetting CUDA_VISIBLE_DEVICES to 0"
+  export CUDA_VISIBLE_DEVICES=0
+fi
+
+"{{ hpctests_gpuburn_install_dir }}/gpu_burn" \
+  -c "{{ hpctests_gpuburn_install_dir }}/compare.ptx" \
+  -d "{{ (hpctests_gpuburn_minutes | int) * 60 }}"

--- a/ansible/roles/hpctests/templates/gpuburn.sh.j2
+++ b/ansible/roles/hpctests/templates/gpuburn.sh.j2
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#SBATCH --gres={{ hpctests_gpuburn_gres }}
+#SBATCH --ntasks-per-gpu=1
+#SBATCH --cpus-per-gpu=1
+#SBATCH --mem-per-gpu=2G
+#SBATCH --output=%x.%N.out
+#SBATCH --error=%x.%N.out
+#SBATCH --array=0-{{ hpctests_computes.stdout_lines | length - 1 }}
+#SBATCH --partition={{ hpctests_partition }}
+{%if hpctests_nodes is defined %}
+#SBATCH --nodelist={{ hpctests_computes.stdout_lines[0] }}
+{% endif %}
+{%if hpctests_account is defined %}
+#SBATCH --account={{ hpctests_account }}
+{% endif %}
+{%if hpctests_qos is defined %}
+#SBATCH --qos={{ hpctests_qos }}
+{% endif %}
+echo SLURM_JOB_NODELIST: $SLURM_JOB_NODELIST
+echo SLURM_JOB_ID: $SLURM_JOB_ID
+echo gpuburn install dir: {{ hpctests_gpuburn_install_dir }}
+{{ hpctests_pre_cmd }}
+
+# shellcheck gets confused about jinja templates
+#shellcheck disable=SC1036,SC1056
+srun --output=%x.%N.%t.out --error=%x.%N.%t.out \
+	"{{ hpctests_gpuburn_install_dir }}/gpu_burn" \
+		-c "{{ hpctests_gpuburn_install_dir }}/compare.ptx" \
+		-d \
+		{{ (hpctests_gpuburn_minutes | int) * 60 }}

--- a/ansible/roles/hpctests/templates/gpuburn.sh.j2
+++ b/ansible/roles/hpctests/templates/gpuburn.sh.j2
@@ -3,12 +3,12 @@
 #SBATCH --ntasks-per-gpu=1
 #SBATCH --cpus-per-gpu=1
 #SBATCH --mem-per-gpu=2G
-#SBATCH --output=%x.%N.out
-#SBATCH --error=%x.%N.out
+#SBATCH --output=%x.out
+#SBATCH --error=%x.out
 #SBATCH --nodes={{ hpctests_computes.stdout_lines | length }}
 #SBATCH --partition={{ hpctests_partition }}
 {%if hpctests_nodes is defined %}
-#SBATCH --nodelist={{ hpctests_computes.stdout_lines[0] }}
+#SBATCH --nodelist={{ hpctests_computes.stdout_lines | join(',') }}
 {% endif %}
 {%if hpctests_account is defined %}
 #SBATCH --account={{ hpctests_account }}
@@ -22,9 +22,12 @@ echo gpuburn install dir: {{ hpctests_gpuburn_install_dir }}
 {{ hpctests_pre_cmd }}
 
 # shellcheck gets confused about jinja templates
+for i in $(scontrol show hostnames | xargs -n {{ hpctests_gpuburn_node_chunk_size }} | sed 's/ /,/g'); do
+echo "Testing chunk of nodes $i..."
 #shellcheck disable=SC1036,SC1056
-srun --output=%x.%N.%t.out --error=%x.%N.%t.out \
+srun --nodelist $i --nodes {{ hpctests_gpuburn_node_chunk_size }} --ntasks=$(( $SLURM_GPUS_ON_NODE * {{ hpctests_gpuburn_node_chunk_size }} )) --output=%x.$i.%t.out --error=%x.$i.%t.out \
 	"{{ hpctests_gpuburn_install_dir }}/gpu_burn" \
 		-c "{{ hpctests_gpuburn_install_dir }}/compare.ptx" \
 		-d \
 		{{ (hpctests_gpuburn_minutes | int) * 60 }}
+done

--- a/ansible/roles/hpctests/templates/gpuburn.sh.j2
+++ b/ansible/roles/hpctests/templates/gpuburn.sh.j2
@@ -5,7 +5,7 @@
 #SBATCH --mem-per-gpu=2G
 #SBATCH --output=%x.%N.out
 #SBATCH --error=%x.%N.out
-#SBATCH --array=0-{{ hpctests_computes.stdout_lines | length - 1 }}
+#SBATCH --nodes={{ hpctests_computes.stdout_lines | length }}
 #SBATCH --partition={{ hpctests_partition }}
 {%if hpctests_nodes is defined %}
 #SBATCH --nodelist={{ hpctests_computes.stdout_lines[0] }}

--- a/ansible/roles/hpctests/templates/gpuburn.sh.j2
+++ b/ansible/roles/hpctests/templates/gpuburn.sh.j2
@@ -24,10 +24,6 @@ echo gpuburn install dir: {{ hpctests_gpuburn_install_dir }}
 # shellcheck gets confused about jinja templates
 for i in $(scontrol show hostnames | xargs -n {{ hpctests_gpuburn_node_chunk_size }} | sed 's/ /,/g'); do
 echo "Testing chunk of nodes $i..."
-#shellcheck disable=SC1036,SC1056
 srun --nodelist $i --nodes {{ hpctests_gpuburn_node_chunk_size }} --ntasks=$(( $SLURM_GPUS_ON_NODE * {{ hpctests_gpuburn_node_chunk_size }} )) --output=%x.$i.%t.out --error=%x.$i.%t.out \
-	"{{ hpctests_gpuburn_install_dir }}/gpu_burn" \
-		-c "{{ hpctests_gpuburn_install_dir }}/compare.ptx" \
-		-d \
-		{{ (hpctests_gpuburn_minutes | int) * 60 }}
+    ./gpuburn-task.sh
 done

--- a/ansible/roles/hpctests/templates/gpuburn.sh.j2
+++ b/ansible/roles/hpctests/templates/gpuburn.sh.j2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#SBATCH --gres={{ hpctests_gpuburn_gres }}
+#SBATCH --gres={{ hpctests_gpu_gres }}
 #SBATCH --ntasks-per-gpu=1
 #SBATCH --cpus-per-gpu=1
 #SBATCH --mem-per-gpu=2G

--- a/ansible/roles/hpctests/templates/gpuburn.sh.j2
+++ b/ansible/roles/hpctests/templates/gpuburn.sh.j2
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #SBATCH --gres={{ hpctests_gpu_gres }}
-#SBATCH --ntasks-per-gpu=1
-#SBATCH --cpus-per-gpu=1
-#SBATCH --mem-per-gpu=2G
+#SBATCH --ntasks-per-node={{ hpctests_gpus_per_node }}
+#SBATCH --cpus-per-task=1
+#SBATCH --mem-per-cpu=2G
 #SBATCH --output=%x.out
 #SBATCH --error=%x.out
 #SBATCH --nodes={{ hpctests_computes.stdout_lines | length }}
@@ -24,6 +24,9 @@ echo gpuburn install dir: {{ hpctests_gpuburn_install_dir }}
 # shellcheck gets confused about jinja templates
 for i in $(scontrol show hostnames | xargs -n {{ hpctests_gpuburn_node_chunk_size }} | sed 's/ /,/g'); do
 echo "Testing chunk of nodes $i..."
-srun --nodelist $i --nodes {{ hpctests_gpuburn_node_chunk_size }} --ntasks=$(( $SLURM_GPUS_ON_NODE * {{ hpctests_gpuburn_node_chunk_size }} )) --output=%x.$i.%t.out --error=%x.$i.%t.out \
+srun --nodelist $i --nodes {{ hpctests_gpuburn_node_chunk_size }} \
+		--ntasks={{ hpctests_gpus_per_node * hpctests_gpuburn_node_chunk_size }} \
+		--tres-bind=gres/gpu:verbose,single:1 \
+		--output=%x.$i.%t.out --error=%x.$i.%t.out \
     ./gpuburn-task.sh
 done

--- a/ansible/roles/hpctests/vars/main.yml
+++ b/ansible/roles/hpctests/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 hpctests_hpl_srcdir: "{{ hpctests_rootdir }}/hpl/hpl-{{ hpctests_hpl_version }}"
+hpctests_gpuburn_install_dir: "{{ hpctests_rootdir }}/gpuburn/install/{{ hpctests_hpl_arch }}-{{ hpctests_cuda_compute_level }}"


### PR DESCRIPTION
- gpuburn is compiled once, then run in one task per GPU, one job per node.
- gpuburn can target muliple GPUs at once, but it doesn't work for a mix of full GPUs and MIGs. Running one gpuburn per GPU/MIG works around this limitation.

Please note that gpuburn can provoke hardware errors due to overconsumption/overheating in some hardware configurations.