### PR TITLE
Run NVIDIA HPL as part of hpctests

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -254,7 +254,7 @@ jobs:
         run: |
           . venv/bin/activate
           . environments/.stackhpc/activate
-          ansible-playbook -vv ansible/adhoc/hpctests.yml
+          ansible-playbook -vv ansible/adhoc/hpctests.yml --skip-tags hpctests-gpu
 
       - name: Run EESSI tests
         run: |

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -9,6 +9,7 @@ Tests (with corresponding tags) are:
 - `pingpong`: Runs Intel MPI Benchmark's IMB-MPI1 pingpong between a pair of (scheduler-selected) nodes. Reports zero-size message latency and maximum bandwidth.
 - `pingmatrix`: Runs a similar pingpong test but between all pairs of nodes. Reports zero-size message latency & maximum bandwidth.
 - `hpl-solo`: Runs the HPL benchmark individually on all nodes. Reports Gflops.
+- `nvidia-hpl`: Runs the [NVIDIA HPL benchmark](https://github.com/wilicc/gpu-burn/) to load-test GPUs. Reports Gflops.
 
 All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 
@@ -39,6 +40,13 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
   be selected to target using this fraction of each node's memory -
   **CAUTION: see note below**.
 - `hpctests_hpl_arch`: Optional, default 'linux64'. Arbitrary architecture name for HPL build. HPL is compiled on the first compute node of those selected (see `hpctests_nodes`), so this can be used to create different builds for different types of compute node.
+- `hpctests_nvidia_hpl_dat_matrix`: Optional. Matches gpu gres specification to a `.dat` file from the NVIDIA HPC Benchmarks image.
+- `hpctests_nvidia_hpl_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
+- `hpctests_nvidia_hpl_image`: Optional, default 'nvcr.io/nvidia/hpc-benchmarks'. docker image of the nvidia HPC Benchmarks
+- `hpctests_nvidia_hpl_minutes`: Optional, default 20. Timeout for Slurm and the async task.
+- `hpctests_nvidia_hpl_sif_file`: Optional, default '{{ hpctests_rootdir }}/nvidia-hpl/nvidia-hpc-benchmarks-{{ hpctests_nvidia_hpl_version }}.sif'. Apptainer image to run: change it if you downloaded the image manually.
+- `hpctests_nvidia_hpl_test_loops`: Optional, default 1. xhpl can be called N times in a loop. An iteration takes ~45s on a H200 GPU.
+- `hpctests_nvidia_hpl_version`: Optional, default '25.02'. Version of the hpc-benchmarks image to use. Pick a version compatible with your nvidia drivers.
 
 ---
 

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -40,9 +40,9 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
   be selected to target using this fraction of each node's memory -
   **CAUTION: see note below**.
 - `hpctests_hpl_arch`: Optional, default 'linux64'. Arbitrary architecture name for HPL build. HPL is compiled on the first compute node of those selected (see `hpctests_nodes`), so this can be used to create different builds for different types of compute node.
-- `hpctests_nvidia_hpl_dat_matrix`: Optional. Matches gpu gres specification to a `.dat` file from the NVIDIA HPC Benchmarks image.
+- `hpctests_nvidia_hpl_dat_matrix`: Optional. Matches GPU gres specification to a `.dat` file from the NVIDIA HPC Benchmarks image.
 - `hpctests_nvidia_hpl_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
-- `hpctests_nvidia_hpl_image`: Optional, default 'nvcr.io/nvidia/hpc-benchmarks'. docker image of the nvidia HPC Benchmarks
+- `hpctests_nvidia_hpl_image`: Optional, default 'nvcr.io/nvidia/hpc-benchmarks'. Docker image of the nvidia HPC Benchmarks
 - `hpctests_nvidia_hpl_minutes`: Optional, default 20. Timeout for Slurm and the async task.
 - `hpctests_nvidia_hpl_sif_file`: Optional, default '{{ hpctests_rootdir }}/nvidia-hpl/nvidia-hpc-benchmarks-{{ hpctests_nvidia_hpl_version }}.sif'. Apptainer image to run: change it if you downloaded the image manually.
 - `hpctests_nvidia_hpl_test_loops`: Optional, default 1. xhpl can be called N times in a loop. An iteration takes ~45s on a H200 GPU.

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -41,9 +41,9 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
   be selected to target using this fraction of each node's memory -
   **CAUTION: see note below**.
 - `hpctests_hpl_arch`: Optional, default 'linux64'. Arbitrary architecture name for HPL build. HPL is compiled on the first compute node of those selected (see `hpctests_nodes`), so this can be used to create different builds for different types of compute node.
-- `hpctests_nvidia_hpl_dat_matrix`: Optional. Matches gpu gres specification to a `.dat` file from the NVIDIA HPC Benchmarks image.
+- `hpctests_nvidia_hpl_dat_matrix`: Optional. Matches GPU gres specification to a `.dat` file from the NVIDIA HPC Benchmarks image.
 - `hpctests_nvidia_hpl_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
-- `hpctests_nvidia_hpl_image`: Optional, default 'nvcr.io/nvidia/hpc-benchmarks'. docker image of the nvidia HPC Benchmarks
+- `hpctests_nvidia_hpl_image`: Optional, default 'nvcr.io/nvidia/hpc-benchmarks'. Docker image of the nvidia HPC Benchmarks
 - `hpctests_nvidia_hpl_minutes`: Optional, default 20. Timeout for Slurm and the async task.
 - `hpctests_nvidia_hpl_sif_file`: Optional, default '{{ hpctests_rootdir }}/nvidia-hpl/nvidia-hpc-benchmarks-{{ hpctests_nvidia_hpl_version }}.sif'. Apptainer image to run: change it if you downloaded the image manually.
 - `hpctests_nvidia_hpl_test_loops`: Optional, default 1. xhpl can be called N times in a loop. An iteration takes ~45s on a H200 GPU.

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -42,7 +42,7 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
   **CAUTION: see note below**.
 - `hpctests_hpl_arch`: Optional, default 'linux64'. Arbitrary architecture name for HPL build. HPL is compiled on the first compute node of those selected (see `hpctests_nodes`), so this can be used to create different builds for different types of compute node.
 - `hpctests_nvidia_hpl_dat_matrix`: Optional. Matches GPU gres specification to a `.dat` file from the NVIDIA HPC Benchmarks image.
-- `hpctests_nvidia_hpl_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
+- `hpctests_gpu_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200:2gpu`
 - `hpctests_nvidia_hpl_image`: Optional, default 'nvcr.io/nvidia/hpc-benchmarks'. Docker image of the nvidia HPC Benchmarks
 - `hpctests_nvidia_hpl_minutes`: Optional, default 20. Timeout for Slurm and the async task.
 - `hpctests_nvidia_hpl_sif_file`: Optional, default '{{ hpctests_rootdir }}/nvidia-hpl/nvidia-hpc-benchmarks-{{ hpctests_nvidia_hpl_version }}.sif'. Apptainer image to run: change it if you downloaded the image manually.

--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -9,6 +9,7 @@ Tests (with corresponding tags) are:
 - `pingpong`: Runs Intel MPI Benchmark's IMB-MPI1 pingpong between a pair of (scheduler-selected) nodes. Reports zero-size message latency and maximum bandwidth.
 - `pingmatrix`: Runs a similar pingpong test but between all pairs of nodes. Reports zero-size message latency & maximum bandwidth.
 - `hpl-solo`: Runs the HPL benchmark individually on all nodes. Reports Gflops.
+- `nvidia-hpl`: Runs the [NVIDIA HPL benchmark](https://github.com/wilicc/gpu-burn/) to load-test GPUs. Reports Gflops.
 
 All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
 
@@ -40,6 +41,13 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
   be selected to target using this fraction of each node's memory -
   **CAUTION: see note below**.
 - `hpctests_hpl_arch`: Optional, default 'linux64'. Arbitrary architecture name for HPL build. HPL is compiled on the first compute node of those selected (see `hpctests_nodes`), so this can be used to create different builds for different types of compute node.
+- `hpctests_nvidia_hpl_dat_matrix`: Optional. Matches gpu gres specification to a `.dat` file from the NVIDIA HPC Benchmarks image.
+- `hpctests_nvidia_hpl_gres`: Optional, all GPUs will be selected if absent. `srun --gres` option: needed on hosts with heterogeneous cards (incl. MIG). eg. `gpu:nvidia_h200=2gpu`
+- `hpctests_nvidia_hpl_image`: Optional, default 'nvcr.io/nvidia/hpc-benchmarks'. docker image of the nvidia HPC Benchmarks
+- `hpctests_nvidia_hpl_minutes`: Optional, default 20. Timeout for Slurm and the async task.
+- `hpctests_nvidia_hpl_sif_file`: Optional, default '{{ hpctests_rootdir }}/nvidia-hpl/nvidia-hpc-benchmarks-{{ hpctests_nvidia_hpl_version }}.sif'. Apptainer image to run: change it if you downloaded the image manually.
+- `hpctests_nvidia_hpl_test_loops`: Optional, default 1. xhpl can be called N times in a loop. An iteration takes ~45s on a H200 GPU.
+- `hpctests_nvidia_hpl_version`: Optional, default '25.02'. Version of the hpc-benchmarks image to use. Pick a version compatible with your nvidia drivers.
 
 ---
 

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -25,3 +25,28 @@ hpctests_hpl_arch: linux64
 # hpctests_partition:
 # hpctests_account:
 # hpctests_qos:
+hpctests_nvidia_hpl_image: nvcr.io/nvidia/hpc-benchmarks
+hpctests_nvidia_hpl_version: 25.02
+hpctests_nvidia_hpl_install_dir: "{{ hpctests_rootdir }}/nvidia-hpl"
+hpctests_nvidia_hpl_sif_file: "{{ hpctests_nvidia_hpl_install_dir }}/nvidia-hpc-benchmarks-{{ hpctests_nvidia_hpl_version }}.sif"
+
+hpctests_nvidia_hpl_dat_matrix:
+  nvidia_h200:
+    1: HPL-H200-1GPU.dat
+    2: HPL-H200-2GPUs.dat
+    4: HPL-H200-4GPUs.dat
+  default:
+    1: HPL-1GPU.dat
+    2: HPL-2GPUs.dat
+    4: HPL-4GPUs.dat
+
+#Apptainer> less /workspace/hpl-linux-x86_64/sample-dat/HPL-
+#HPL-1024GPUs.dat      HPL-4GPUs.dat         HPL-B200-256GPUs.dat  HPL-GH-128GPUs.dat    HPL-GH-512GPUs.dat    HPL-H200-4GPUs.dat    HPL-OOC-4GPUs.dat     HPL-dgx-1N-4.dat
+#HPL-128GPUs.dat       HPL-512GPUs.dat       HPL-B200-2GPUs.dat    HPL-GH-16GPUs.dat     HPL-GH-64GPUs.dat     HPL-H200-8GPUs.dat    HPL-OOC-64GPUs.dat    HPL-dgx-1N.dat
+#HPL-16GPUs.dat        HPL-64GPUs.dat        HPL-B200-32GPUs.dat   HPL-GH-1GPU.dat       HPL-GH-8GPUs.dat      HPL-OOC-128GPUs.dat   HPL-OOC-8GPUs.dat     HPL-dgx-2N.dat
+#HPL-1GPU.dat          HPL-8GPUs.dat         HPL-B200-4GPUs.dat    HPL-GH-256GPUs.dat    HPL-H200-16GPUs.dat   HPL-OOC-16GPUs.dat    HPL-dgx-128N.dat      HPL-dgx-32N.dat
+#HPL-256GPUs.dat       HPL-B200-128GPUs.dat  HPL-B200-512GPUs.dat  HPL-GH-2GPUs.dat      HPL-H200-1GPU.dat     HPL-OOC-1GPU.dat      HPL-dgx-16N.dat       HPL-dgx-4N.dat
+#HPL-2GPUs.dat         HPL-B200-16GPUs.dat   HPL-B200-64GPUs.dat   HPL-GH-32GPUs.dat     HPL-H200-2GPUs.dat    HPL-OOC-2GPUs.dat     HPL-dgx-1N-1.dat      HPL-dgx-64N.dat
+#HPL-32GPUs.dat        HPL-B200-1GPU.dat     HPL-B200-8GPUs.dat    HPL-GH-4GPUs.dat      HPL-H200-32GPUs.dat   HPL-OOC-32GPUs.dat    HPL-dgx-1N-2.dat      HPL-dgx-8N.dat
+
+hpctests_nvidia_hpl_test_loops: 1

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -25,11 +25,13 @@ hpctests_hpl_arch: linux64
 # hpctests_partition:
 # hpctests_account:
 # hpctests_qos:
+# hpctests_nvidia_hpl_gres:
 hpctests_nvidia_hpl_image: nvcr.io/nvidia/hpc-benchmarks
-hpctests_nvidia_hpl_version: 25.02
 hpctests_nvidia_hpl_install_dir: "{{ hpctests_rootdir }}/nvidia-hpl"
+hpctests_nvidia_hpl_minutes: 20
 hpctests_nvidia_hpl_sif_file: "{{ hpctests_nvidia_hpl_install_dir }}/nvidia-hpc-benchmarks-{{ hpctests_nvidia_hpl_version }}.sif"
-
+hpctests_nvidia_hpl_test_loops: 1
+hpctests_nvidia_hpl_version: 25.02
 hpctests_nvidia_hpl_dat_matrix:
   nvidia_h200:
     1: HPL-H200-1GPU.dat
@@ -40,13 +42,11 @@ hpctests_nvidia_hpl_dat_matrix:
     2: HPL-2GPUs.dat
     4: HPL-4GPUs.dat
 
-#Apptainer> less /workspace/hpl-linux-x86_64/sample-dat/HPL-
-#HPL-1024GPUs.dat      HPL-4GPUs.dat         HPL-B200-256GPUs.dat  HPL-GH-128GPUs.dat    HPL-GH-512GPUs.dat    HPL-H200-4GPUs.dat    HPL-OOC-4GPUs.dat     HPL-dgx-1N-4.dat
-#HPL-128GPUs.dat       HPL-512GPUs.dat       HPL-B200-2GPUs.dat    HPL-GH-16GPUs.dat     HPL-GH-64GPUs.dat     HPL-H200-8GPUs.dat    HPL-OOC-64GPUs.dat    HPL-dgx-1N.dat
-#HPL-16GPUs.dat        HPL-64GPUs.dat        HPL-B200-32GPUs.dat   HPL-GH-1GPU.dat       HPL-GH-8GPUs.dat      HPL-OOC-128GPUs.dat   HPL-OOC-8GPUs.dat     HPL-dgx-2N.dat
-#HPL-1GPU.dat          HPL-8GPUs.dat         HPL-B200-4GPUs.dat    HPL-GH-256GPUs.dat    HPL-H200-16GPUs.dat   HPL-OOC-16GPUs.dat    HPL-dgx-128N.dat      HPL-dgx-32N.dat
-#HPL-256GPUs.dat       HPL-B200-128GPUs.dat  HPL-B200-512GPUs.dat  HPL-GH-2GPUs.dat      HPL-H200-1GPU.dat     HPL-OOC-1GPU.dat      HPL-dgx-16N.dat       HPL-dgx-4N.dat
-#HPL-2GPUs.dat         HPL-B200-16GPUs.dat   HPL-B200-64GPUs.dat   HPL-GH-32GPUs.dat     HPL-H200-2GPUs.dat    HPL-OOC-2GPUs.dat     HPL-dgx-1N-1.dat      HPL-dgx-64N.dat
-#HPL-32GPUs.dat        HPL-B200-1GPU.dat     HPL-B200-8GPUs.dat    HPL-GH-4GPUs.dat      HPL-H200-32GPUs.dat   HPL-OOC-32GPUs.dat    HPL-dgx-1N-2.dat      HPL-dgx-8N.dat
-
-hpctests_nvidia_hpl_test_loops: 1
+# Apptainer> less /workspace/hpl-linux-x86_64/sample-dat/HPL-
+# HPL-1024GPUs.dat      HPL-4GPUs.dat         HPL-B200-256GPUs.dat  HPL-GH-128GPUs.dat    HPL-GH-512GPUs.dat    HPL-H200-4GPUs.dat    HPL-OOC-4GPUs.dat     HPL-dgx-1N-4.dat
+# HPL-128GPUs.dat       HPL-512GPUs.dat       HPL-B200-2GPUs.dat    HPL-GH-16GPUs.dat     HPL-GH-64GPUs.dat     HPL-H200-8GPUs.dat    HPL-OOC-64GPUs.dat    HPL-dgx-1N.dat
+# HPL-16GPUs.dat        HPL-64GPUs.dat        HPL-B200-32GPUs.dat   HPL-GH-1GPU.dat       HPL-GH-8GPUs.dat      HPL-OOC-128GPUs.dat   HPL-OOC-8GPUs.dat     HPL-dgx-2N.dat
+# HPL-1GPU.dat          HPL-8GPUs.dat         HPL-B200-4GPUs.dat    HPL-GH-256GPUs.dat    HPL-H200-16GPUs.dat   HPL-OOC-16GPUs.dat    HPL-dgx-128N.dat      HPL-dgx-32N.dat
+# HPL-256GPUs.dat       HPL-B200-128GPUs.dat  HPL-B200-512GPUs.dat  HPL-GH-2GPUs.dat      HPL-H200-1GPU.dat     HPL-OOC-1GPU.dat      HPL-dgx-16N.dat       HPL-dgx-4N.dat
+# HPL-2GPUs.dat         HPL-B200-16GPUs.dat   HPL-B200-64GPUs.dat   HPL-GH-32GPUs.dat     HPL-H200-2GPUs.dat    HPL-OOC-2GPUs.dat     HPL-dgx-1N-1.dat      HPL-dgx-64N.dat
+# HPL-32GPUs.dat        HPL-B200-1GPU.dat     HPL-B200-8GPUs.dat    HPL-GH-4GPUs.dat      HPL-H200-32GPUs.dat   HPL-OOC-32GPUs.dat    HPL-dgx-1N-2.dat      HPL-dgx-8N.dat

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -26,11 +26,13 @@ hpctests_hpl_arch: linux64
 # hpctests_reservation:
 # hpctests_account:
 # hpctests_qos:
+# hpctests_nvidia_hpl_gres:
 hpctests_nvidia_hpl_image: nvcr.io/nvidia/hpc-benchmarks
-hpctests_nvidia_hpl_version: 25.02
 hpctests_nvidia_hpl_install_dir: "{{ hpctests_rootdir }}/nvidia-hpl"
+hpctests_nvidia_hpl_minutes: 20
 hpctests_nvidia_hpl_sif_file: "{{ hpctests_nvidia_hpl_install_dir }}/nvidia-hpc-benchmarks-{{ hpctests_nvidia_hpl_version }}.sif"
-
+hpctests_nvidia_hpl_test_loops: 1
+hpctests_nvidia_hpl_version: 25.02
 hpctests_nvidia_hpl_dat_matrix:
   nvidia_h200:
     1: HPL-H200-1GPU.dat
@@ -41,13 +43,11 @@ hpctests_nvidia_hpl_dat_matrix:
     2: HPL-2GPUs.dat
     4: HPL-4GPUs.dat
 
-#Apptainer> less /workspace/hpl-linux-x86_64/sample-dat/HPL-
-#HPL-1024GPUs.dat      HPL-4GPUs.dat         HPL-B200-256GPUs.dat  HPL-GH-128GPUs.dat    HPL-GH-512GPUs.dat    HPL-H200-4GPUs.dat    HPL-OOC-4GPUs.dat     HPL-dgx-1N-4.dat
-#HPL-128GPUs.dat       HPL-512GPUs.dat       HPL-B200-2GPUs.dat    HPL-GH-16GPUs.dat     HPL-GH-64GPUs.dat     HPL-H200-8GPUs.dat    HPL-OOC-64GPUs.dat    HPL-dgx-1N.dat
-#HPL-16GPUs.dat        HPL-64GPUs.dat        HPL-B200-32GPUs.dat   HPL-GH-1GPU.dat       HPL-GH-8GPUs.dat      HPL-OOC-128GPUs.dat   HPL-OOC-8GPUs.dat     HPL-dgx-2N.dat
-#HPL-1GPU.dat          HPL-8GPUs.dat         HPL-B200-4GPUs.dat    HPL-GH-256GPUs.dat    HPL-H200-16GPUs.dat   HPL-OOC-16GPUs.dat    HPL-dgx-128N.dat      HPL-dgx-32N.dat
-#HPL-256GPUs.dat       HPL-B200-128GPUs.dat  HPL-B200-512GPUs.dat  HPL-GH-2GPUs.dat      HPL-H200-1GPU.dat     HPL-OOC-1GPU.dat      HPL-dgx-16N.dat       HPL-dgx-4N.dat
-#HPL-2GPUs.dat         HPL-B200-16GPUs.dat   HPL-B200-64GPUs.dat   HPL-GH-32GPUs.dat     HPL-H200-2GPUs.dat    HPL-OOC-2GPUs.dat     HPL-dgx-1N-1.dat      HPL-dgx-64N.dat
-#HPL-32GPUs.dat        HPL-B200-1GPU.dat     HPL-B200-8GPUs.dat    HPL-GH-4GPUs.dat      HPL-H200-32GPUs.dat   HPL-OOC-32GPUs.dat    HPL-dgx-1N-2.dat      HPL-dgx-8N.dat
-
-hpctests_nvidia_hpl_test_loops: 1
+# Apptainer> less /workspace/hpl-linux-x86_64/sample-dat/HPL-
+# HPL-1024GPUs.dat      HPL-4GPUs.dat         HPL-B200-256GPUs.dat  HPL-GH-128GPUs.dat    HPL-GH-512GPUs.dat    HPL-H200-4GPUs.dat    HPL-OOC-4GPUs.dat     HPL-dgx-1N-4.dat
+# HPL-128GPUs.dat       HPL-512GPUs.dat       HPL-B200-2GPUs.dat    HPL-GH-16GPUs.dat     HPL-GH-64GPUs.dat     HPL-H200-8GPUs.dat    HPL-OOC-64GPUs.dat    HPL-dgx-1N.dat
+# HPL-16GPUs.dat        HPL-64GPUs.dat        HPL-B200-32GPUs.dat   HPL-GH-1GPU.dat       HPL-GH-8GPUs.dat      HPL-OOC-128GPUs.dat   HPL-OOC-8GPUs.dat     HPL-dgx-2N.dat
+# HPL-1GPU.dat          HPL-8GPUs.dat         HPL-B200-4GPUs.dat    HPL-GH-256GPUs.dat    HPL-H200-16GPUs.dat   HPL-OOC-16GPUs.dat    HPL-dgx-128N.dat      HPL-dgx-32N.dat
+# HPL-256GPUs.dat       HPL-B200-128GPUs.dat  HPL-B200-512GPUs.dat  HPL-GH-2GPUs.dat      HPL-H200-1GPU.dat     HPL-OOC-1GPU.dat      HPL-dgx-16N.dat       HPL-dgx-4N.dat
+# HPL-2GPUs.dat         HPL-B200-16GPUs.dat   HPL-B200-64GPUs.dat   HPL-GH-32GPUs.dat     HPL-H200-2GPUs.dat    HPL-OOC-2GPUs.dat     HPL-dgx-1N-1.dat      HPL-dgx-64N.dat
+# HPL-32GPUs.dat        HPL-B200-1GPU.dat     HPL-B200-8GPUs.dat    HPL-GH-4GPUs.dat      HPL-H200-32GPUs.dat   HPL-OOC-32GPUs.dat    HPL-dgx-1N-2.dat      HPL-dgx-8N.dat

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -26,7 +26,7 @@ hpctests_hpl_arch: linux64
 # hpctests_reservation:
 # hpctests_account:
 # hpctests_qos:
-# hpctests_nvidia_hpl_gres:
+# hpctests_gpu_gres:
 hpctests_nvidia_hpl_image: nvcr.io/nvidia/hpc-benchmarks
 hpctests_nvidia_hpl_install_dir: "{{ hpctests_rootdir }}/nvidia-hpl"
 hpctests_nvidia_hpl_minutes: 20

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -26,3 +26,28 @@ hpctests_hpl_arch: linux64
 # hpctests_reservation:
 # hpctests_account:
 # hpctests_qos:
+hpctests_nvidia_hpl_image: nvcr.io/nvidia/hpc-benchmarks
+hpctests_nvidia_hpl_version: 25.02
+hpctests_nvidia_hpl_install_dir: "{{ hpctests_rootdir }}/nvidia-hpl"
+hpctests_nvidia_hpl_sif_file: "{{ hpctests_nvidia_hpl_install_dir }}/nvidia-hpc-benchmarks-{{ hpctests_nvidia_hpl_version }}.sif"
+
+hpctests_nvidia_hpl_dat_matrix:
+  nvidia_h200:
+    1: HPL-H200-1GPU.dat
+    2: HPL-H200-2GPUs.dat
+    4: HPL-H200-4GPUs.dat
+  default:
+    1: HPL-1GPU.dat
+    2: HPL-2GPUs.dat
+    4: HPL-4GPUs.dat
+
+#Apptainer> less /workspace/hpl-linux-x86_64/sample-dat/HPL-
+#HPL-1024GPUs.dat      HPL-4GPUs.dat         HPL-B200-256GPUs.dat  HPL-GH-128GPUs.dat    HPL-GH-512GPUs.dat    HPL-H200-4GPUs.dat    HPL-OOC-4GPUs.dat     HPL-dgx-1N-4.dat
+#HPL-128GPUs.dat       HPL-512GPUs.dat       HPL-B200-2GPUs.dat    HPL-GH-16GPUs.dat     HPL-GH-64GPUs.dat     HPL-H200-8GPUs.dat    HPL-OOC-64GPUs.dat    HPL-dgx-1N.dat
+#HPL-16GPUs.dat        HPL-64GPUs.dat        HPL-B200-32GPUs.dat   HPL-GH-1GPU.dat       HPL-GH-8GPUs.dat      HPL-OOC-128GPUs.dat   HPL-OOC-8GPUs.dat     HPL-dgx-2N.dat
+#HPL-1GPU.dat          HPL-8GPUs.dat         HPL-B200-4GPUs.dat    HPL-GH-256GPUs.dat    HPL-H200-16GPUs.dat   HPL-OOC-16GPUs.dat    HPL-dgx-128N.dat      HPL-dgx-32N.dat
+#HPL-256GPUs.dat       HPL-B200-128GPUs.dat  HPL-B200-512GPUs.dat  HPL-GH-2GPUs.dat      HPL-H200-1GPU.dat     HPL-OOC-1GPU.dat      HPL-dgx-16N.dat       HPL-dgx-4N.dat
+#HPL-2GPUs.dat         HPL-B200-16GPUs.dat   HPL-B200-64GPUs.dat   HPL-GH-32GPUs.dat     HPL-H200-2GPUs.dat    HPL-OOC-2GPUs.dat     HPL-dgx-1N-1.dat      HPL-dgx-64N.dat
+#HPL-32GPUs.dat        HPL-B200-1GPU.dat     HPL-B200-8GPUs.dat    HPL-GH-4GPUs.dat      HPL-H200-32GPUs.dat   HPL-OOC-32GPUs.dat    HPL-dgx-1N-2.dat      HPL-dgx-8N.dat
+
+hpctests_nvidia_hpl_test_loops: 1

--- a/ansible/roles/hpctests/library/scontrol_node_info.py
+++ b/ansible/roles/hpctests/library/scontrol_node_info.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# pylint: disable=missing-module-docstring
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, StackHPC
+# Apache 2 License
+import json
+import re
+
+from ansible.module_utils.basic import AnsibleModule  # pylint: disable=import-error
+
+ANSIBLE_METADATA = {
+    "metadata_version": "0.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: scontrol_node_info
+short_description: Get information about Slurm nodes via scontrol
+version_added: "0.0"
+description: >
+    Gets all the available information from Slurm's `scontrol show nodes` command about specified nodes.
+    The returned `info` property is a dict with keys from scontrol --
+    All parameters and values a list of strings in specified node order.
+options
+    nodes:
+        description:
+            - Slurm nodenames for which information is required.
+        required: true
+        type: list
+requirements:
+    - "python >= 3.6"
+author:
+    - Steve Brasier, StackHPC
+"""
+
+EXAMPLES = """
+TODO
+"""
+
+
+def run_module():  # pylint: disable=missing-function-docstring
+    module_args = {
+        "nodes": {
+            "type": "list",
+            "required": True,
+        }
+    }
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+    result = {"changed": False}
+    if module.check_mode:
+        module.exit_json(**result)
+
+    _, stdout, _ = module.run_command(
+        ["scontrol", "show", "nodes", "--json", ",".join(module.params["nodes"])],
+        check_rc=True,
+    )  # `--nodes` doesn't filter enough, other partitions are still shown
+    info = json.loads(stdout)
+    for node_info in info.get("nodes", []):
+        node_info["gpus"] = {}
+        if "gres" in node_info:
+            gres = node_info["gres"]
+            for g in gres.split(","):
+                if m := re.match(r"""^gpu:(.+):([0-9]+)\(S:[0-9]+\)$""", g):
+                    resource, cnt = m.group(1), m.group(2)
+                    node_info["gpus"][resource] = int(cnt)
+    result["info"] = info.get("nodes", [])
+    module.exit_json(**result)
+
+
+def main():  # pylint: disable=missing-function-docstring
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/hpctests/tasks/fetch-nvidia-hpl.yml
+++ b/ansible/roles/hpctests/tasks/fetch-nvidia-hpl.yml
@@ -1,0 +1,18 @@
+---
+- name: Make root directory
+  ansible.builtin.file:
+    path: "{{ hpctests_rootdir }}/nvidia-hpl"
+    state: directory
+    mode: "0755"
+
+- name: Create fetch hpl script
+  ansible.builtin.template:
+    src: "nvidia-hpl-fetch.sh.j2"
+    dest: "{{ hpctests_rootdir }}/nvidia-hpl/nvidia-hpl-fetch.sh"
+    mode: "0755"
+
+- name: Fetch nvidia-hpl docker image
+  ansible.builtin.command:
+    cmd: sbatch --wait ./nvidia-hpl-fetch.sh
+    chdir: "{{ hpctests_rootdir }}/nvidia-hpl"
+    creates: "{{ hpctests_nvidia_hpl_sif_file }}"

--- a/ansible/roles/hpctests/tasks/main.yml
+++ b/ansible/roles/hpctests/tasks/main.yml
@@ -43,6 +43,7 @@
   become_user: "{{ hpctests_user }}"
   tags:
     - nvidia-hpl
+    - hpctests-gpu
   block:
     - ansible.builtin.include_tasks: fetch-nvidia-hpl.yml
 
@@ -50,6 +51,7 @@
   become: true
   tags:
     - nvidia-hpl
+    - hpctests-gpu
   block:
     - ansible.builtin.include_tasks: prepare-nvidia-hpl.yml
 
@@ -58,5 +60,6 @@
   become_user: "{{ hpctests_user }}"
   tags:
     - nvidia-hpl
+    - hpctests-gpu
   block:
     - ansible.builtin.include_tasks: run-nvidia-hpl.yml

--- a/ansible/roles/hpctests/tasks/main.yml
+++ b/ansible/roles/hpctests/tasks/main.yml
@@ -37,3 +37,26 @@
     - hpl-solo
   block:
     - ansible.builtin.include_tasks: hpl-solo.yml
+
+- name: Fetch nvidia-hpl
+  become: true
+  become_user: "{{ hpctests_user }}"
+  tags:
+    - nvidia-hpl
+  block:
+    - ansible.builtin.include_tasks: fetch-nvidia-hpl.yml
+
+- name: Prepare nvidia-hpl
+  become: true
+  tags:
+    - nvidia-hpl
+  block:
+    - ansible.builtin.include_tasks: prepare-nvidia-hpl.yml
+
+- name: Run nvidia-hpl on individual nodes
+  become: true
+  become_user: "{{ hpctests_user }}"
+  tags:
+    - nvidia-hpl
+  block:
+    - ansible.builtin.include_tasks: run-nvidia-hpl.yml

--- a/ansible/roles/hpctests/tasks/prepare-nvidia-hpl.yml
+++ b/ansible/roles/hpctests/tasks/prepare-nvidia-hpl.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Run nvidia-smi
+  # WORKAROUND: cudaGetDeviceCount(&device_count) = 999 (unknown error) on some hosts after reboot
+  ansible.builtin.command: nvidia-smi
+  become: true
+  changed_when: false
+  delegate_to: "{{ item }}"
+  loop: "{{ hpctests_computes.stdout_lines }}"
+
+- name: Ensure nvidia_peermem is loaded
+  # FIXME: Move into site hook
+  ansible.builtin.modprobe:
+    name: nvidia_peermem
+    persistent: present
+    state: present
+  become: true
+  delegate_to: "{{ item }}"
+  loop: "{{ hpctests_computes.stdout_lines }}"

--- a/ansible/roles/hpctests/tasks/prepare-nvidia-hpl.yml
+++ b/ansible/roles/hpctests/tasks/prepare-nvidia-hpl.yml
@@ -10,7 +10,7 @@
 
 - name: Ensure nvidia_peermem is loaded
   # FIXME: Move into site hook
-  ansible.builtin.modprobe:
+  community.general.modprobe:
     name: nvidia_peermem
     persistent: present
     state: present

--- a/ansible/roles/hpctests/tasks/run-nvidia-hpl.yml
+++ b/ansible/roles/hpctests/tasks/run-nvidia-hpl.yml
@@ -1,0 +1,225 @@
+---
+# Runs one task per gpu using mpirun because task isolation via slurm cgroup ConstrainDevices=yes breaks NVIDIA HPL:
+# xhpl crashes with following stacktrace:
+# [HPL TRACE] cuda_nvshmem_init: max=0.3384 (0) min=0.3384 (1)
+# [WARNING] Change Input N 136608 to 136192
+# detected in tcache 2
+#  *** Process received signal ***
+#  Signal: Aborted (6)
+#  Signal code:  (-6)
+#  [ 0] /lib/x86_64-linux-gnu/libc.so.6(+0x45320)[0x7f78c4633320]
+#  [ 1] /lib/x86_64-linux-gnu/libc.so.6(pthread_kill+0x11c)[0x7f78c468cb1c]
+#  [ 2] /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x1e)[0x7f78c463326e]
+#  [ 3] /lib/x86_64-linux-gnu/libc.so.6(abort+0xdf)[0x7f78c46168ff]
+#  [ 4] /lib/x86_64-linux-gnu/libc.so.6(+0x297b6)[0x7f78c46177b6]
+#  [ 5] /lib/x86_64-linux-gnu/libc.so.6(+0xa8fe5)[0x7f78c4696fe5]
+#  [ 6] /lib/x86_64-linux-gnu/libc.so.6(+0xab54f)[0x7f78c469954f]
+#  [ 7] /lib/x86_64-linux-gnu/libc.so.6(__libc_free+0x7e)[0x7f78c469bd9e]
+#  [ 8] /lib/x86_64-linux-gnu/libnccl.so.2(+0x6437e)[0x7f78caa6337e]
+#  [ 9] /lib/x86_64-linux-gnu/libnccl.so.2(pncclCommInitRank+0x153)[0x7f78caa65513]
+#  [10] /workspace/hpl-linux-x86_64/xhpl[0x46a00a]
+#  [11] /workspace/hpl-linux-x86_64/xhpl[0x488d07]
+#  [12] /workspace/hpl-linux-x86_64/xhpl[0x45bfdc]
+#  [13] /lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7f78c46181ca]
+#  [14] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7f78c461828b]
+#  [15] /workspace/hpl-linux-x86_64/xhpl[0x45c92e]
+#  *** End of error message ***
+#
+# Also note that on clusters with ConstrainDevices=no, a direct srun with one task per GPU works,
+# but it must be run with --cpu-bind=none or the cards end up in error.
+
+- name: Assert sif image is present
+  block:
+    - ansible.builtin.stat:
+        path: "{{ hpctests_nvidia_hpl_sif_file }}"
+        get_checksum: false
+      register: sif_stat
+    - ansible.builtin.assert:
+        that:
+          - sif_stat.stat.exists
+        fail_msg: "Run fetch-nvidia-hpl.yml to produce {{ hpctests_nvidia_hpl_sif_file }}"
+
+- name: Get all nodes in partition
+  ansible.builtin.command: "sinfo --Node --noheader --format %N --partition={{ hpctests_partition }}"
+  register: all_nodes
+  changed_when: false
+
+- name: Calculate excluded nodes
+  ansible.builtin.set_fact:
+    hpctests_excluded_nodes: "{{ all_nodes.stdout_lines | difference(hpctests_computes.stdout_lines) }}"
+
+- name: Get Slurm node info
+  scontrol_node_info:
+    nodes: "{{ hpctests_computes.stdout_lines }}"
+  register: hpctests_nodeinfo
+
+- debug:
+   msg: "{{ hpctests_nodeinfo.info[0] }}"
+
+- name: Select GPUs
+  ansible.builtin.set_fact:
+    hpctests_nvidia_hpl_gres: >-
+      {%- if gpus | length == 1 -%}
+        {# homogeneous node #}
+        {%- set gpu = gpus | dict2items | first -%}
+            gpu:{{ gpu.key }}:{{ gpu.value }}
+      {%- else -%}
+        {{ notdefined | mandatory(msg="Unsupported: nodes with heterogeneous (MIG?) GPUs, please specify wanted hpctests_nvidia_hpl_gres") }}
+      {%- endif -%}
+  vars:
+    gpus: hpctests_nodeinfo.info[0].gpus | default({})
+  when: hpctests_nvidia_hpl_gres is not defined
+
+- debug:
+    var: hpctests_nvidia_hpl_gres
+
+- name: Check hpctests_nvidia_hpl_gres
+  ansible.builtin.assert:
+    that: hpctests_nvidia_hpl_gres is search('^gpu:.*=[0-9]+$')
+
+- name: Select HPL.dat
+  ansible.builtin.set_fact:
+    hpctests_nvidia_hpl_dat: >-
+      {{ hpctests_nvidia_hpl_dat | default(hpctests_nvidia_hpl_dat_matrix.get(selected_gpu, hpctests_nvidia_hpl_dat_matrix.default).get(selected_gpu_count | int ) | mandatory(msg="Unsupported GPU count")) }}
+    hpctests_ntasks: "{{ selected_gpu_count }}"
+  vars:
+    selected_gpu: "{{ ((hpctests_nvidia_hpl_gres | split(':'))[1] | split('='))[0] }}"
+    selected_gpu_count: "{{ (hpctests_nvidia_hpl_gres | split('='))[1] | int }}"
+
+- debug:
+   var: hpctests_nvidia_hpl_dat
+
+# Templating a script to be run on each node by srun.
+# Contrary to sbatch, all slurm parameters must be given on the command-line.
+- name: Create srun script
+  ansible.builtin.copy:
+    dest: "{{ hpctests_rootdir }}/nvidia-hpl/nvidia-hpl.sh"
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      #https://github.com/openucx/ucx/issues/4224
+      export UCX_POSIX_USE_PROC_LINK=n
+      # https://github.com/open-mpi/ompi/issues/7516
+      export PMIX_MCA_gds=^ds12
+      # https://docs.nvidia.com/nvidia-hpc-benchmarks/HPL_benchmark.html#nvidia-hpl-benchmark-environment-variables
+      # Possible Values: 0 (NVSHMEM), 1 (host MPI)
+      export HPL_FCT_COMM_POLICY=0
+      # Disable self testing
+      export HPL_CUSOLVER_MP_TESTS=0
+      {% if hpctests_nvidia_hpl_version == 26.02 %}
+      # Avoid the error message: host version is not compatible with container version of the library
+      export HPL_USE_NVSHMEM=0
+      {% endif %}
+      # xhpl will be run TEST_LOOPS times. One time takes ~1 minute
+      export TEST_LOOPS={{ hpctests_nvidia_hpl_test_loops }}
+
+      echo "Job Id: $SLURM_JOB_ID"
+      echo "Hostname: $(hostname -s)"
+      echo "Tasks per host: {{ hpctests_ntasks }}"
+      nvidia-smi -L
+
+      # to get mpirun command
+      module load {{ hpctests_hpl_modules | join(' ' ) }}
+
+      # cleanup SLURM environment, preventing mpirun to spawn N tasks. Message is:
+      #   There are not enough slots available in the system to satisfy the 2
+      #   slots that were requested by the application
+      eval $(env|grep SLURM | sed 's/=.*//' | xargs echo unset)
+      mpirun -n {{ hpctests_ntasks }} apptainer run --nv "{{ hpctests_nvidia_hpl_sif_file }}" \
+      		bash -c '/workspace/hpl.sh --dat /workspace/hpl-linux-x86_64/sample-dat/{{ hpctests_nvidia_hpl_dat }}'
+
+- name: Delete old results
+  file:
+    path: "{{ hpctests_rootdir }}/nvidia-hpl/results"
+    state: absent
+  run_once: true
+
+- name: Create results directory
+  file:
+    path: "{{ hpctests_rootdir }}/nvidia-hpl/results"
+    state: directory
+  run_once: true
+
+# We could have used another sbatch script, calling `srun nvidia-hpl.sh` after
+# setting the environment but I preferred using a single templated file + direct srun.
+- name: Run nvidia-hpl # noqa: no-changed-when
+  ansible.builtin.shell: |
+    source /etc/profile.d/lmod.sh
+    srun \
+      --tasks-per-node=1 \
+      --cpu-bind=none \
+      --time={{ timeout_h }}:{{ timeout_m }}:30 \
+      --gres={{ hpctests_nvidia_hpl_gres }} \
+      --mem={{ (0.8 * (hpctests_nodeinfo.info[0].free_mem.number | int)) | round(method='floor') | int }} \
+      --cpus-per-gpu={{ hpctests_nodeinfo.info[0].effective_cpus // (hpctests_ntasks | int) }} \
+      --nodes={{ hpctests_nodeinfo.info | length }} \
+      --output=results/%x.%N.out \
+      --partition={{ hpctests_partition }} \
+      {% if hpctests_excluded_nodes | length > 0 %}--exclude={{ hpctests_excluded_nodes | join(',') }} {% endif %} \
+      {%if hpctests_account is defined %}--account={{ hpctests_account }}{% endif %} \
+      {%if hpctests_qos is defined %}--qos={{ hpctests_qos }}{% endif %} \
+      nvidia-hpl.sh
+  args:
+    chdir: "{{ hpctests_rootdir }}/nvidia-hpl"
+  register: hpctests_nvidia_hpl_srun
+  async: "{{ (hpctests_nvidia_hpl_minutes + 1) * 60 }}" # give async an extra minute after slurm
+  poll: 5 # check every 5 seconds
+  vars:
+    timeout_h: "{{ ((hpctests_nvidia_hpl_minutes | int) // 60) }}"
+    timeout_m: "{{ ((hpctests_nvidia_hpl_minutes | int) % 60) }}"
+
+- name: Display results
+  tags: postpro
+  block:
+  - ansible.builtin.shell: |
+      set -o pipefail
+       for res in results/nvidia-hpl.*.out; do
+         echo "=== $res ==="
+         grep -E '^((GPU [0-9]*)|(Job Id)|(Tasks per host)|(Hostname)):' "$res"
+         echo
+         awk '/Time          Gflops/ { ok=1;} (ok) { print}' "$res"
+         echo
+       done
+    register: cat_res
+    args:
+      chdir: "{{ hpctests_rootdir }}/nvidia-hpl"
+    changed_when: false
+  - ansible.builtin.debug:
+      msg: "{{ cat_res.stdout }}"
+
+- name: Extract Job Id
+  tags: postpro
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep '^Job Id: ' results/nvidia-hpl.*.out | head -n 1 | awk '{ print $3}'
+  args:
+    chdir: "{{ hpctests_rootdir }}/nvidia-hpl"
+  changed_when: false
+  register: srun_job_id
+
+- name: Extract performance
+  tags: postpro
+  ansible.builtin.shell: |
+    set -o pipefail
+    for res in $(ls -1 results/nvidia-hpl.*.out | sort); do
+      # T/V                N    NB     P     Q         Time          Gflops (   per GPU)
+      awk '/^WC0 / {print $7}' "$res"
+    done
+  args:
+    chdir: "{{ hpctests_rootdir }}/nvidia-hpl"
+  changed_when: false
+  register: perf
+
+- name: Summarise results
+  tags: postpro
+  ansible.builtin.debug:
+    # yamllint disable rule:line-length
+    msg: |
+      {%- set floats = perf.stdout_lines | map('float') -%}
+      Summary for nvidia-hpl on {{ hpctests_computes.stdout_lines | length }} nodes in '{{ hpctests_partition }}' partition, job ID {{ srun_job_id.stdout.split()[-1] }}, GPUs '{{ hpctests_nvidia_hpl_gres }}':
+        Max:  {{ floats | max }} Gflops ({{ ((floats | max) / hpctests_ntasks | int) | round(1)  }} Gflops per GPU)
+        Min:  {{ floats | min }} Gflops ({{ ((floats | min) / hpctests_ntasks | int) | round(1) }} Gflops per GPU)
+        Mean: {{ ((floats | sum) / (hpctests_computes.stdout_lines | length)) | round(1) }} Gflops ({{ ((floats | sum) / (hpctests_computes.stdout_lines | length) / hpctests_ntasks | int) | round(1) }} Gflops per GPU)
+
+      Individual node results (Gflops):
+      {{ dict(hpctests_computes.stdout_lines | sort | zip(perf.stdout_lines | map('float'))) | to_nice_yaml }}

--- a/ansible/roles/hpctests/tasks/run-nvidia-hpl.yml
+++ b/ansible/roles/hpctests/tasks/run-nvidia-hpl.yml
@@ -53,9 +53,6 @@
     nodes: "{{ hpctests_computes.stdout_lines }}"
   register: hpctests_nodeinfo
 
-- debug:
-   msg: "{{ hpctests_nodeinfo.info[0] }}"
-
 - name: Select GPUs
   ansible.builtin.set_fact:
     hpctests_nvidia_hpl_gres: >-
@@ -70,8 +67,8 @@
     gpus: hpctests_nodeinfo.info[0].gpus | default({})
   when: hpctests_nvidia_hpl_gres is not defined
 
-- debug:
-    var: hpctests_nvidia_hpl_gres
+- ansible.builtin.debug:
+    msg: "Will run --gres={{ hpctests_nvidia_hpl_gres }}"
 
 - name: Check hpctests_nvidia_hpl_gres
   ansible.builtin.assert:
@@ -86,8 +83,8 @@
     selected_gpu: "{{ ((hpctests_nvidia_hpl_gres | split(':'))[1] | split('='))[0] }}"
     selected_gpu_count: "{{ (hpctests_nvidia_hpl_gres | split('='))[1] | int }}"
 
-- debug:
-   var: hpctests_nvidia_hpl_dat
+- ansible.builtin.debug:
+    var: hpctests_nvidia_hpl_dat
 
 # Templating a script to be run on each node by srun.
 # Contrary to sbatch, all slurm parameters must be given on the command-line.
@@ -129,15 +126,17 @@
       		bash -c '/workspace/hpl.sh --dat /workspace/hpl-linux-x86_64/sample-dat/{{ hpctests_nvidia_hpl_dat }}'
 
 - name: Delete old results
-  file:
+  ansible.builtin.file:
     path: "{{ hpctests_rootdir }}/nvidia-hpl/results"
     state: absent
   run_once: true
 
 - name: Create results directory
-  file:
+  ansible.builtin.file:
     path: "{{ hpctests_rootdir }}/nvidia-hpl/results"
     state: directory
+    mode: "0755"
+    owner: "{{ hpctests_user }}"
   run_once: true
 
 # We could have used another sbatch script, calling `srun nvidia-hpl.sh` after
@@ -171,21 +170,21 @@
 - name: Display results
   tags: postpro
   block:
-  - ansible.builtin.shell: |
-      set -o pipefail
-       for res in results/nvidia-hpl.*.out; do
-         echo "=== $res ==="
-         grep -E '^((GPU [0-9]*)|(Job Id)|(Tasks per host)|(Hostname)):' "$res"
-         echo
-         awk '/Time          Gflops/ { ok=1;} (ok) { print}' "$res"
-         echo
-       done
-    register: cat_res
-    args:
-      chdir: "{{ hpctests_rootdir }}/nvidia-hpl"
-    changed_when: false
-  - ansible.builtin.debug:
-      msg: "{{ cat_res.stdout }}"
+    - ansible.builtin.shell: |
+        set -o pipefail
+         for res in results/nvidia-hpl.*.out; do
+           echo "=== $res ==="
+           grep -E '^((GPU [0-9]*)|(Job Id)|(Tasks per host)|(Hostname)):' "$res"
+           echo
+           awk '/Time          Gflops/ { ok=1;} (ok) { print}' "$res"
+           echo
+         done
+      register: cat_res
+      args:
+        chdir: "{{ hpctests_rootdir }}/nvidia-hpl"
+      changed_when: false
+    - ansible.builtin.debug:
+        msg: "{{ cat_res.stdout }}"
 
 - name: Extract Job Id
   tags: postpro

--- a/ansible/roles/hpctests/tasks/run-nvidia-hpl.yml
+++ b/ansible/roles/hpctests/tasks/run-nvidia-hpl.yml
@@ -55,24 +55,24 @@
 
 - name: Select GPUs
   ansible.builtin.set_fact:
-    hpctests_nvidia_hpl_gres: >-
+    hpctests_gpu_gres: >-
       {%- if gpus | length == 1 -%}
         {# homogeneous node #}
         {%- set gpu = gpus | dict2items | first -%}
             gpu:{{ gpu.key }}:{{ gpu.value }}
       {%- else -%}
-        {{ notdefined | mandatory(msg="Unsupported: nodes with heterogeneous (MIG?) GPUs, please specify wanted hpctests_nvidia_hpl_gres") }}
+        {{ notdefined | mandatory(msg="Unsupported: nodes with heterogeneous (MIG?) GPUs, please specify wanted hpctests_gpu_gres") }}
       {%- endif -%}
   vars:
     gpus: hpctests_nodeinfo.info[0].gpus | default({})
-  when: hpctests_nvidia_hpl_gres is not defined
+  when: hpctests_gpu_gres is not defined
 
 - ansible.builtin.debug:
-    msg: "Will run --gres={{ hpctests_nvidia_hpl_gres }}"
+    msg: "Will run --gres={{ hpctests_gpu_gres }}"
 
-- name: Check hpctests_nvidia_hpl_gres
+- name: Check hpctests_gpu_gres
   ansible.builtin.assert:
-    that: hpctests_nvidia_hpl_gres is search('^gpu:.*=[0-9]+$')
+    that: hpctests_gpu_gres is search('^gpu:.+:[0-9]+$')
 
 - name: Select HPL.dat
   ansible.builtin.set_fact:
@@ -80,11 +80,16 @@
       {{ hpctests_nvidia_hpl_dat | default(hpctests_nvidia_hpl_dat_matrix.get(selected_gpu, hpctests_nvidia_hpl_dat_matrix.default).get(selected_gpu_count | int ) | mandatory(msg="Unsupported GPU count")) }}
     hpctests_ntasks: "{{ selected_gpu_count }}"
   vars:
-    selected_gpu: "{{ ((hpctests_nvidia_hpl_gres | split(':'))[1] | split('='))[0] }}"
-    selected_gpu_count: "{{ (hpctests_nvidia_hpl_gres | split('='))[1] | int }}"
+    selected_gpu: "{{ (hpctests_gpu_gres | split(':'))[1] }}"
+    selected_gpu_count: "{{ (hpctests_gpu_gres | split(':'))[2] | int }}"
 
 - ansible.builtin.debug:
-    var: hpctests_nvidia_hpl_dat
+    msg: "Using NVIDIA-HPL data file '{{ hpctests_nvidia_hpl_dat }}' for {{ (hpctests_gpu_gres | split(':'))[2] | int }} GPUs"
+
+- ansible.builtin.assert:
+    that:
+      - (hpctests_nvidia_hpl_dat | length) > 0
+    fail_msg: "Unable to detect the NVIDIA-HPL data file to use. Please set hpctests_nvidia_hpl_dat"
 
 # Templating a script to be run on each node by srun.
 # Contrary to sbatch, all slurm parameters must be given on the command-line.
@@ -148,7 +153,7 @@
       --tasks-per-node=1 \
       --cpu-bind=none \
       --time={{ timeout_h }}:{{ timeout_m }}:30 \
-      --gres={{ hpctests_nvidia_hpl_gres }} \
+      --gres={{ hpctests_gpu_gres }} \
       --mem={{ (0.8 * (hpctests_nodeinfo.info[0].free_mem.number | int)) | round(method='floor') | int }} \
       --cpus-per-gpu={{ hpctests_nodeinfo.info[0].effective_cpus // (hpctests_ntasks | int) }} \
       --nodes={{ hpctests_nodeinfo.info | length }} \
@@ -215,7 +220,7 @@
     # yamllint disable rule:line-length
     msg: |
       {%- set floats = perf.stdout_lines | map('float') -%}
-      Summary for nvidia-hpl on {{ hpctests_computes.stdout_lines | length }} nodes in '{{ hpctests_partition }}' partition, job ID {{ srun_job_id.stdout.split()[-1] }}, GPUs '{{ hpctests_nvidia_hpl_gres }}':
+      Summary for nvidia-hpl on {{ hpctests_computes.stdout_lines | length }} nodes in '{{ hpctests_partition }}' partition, job ID {{ srun_job_id.stdout.split()[-1] }}, GPUs '{{ hpctests_gpu_gres }}':
         Max:  {{ floats | max }} Gflops ({{ ((floats | max) / hpctests_ntasks | int) | round(1)  }} Gflops per GPU)
         Min:  {{ floats | min }} Gflops ({{ ((floats | min) / hpctests_ntasks | int) | round(1) }} Gflops per GPU)
         Mean: {{ ((floats | sum) / (hpctests_computes.stdout_lines | length)) | round(1) }} Gflops ({{ ((floats | sum) / (hpctests_computes.stdout_lines | length) / hpctests_ntasks | int) | round(1) }} Gflops per GPU)

--- a/ansible/roles/hpctests/templates/nvidia-hpl-fetch.sh.j2
+++ b/ansible/roles/hpctests/templates/nvidia-hpl-fetch.sh.j2
@@ -1,0 +1,30 @@
+#!/usr/bin/bash
+#SBATCH --nodes=1
+#SBATCH --output=%x.%a.out
+#SBATCH --error=%x.%a.out
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=40G
+#SBATCH --partition={{ hpctests_partition }}
+#SBATCH --time=00:30:00
+{%if hpctests_nodes is defined %}
+#SBATCH --nodelist={{ hpctests_computes.stdout_lines[0] }}
+{% endif %}
+{%if hpctests_account is defined %}
+#SBATCH --account={{ hpctests_account }}
+{% endif %}
+{%if hpctests_qos is defined %}
+#SBATCH --qos={{ hpctests_qos }}
+{% endif %}
+
+set -e
+DOCKER_REF=docker://"{{ hpctests_nvidia_hpl_image }}:{{ hpctests_nvidia_hpl_version }}"
+echo "Downloading $DOCKER_REF to {{ hpctests_nvidia_hpl_sif_file }}..."
+{{ hpctests_pre_cmd }}
+if [ -e "$DEST_FILE" ]; then
+  rm "$DEST_FILE"
+fi
+mkdir -p "$(dirname "{{ hpctests_nvidia_hpl_sif_file }}")"
+apptainer pull --disable-cache=true "{{ hpctests_nvidia_hpl_sif_file }}" "$DOCKER_REF"
+ls -hl "{{ hpctests_nvidia_hpl_sif_file }}"
+# shellcheck gets confused about jinja templates
+#shellcheck disable=SC1056


### PR DESCRIPTION
-  the nvidia/hpc-benchmarks docker image is imported and run using apptainer
- NVIDIA HPL is run per host, using mpirun
- the HPL.dat file is selected based on given or discovered GPU model

It is possible to run one big NVIDIA HPL accross hosts, but only on clusters without cgroup resource isolation per task.
Since it is a common configuration, we run NVIDIA HPL via `mpirun` inside a slurm task per node as a workaround.

Please note that NVIDIA HPL can provoke hardware errors due to overconsumption/overheating in some hardware configurations and durations.