### PR TITLE
Allow multiple keys to be injected into user's authorized_keys

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -106,3 +106,5 @@ roles/*
 !roles/mounts/**
 !roles/opkssh/
 !roles/opkssh/**
+!roles/authorized_keys/
+!roles/authorized_keys/**

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -110,6 +110,16 @@
       ansible.builtin.meta: reset_connection
       become: false
 
+- hosts: cluster
+  gather_facts: false
+  become: true
+  tags:
+    - authorized_keys
+  tasks:
+    - name: Write authorized_keys for local users
+      ansible.builtin.include_role:
+        name: authorized_keys
+
 - hosts: systemd
   become: true
   gather_facts: false

--- a/ansible/roles/authorized_keys/README.md
+++ b/ansible/roles/authorized_keys/README.md
@@ -1,0 +1,3 @@
+# authorized_keys
+
+Configures authorized keys for local users

--- a/ansible/roles/authorized_keys/tasks/main.yml
+++ b/ansible/roles/authorized_keys/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Write supplied authorized_keys to authorized_keys for local users
+  ansible.posix.authorized_key:
+    user: "{{ item.0.user.name }}"
+    state: "{{ _authorized_key_state }}"
+    manage_dir: false
+    key: "{{ _authorized_key }}"
+    path: ~/.ssh/authorized_keys
+  become: true
+  become_user: "{{ item.0.user.name }}"
+  loop: "{{ appliances_local_users | selectattr('user.authorized_keys', 'defined') | subelements('user.authorized_keys') }}"
+  loop_control:
+    label: "{{ item.0.user.name }} :: {{ _authorized_key }}"
+  vars:
+    _authorized_key: "{{ item.1.public_key if item.1 is mapping else item.1 }}"
+    _authorized_key_state: "{{ item.1.state | default('present') if item.1 is mapping else 'present' }}"
+  when:
+    - item.0.enable | default(true) | bool
+    - item.0.user.state | default('present') == 'present'
+    - _authorized_key | string | length > 0 # NB this is a *provided* public key from authorized_keys

--- a/ansible/roles/basic_users/README.md
+++ b/ansible/roles/basic_users/README.md
@@ -50,7 +50,18 @@ without requiring LDAP etc. Features:
     nodes. Explicitly setting this defines the shell for all nodes and if the
     shared home directories are mounted on the control node will allow the
     user to log in to the control node.
-  - `public_key`: Optional, define a key to log into the cluster with.
+  - `authorized_keys`: Optional, list of mappings defining SSH public keys for
+    the user's authorized_keys file.
+    - `public_key`: Required, SSH public key string.
+    - `state`: Optional, one of `present` or `absent`. Default `present`.
+      Shorthand is also supported: list items may be plain strings, treated as
+      `public_key` with `state: present`.
+      For backwards compatibility this list is extended to include item.public_key
+      if that is set. It is preferred not to set public_key, but to include that
+      key in this list explicitly as item.public_key will be removed at some point
+      in the future.
+  - `public_key`: Deprecated: public key to add to authorized_keys. Please use
+    authorized_keys instead.
   - `sudo`: Optional, a (possibly multiline) string defining sudo rules for the
     user.
   - `ssh_key_type` defaults to `ed25519` instead of the `ansible.builtin.user`
@@ -76,11 +87,16 @@ None.
      - comment: Alice Aardvark
        name: alice
        uid: 2005
-       public_key: ssh-ed25519 ...
+       authorized_keys:
+         - ssh-ed25519 ... # shorthand for { public_key: ..., state: present }
+         - public_key: ssh-ed25519 ...
+           state: present
      - comment: Bob Badger
        name: bob
        uid: 2006
-       public_key: ssh-ed25519 ...
+       authorized_keys:
+         - public_key: ssh-ed25519 ...
+           state: present
        state: absent
    ```
 
@@ -101,7 +117,9 @@ None.
      - comment: Carol Crane
        name: carol
        uid: 2007
-       public_key: ssh-ed25519 ...
+       authorized_keys:
+         - public_key: ssh-ed25519 ...
+           state: present
    ```
 
 3. Using an external share which _does_ root squash, so home directories cannot be
@@ -116,7 +134,9 @@ None.
        create_home: false
        name: dan
        uuid: 2008
-       public_key: ssh-ed25519 ...
+       authorized_keys:
+         - public_key: ssh-ed25519 ...
+           state: present
    ```
 
 4. Using NFS exported from the control node, but mounted to all nodes (so that
@@ -132,5 +152,7 @@ None.
        groups:
          - adm # enables ssh to compute nodes even without a job running
        sudo: erin ALL=(ALL) NOPASSWD:ALL
-       public_key: ssh-ed25519 ...
+       authorized_keys:
+         - public_key: ssh-ed25519 ...
+           state: present
    ```

--- a/ansible/roles/basic_users/tasks/main.yml
+++ b/ansible/roles/basic_users/tasks/main.yml
@@ -86,9 +86,31 @@
     - item.create_home | default(true) | bool
     - ansible_hostname == basic_users_homedir_server
 
+- name: Normalise user key configuration
+  ansible.builtin.set_fact:
+    _basic_users_users: |
+      {%- set ns = namespace(users=[]) -%}
+      {%- for user in basic_users_users -%}
+      {# public_key is deprecated; include it for backward compatibility #}
+      {%-   set keys = namespace(items=[]) -%}
+      {%-   for key in user.authorized_keys | default([]) -%}
+      {%-     if key is mapping -%}
+      {%-       set _ = keys.items.append({'public_key': key.public_key, 'state': key.state | default('present')}) -%}
+      {%-     else -%}
+      {%-       set _ = keys.items.append({'public_key': key, 'state': 'present'}) -%}
+      {%-     endif -%}
+      {%-   endfor -%}
+      {%-   if user.public_key is defined -%}
+      {%-     set _ = keys.items.append({'public_key': user.public_key, 'state': 'present'}) -%}
+      {%-   endif -%}
+      {%-   set _ = ns.users.append(user | combine({'authorized_keys': keys.items})) -%}
+      {%- endfor -%}
+      {{ ns.users }}
+
 # The following tasks run on a single *client* node, so that home directory
 # paths are easily constructed, becoming each user so that root-squash
 # doesn't matter
+
 - name: Create ~/.ssh directories
   ansible.builtin.file:
     state: directory
@@ -98,12 +120,12 @@
     mode: u=rwX,go=
   become: true
   become_user: "{{ item.name }}"
-  loop: "{{ basic_users_users }}"
+  loop: "{{ _basic_users_users }}"
   loop_control:
     label: "{{ item.name }}"
   when:
     - item.state | default('present') == 'present'
-    - item.generate_ssh_key | default(basic_users_generate_ssh_key) | bool or item.public_key is defined
+    - item.generate_ssh_key | default(basic_users_generate_ssh_key) | bool or (item.authorized_keys | length > 0)
     - ansible_hostname == basic_users_homedir_client
 
 - name: Generate cluster ssh key
@@ -115,7 +137,7 @@
     _ssh_key_type: "{{ item.ssh_key_type | default('ed25519') }}"
   become: true
   become_user: "{{ item.name }}"
-  loop: "{{ basic_users_users }}"
+  loop: "{{ _basic_users_users }}"
   loop_control:
     label: "{{ item.name }}"
   when:
@@ -142,19 +164,18 @@
     - ansible_hostname == basic_users_homedir_client
     - item.public_key is defined # NB this is the *returned* public key
 
-- name: Write supplied public key to authorized_keys
+- name: Write supplied authorized_keys to authorized_keys
   ansible.posix.authorized_key:
-    user: "{{ item.name }}"
-    state: present
+    user: "{{ item.0.name }}"
+    state: "{{ item.1.state }}"
     manage_dir: false
-    key: "{{ item.public_key }}"
+    key: "{{ item.1.public_key }}"
     path: ~/.ssh/authorized_keys
   become: true
-  become_user: "{{ item.name }}"
-  loop: "{{ basic_users_users }}"
+  become_user: "{{ item.0.name }}"
+  loop: "{{ query('subelements', _basic_users_users, 'authorized_keys') }}"
   loop_control:
-    label: "{{ item.name }}"
+    label: "{{ item.0.name }}"
   when:
-    - item.state | default('present') == 'present'
-    - ansible_hostname == basic_users_homedir_client
-    - item.public_key is defined # NB this is the *provided* public key
+    - item.0.state | default('present') == 'present'
+    - item.1.public_key | string | length > 0 # NB this is a *provided* public key from authorized_keys

--- a/ansible/roles/compute_init/README.md
+++ b/ansible/roles/compute_init/README.md
@@ -41,6 +41,7 @@ it also requires an image build with the role name added to the
 | hooks/pre.yml            | ?                             | None at present                 | n/a                 |
 | validate.yml             | n/a                           | Not relevant during boot        | n/a                 |
 | bootstrap.yml            | (wait for ansible-init)       | Not relevant during boot        | n/a                 |
+| bootstrap.yml            | authorized_keys               | Fully supported                 | No                  |
 | bootstrap.yml            | journald                      | Fully supported                 | No                  |
 | bootstrap.yml            | resolv_conf                   | Fully supported                 | No                  |
 | bootstrap.yml            | etc_hosts                     | Fully supported                 | No                  |

--- a/ansible/roles/compute_init/files/compute-init.yml
+++ b/ansible/roles/compute_init/files/compute-init.yml
@@ -122,6 +122,10 @@
         name: journald
       when: enable_journald
 
+    - name: Run authorized_keys role
+      ansible.builtin.include_role:
+        name: authorized_keys
+
     - name: Run chrony role
       ansible.builtin.include_role:
         name: mrlesmithjr.chrony

--- a/ansible/roles/compute_init/tasks/install.yml
+++ b/ansible/roles/compute_init/tasks/install.yml
@@ -58,6 +58,8 @@
       dest: roles/
     - src: ../../journald
       dest: roles/
+    - src: ../../authorized_keys
+      dest: roles/
 
 - name: Add filter_plugins to ansible.cfg
   ansible.builtin.lineinfile:

--- a/environments/.caas/inventory/group_vars/all/basic_users.yml
+++ b/environments/.caas/inventory/group_vars/all/basic_users.yml
@@ -4,7 +4,9 @@ basic_users_users:
     # Hash the password with a salt that is different for each host
     password: "{{ vault_azimuth_user_password | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
     uid: 1005
-    public_key: "{{ cluster_user_ssh_public_key }}"
+    authorized_keys:
+      - public_key: "{{ lookup('env', 'CLUSTER_USER_SSH_PUBLIC_KEY') }}"
+        state: present
     shell: /bin/bash
     append: true
     groups:

--- a/environments/common/inventory/group_vars/all/defaults.yml
+++ b/environments/common/inventory/group_vars/all/defaults.yml
@@ -43,12 +43,15 @@ appliances_local_users_podman: # also used in environments/common/inventory/grou
   home: /var/lib/podman
   uid: "{{ appliances_local_users_podman_uid }}"
 
+appliances_local_users_ansible_user_authorized_keys: []
+
 appliances_local_users_default:
   - user:
       name: "{{ appliances_local_users_ansible_user_name }}"
       home: /var/lib/{{ appliances_local_users_ansible_user_name }}
       move_home: true
       local: true
+      authorized_keys: "{{ appliances_local_users_ansible_user_authorized_keys }}"
 
   - user: "{{ appliances_local_users_podman }}"
     enable: "{{ 'podman' in group_names }}"


### PR DESCRIPTION
Adds support for multiple keys to basic_users, along with ability to remove keys.

Use cases:

1) User has multiple keys e.g primary yubikey and a backup yubikey 
2) Removing old keys with state: absent

Adds support for disabling and adding additional keys to rocky user; this can be useful for debugging if LDAP is down. 