### PR TITLE
Fix ood file shortcuts

### DIFF
--- a/ansible/roles/openondemand/templates/files_shortcuts.rb.j2
+++ b/ansible/roles/openondemand/templates/files_shortcuts.rb.j2
@@ -1,5 +1,5 @@
 # Template to add additional shortcuts to the Files dashboard app
-# See https://osc.github.io/ood-documentation/master/customization.html#add-shortcuts-to-files-menu
+# See https://osc.github.io/ood-documentation/latest/customizations.html#add-shortcuts-to-files-menu
 
 Rails.application.config.after_initialize do
   OodFilesApp.candidate_favorite_paths.tap do |paths|

--- a/ansible/roles/openondemand/templates/files_shortcuts.rb.j2
+++ b/ansible/roles/openondemand/templates/files_shortcuts.rb.j2
@@ -1,8 +1,10 @@
 # Template to add additional shortcuts to the Files dashboard app
 # See https://osc.github.io/ood-documentation/master/customization.html#add-shortcuts-to-files-menu
 
-OodFilesApp.candidate_favorite_paths.tap do |paths|
-{% for path in openondemand_filesapp_paths %}
-  paths << Pathname.new("{{ path }}")
+Rails.application.config.after_initialize do
+  OodFilesApp.candidate_favorite_paths.tap do |paths|
+{% for path in openondemand_filesapp_paths | default([]) %}
+    paths << Pathname.new("{{ path }}")
 {% endfor %}
+  end
 end

--- a/ansible/roles/openondemand/templates/files_shortcuts.rb.j2
+++ b/ansible/roles/openondemand/templates/files_shortcuts.rb.j2
@@ -4,7 +4,7 @@
 Rails.application.config.after_initialize do
   OodFilesApp.candidate_favorite_paths.tap do |paths|
 {% for path in openondemand_filesapp_paths | default([]) %}
-    paths << Pathname.new("{{ path }}")
+    paths << Pathname.new({{ path | to_json }})
 {% endfor %}
   end
 end

--- a/ansible/roles/openondemand/templates/files_shortcuts.rb.j2
+++ b/ansible/roles/openondemand/templates/files_shortcuts.rb.j2
@@ -4,7 +4,7 @@
 Rails.application.config.after_initialize do
   OodFilesApp.candidate_favorite_paths.tap do |paths|
 {% for path in openondemand_filesapp_paths | default([]) %}
-    paths << Pathname.new({{ path | to_json }})
+    paths << FavoritePath.new({{ path | to_json }})
 {% endfor %}
   end
 end


### PR DESCRIPTION
Wait until OodFilesApp has been loaded before modifying candidate_favorite_paths.

We were hitting `uninitialized constant OodFilesApp` after upgrading to v2.16 of the appliance likely due to the newer 4.x version of OOD