### PR TITLE
Use intermediate base image instead of Rocky Linux image to speedup image build

### DIFF
--- a/.github/workflows/build-baseimage.yml
+++ b/.github/workflows/build-baseimage.yml
@@ -183,6 +183,7 @@ jobs:
         run: |
           . venv/bin/activate
           . dev/image-set-properties.sh "${STEPS_MANIFEST_OUTPUTS_IMAGE_ID}"
+          openstack image set --property "gh_run=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID#GITHUB_RUN_ATTEMPT" "${STEPS_MANIFEST_OUTPUTS_IMAGE_ID}"
         env:
           STEPS_MANIFEST_OUTPUTS_IMAGE_ID: ${{ steps.manifest.outputs.image-id }}
 

--- a/.github/workflows/build-baseimage.yml
+++ b/.github/workflows/build-baseimage.yml
@@ -1,0 +1,193 @@
+name: Build base image
+'on':
+  workflow_dispatch:
+    # checkov:skip=CKV_GHA_7: "The build output cannot be affected by user parameters other than the build entry point and the top-level source location. GitHub Actions workflow_dispatch inputs MUST be empty. "
+    inputs:
+      ci_cloud:
+        description: 'Select the CI_CLOUD'
+        required: true
+        type: choice
+        options:
+          - default
+          - LEAFCLOUD
+          - SMS
+          - ARCUS
+        default: default # Use repo CI_CLOUD setting
+      cleanup_on_failure:
+        description: Cleanup Packer resources on failure
+        type: boolean
+        required: true
+        default: true
+
+permissions: {}
+
+jobs:
+  openstack:
+    name: openstack-imagebuild
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.build.image_name }} # to branch/PR + OS
+      cancel-in-progress: true
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false # allow other matrix jobs to continue even if one fails
+      matrix: # build RL8, RL9
+        build:
+          - image_name: base-RL8
+            source_image_name: Rocky-8-GenericCloud-Base-8.10-20240528.0.x86_64.qcow2
+            inventory_groups: fatimage
+          - image_name: base-RL9
+            source_image_name: Rocky-9-GenericCloud-Base-9.8-20260525.0.x86_64
+            inventory_groups: fatimage
+    env:
+      ANSIBLE_FORCE_COLOR: 'true'
+      OS_CLOUD: openstack
+      CI_CLOUD: ${{ github.event.inputs.ci_cloud == 'default' && vars.CI_CLOUD || github.event.inputs.ci_cloud }}
+      ARK_PASSWORD: ${{ secrets.ARK_PASSWORD }}
+      PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PACKER_ON_ERROR: ${{ github.event.inputs.cleanup_on_failure == 'true' && 'cleanup' || 'abort' }}
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Record settings for CI cloud
+        run: |
+          echo "CI_CLOUD: ${CI_CLOUD}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "PACKER_ON_ERROR | tee -a ${PACKER_ON_ERROR}"
+
+      - name: Setup ssh
+        run: |
+          set -x
+          mkdir -p ~/.ssh
+
+          # setup bastion private key:
+          echo "$SECRETS_SSH_KEY" > "${BASTION_KEYFILE}"
+          chmod 0600 "${BASTION_KEYFILE}"
+          ssh-keygen -f "${BASTION_KEYFILE}" -y # tests key format is correct
+
+          # accept bastion hostkeys
+          cat >> ~/.ssh/known_hosts <<< "${BASTION_FINGERPRINTS}"
+
+          {
+            # setup bastion for Ansible:
+            # NB Do NOT change this to use ProxyJump, it doesn't pickup the key
+            echo "ANSIBLE_SSH_COMMON_ARGS=-o ProxyCommand='ssh -i ${BASTION_KEYFILE} -W %h:%p ${BASTION_USER}@${BASTION_HOST}'"
+
+            # setup bastion for Packer:
+            echo "PKR_VAR_ssh_bastion_host=${BASTION_HOST}"
+            echo "PKR_VAR_ssh_bastion_username=${BASTION_USER}"
+            echo "PKR_VAR_ssh_bastion_private_key_file=${BASTION_KEYFILE}"
+
+            # setup additional debug key for Packer:
+            echo "PKR_VAR_ssh_debug_public_key=${SSH_DEBUG_PUBLIC_KEY}"
+          } >> "$GITHUB_ENV"
+
+          echo "bastion details:"
+          cat "$GITHUB_ENV"
+        env:
+          BASTION_KEYFILE: /home/runner/.ssh/bastion_key
+          SECRETS_SSH_KEY: ${{ secrets[format('{0}_SSH_KEY', env.CI_CLOUD)] }} # zizmor: ignore[overprovisioned-secrets]
+          BASTION_HOST: ${{ vars[format('{0}_BASTION_HOST', env.CI_CLOUD)] }}
+          BASTION_USER: slurm-app-ci # currently same for both CI clouds
+          BASTION_FINGERPRINTS: ${{ vars.BASTION_FINGERPRINTS }}
+          SSH_DEBUG_PUBLIC_KEY: ${{ vars.SSH_DEBUG_PUBLIC_KEY}}
+
+      - name: Cache pip
+        # Don't cache galaxy/requirements.yml as during dev its common for this
+        # to use branch names
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('requirements.txt') }}
+
+      - name: Install ansible etc
+        run: dev/setup-env.sh
+
+      - name: Write clouds.yaml
+        run: |
+          mkdir -p ~/.config/openstack/
+          echo "$SECRETS_CLOUD" > ~/.config/openstack/clouds.yaml
+        shell: bash
+        env:
+          SECRETS_CLOUD: ${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }} # zizmor: ignore[overprovisioned-secrets]
+
+      - name: Compute base image_name_version and check if already exists
+        id: compute_image_name_version
+        run: |
+          . venv/bin/activate
+          image_name_version="-$(sha256sum environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml | awk '{ print $1 }')"
+          echo image_name_version="$image_name_version" | tee -a "$GITHUB_OUTPUT"
+          full_image_name="${MATRIX_BUILD_IMAGE_NAME}${image_name_version}"
+          if openstack image show -f value -c name "$full_image_name"; then
+            echo "Image $full_image_name already exists, will skip remaining steps"
+            echo "image_exists=true" | tee -a "$GITHUB_OUTPUT"
+          fi
+        env:
+          MATRIX_BUILD_IMAGE_NAME: ${{ matrix.build.image_name }}
+
+      - name: Setup environment
+        run: |
+          . venv/bin/activate
+          . environments/.stackhpc/activate
+
+      - name: Build fat image with packer
+        id: packer_build
+        run: |
+          set -x
+          . venv/bin/activate
+          . environments/.stackhpc/activate
+          cd packer/
+          packer init .
+
+          PACKER_LOG=1 packer build \
+          -on-error="$PACKER_ON_ERROR" \
+          -var-file="$PKR_VAR_environment_root/${CI_CLOUD}.pkrvars.hcl" \
+          -var "source_image_name=$MATRIX_BUILD_SOURCE_IMAGE_NAME" \
+          -var "image_name=$MATRIX_BUILD_IMAGE_NAME" \
+          -var "image_name_version=$STEP_IMAGE_NAME_VERSION" \
+          -var "playbook=baseimage.yml" \
+          -var "inventory_groups=$MATRIX_BUILD_INVENTORY_GROUPS" \
+          openstack.pkr.hcl
+        env:
+          MATRIX_BUILD_SOURCE_IMAGE_NAME: ${{ matrix.build.source_image_name }}
+          MATRIX_BUILD_IMAGE_NAME: ${{ matrix.build.image_name }}
+          MATRIX_BUILD_INVENTORY_GROUPS: ${{ matrix.build.inventory_groups }}
+          STEP_IMAGE_NAME_VERSION: ${{ steps.compute_image_name_version.outputs.image_name_version }}
+
+      - name: Get created image names from manifest
+        id: manifest
+        run: |
+          . venv/bin/activate
+          IMAGE_ID=$(jq --raw-output '.builds[-1].artifact_id' packer/packer-manifest.json)
+          while ! openstack image show -f value -c name "$IMAGE_ID"; do
+            sleep 5
+          done
+          IMAGE_NAME=$(openstack image show -f value -c name "$IMAGE_ID")
+          echo "image-name=${IMAGE_NAME}" | tee -a "$GITHUB_OUTPUT" "$GITHUB_STEP_SUMMARY"
+          echo "image-id=$IMAGE_ID" | tee -a "$GITHUB_OUTPUT" "$GITHUB_STEP_SUMMARY"
+          echo "$IMAGE_ID" > image-id.txt
+          echo "$IMAGE_NAME" > image-name.txt
+
+      - name: Make image usable for further builds
+        run: |
+          . venv/bin/activate
+          openstack image unset --property signature_verified "${STEPS_MANIFEST_OUTPUTS_IMAGE_ID}" || true
+        env:
+          STEPS_MANIFEST_OUTPUTS_IMAGE_ID: ${{ steps.manifest.outputs.image-id }}
+
+      - name: Set image properties
+        run: |
+          . venv/bin/activate
+          . dev/image-set-properties.sh "${STEPS_MANIFEST_OUTPUTS_IMAGE_ID}"
+        env:
+          STEPS_MANIFEST_OUTPUTS_IMAGE_ID: ${{ steps.manifest.outputs.image-id }}
+
+      - name: Upload manifest artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: image-details-${{ matrix.build.image_name }}
+          path: |
+            ./image-id.txt
+            ./image-name.txt
+          overwrite: true

--- a/.github/workflows/build-baseimage.yml
+++ b/.github/workflows/build-baseimage.yml
@@ -101,8 +101,8 @@ jobs:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('requirements.txt') }}
 
-      - name: Install ansible etc
-        run: dev/setup-env.sh
+      - name: Install python requirements
+        run: SKIP_ANSIBLE_GALAXY=true dev/setup-env.sh
 
       - name: Write clouds.yaml
         run: |
@@ -125,6 +125,9 @@ jobs:
           fi
         env:
           MATRIX_BUILD_IMAGE_NAME: ${{ matrix.build.image_name }}
+
+      - name: Install ansible etc
+        run: dev/setup-env.sh
 
       - name: Setup environment
         run: |

--- a/.github/workflows/build-baseimage.yml
+++ b/.github/workflows/build-baseimage.yml
@@ -113,14 +113,14 @@ jobs:
           SECRETS_CLOUD: ${{ secrets[format('{0}_CLOUDS_YAML', env.CI_CLOUD)] }} # zizmor: ignore[overprovisioned-secrets]
 
       - name: Compute base image_name_version and check if already exists
-        id: compute_image_name_version
+        id: compute_base_image_name_version
         run: |
           . venv/bin/activate
           image_name_version="-$(sha256sum environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml | awk '{ print $1 }')"
           echo image_name_version="$image_name_version" | tee -a "$GITHUB_OUTPUT"
           full_image_name="${MATRIX_BUILD_IMAGE_NAME}${image_name_version}"
-          if openstack image show -f value -c name "$full_image_name"; then
-            echo "Image $full_image_name already exists, will skip remaining steps"
+          if openstack image show -f value -c id "$full_image_name"; then
+            echo "Image $full_image_name already exists, will build anyway"
             echo "image_exists=true" | tee -a "$GITHUB_OUTPUT"
           fi
         env:
@@ -156,7 +156,7 @@ jobs:
           MATRIX_BUILD_SOURCE_IMAGE_NAME: ${{ matrix.build.source_image_name }}
           MATRIX_BUILD_IMAGE_NAME: ${{ matrix.build.image_name }}
           MATRIX_BUILD_INVENTORY_GROUPS: ${{ matrix.build.inventory_groups }}
-          STEP_IMAGE_NAME_VERSION: ${{ steps.compute_image_name_version.outputs.image_name_version }}
+          STEP_IMAGE_NAME_VERSION: ${{ steps.compute_base_image_name_version.outputs.image_name_version }}
 
       - name: Get created image names from manifest
         id: manifest

--- a/.github/workflows/build-baseimage.yml
+++ b/.github/workflows/build-baseimage.yml
@@ -172,6 +172,18 @@ jobs:
           echo "$IMAGE_ID" > image-id.txt
           echo "$IMAGE_NAME" > image-name.txt
 
+      - name: Delete existing image with same name
+        run: |
+          . venv/bin/activate
+          for img in $(openstack image list --name "$STEPS_MANIFEST_OUTPUTS_IMAGE_NAME" --status active -c id -f value | grep -v "$STEPS_MANIFEST_OUTPUTS_IMAGE_ID"); do
+            echo "Existing image with same name, deleting"
+            openstack image show "$img"
+            openstack image delete "$img"
+          done
+        env:
+          STEPS_MANIFEST_OUTPUTS_IMAGE_ID: ${{ steps.manifest.outputs.image-id }}
+          STEPS_MANIFEST_OUTPUTS_IMAGE_NAME: ${{ steps.manifest.outputs.image-name }}
+
       - name: Make image usable for further builds
         run: |
           . venv/bin/activate

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -118,19 +118,20 @@ jobs:
           . environments/.stackhpc/activate
 
       - name: Compute base image_name_version and check if already exists
-        id: compute_base_image_name_version
+        id: compute_source_image_name
         run: |
           . venv/bin/activate
           image_name_version="-$(sha256sum environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml | awk '{ print $1 }')"
-          echo image_name_version="$image_name_version" | tee -a "$GITHUB_OUTPUT"
           full_image_name="base${MATRIX_BUILD_IMAGE_NAME#openhpc}${image_name_version}"
-          if openstack image show -f value -c id "$full_image_name"; then
-            echo "Base image $full_image_name exists, will use instead of $MATRIX_BUILD_SOURCE_IMAGE_NAME"
+          base_image_id="$(openstack image show -f value -c id "$full_image_name" || echo '-')"
+          if [ "$base_image_id" != "-" ]; then
+            echo "Base image $full_image_name exists with id $base_image_id, will use instead of $MATRIX_BUILD_SOURCE_IMAGE_NAME"
             source_image_name="$full_image_name"
           else
-            echo "Base image $full_image_name doesn't exist, will use $MATRIX_BUILD_SOURCE_IMAGE_NAME"
+            echo "Base image $full_image_name doesn't exist or not unique, will use $MATRIX_BUILD_SOURCE_IMAGE_NAME"
+            source_image_name="$MATRIX_BUILD_SOURCE_IMAGE_NAME"
           fi
-          echo "source_image_name=$full_image_name" | tee -a "$GITHUB_OUTPUT"
+          echo "source_image_name=$source_image_name" | tee -a "$GITHUB_OUTPUT" "$GITHUB_STEP_SUMMARY"
         env:
           MATRIX_BUILD_IMAGE_NAME: ${{ matrix.build.image_name }}
           MATRIX_BUILD_SOURCE_IMAGE_NAME: ${{ matrix.build.source_image_name }}
@@ -152,7 +153,7 @@ jobs:
           -var "inventory_groups=$MATRIX_BUILD_INVENTORY_GROUPS" \
           openstack.pkr.hcl
         env:
-          SOURCE_IMAGE_NAME: ${{ steps.compute_base_image_name_version.outputs.source_image_name }}
+          SOURCE_IMAGE_NAME: ${{ steps.compute_source_image_name.outputs.source_image_name }}
           MATRIX_BUILD_IMAGE_NAME: ${{ matrix.build.image_name }}
           MATRIX_BUILD_INVENTORY_GROUPS: ${{ matrix.build.inventory_groups }}
 

--- a/.github/workflows/fatimage.yml
+++ b/.github/workflows/fatimage.yml
@@ -117,6 +117,24 @@ jobs:
           . venv/bin/activate
           . environments/.stackhpc/activate
 
+      - name: Compute base image_name_version and check if already exists
+        id: compute_base_image_name_version
+        run: |
+          . venv/bin/activate
+          image_name_version="-$(sha256sum environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml | awk '{ print $1 }')"
+          echo image_name_version="$image_name_version" | tee -a "$GITHUB_OUTPUT"
+          full_image_name="base${MATRIX_BUILD_IMAGE_NAME#openhpc}${image_name_version}"
+          if openstack image show -f value -c id "$full_image_name"; then
+            echo "Base image $full_image_name exists, will use instead of $MATRIX_BUILD_SOURCE_IMAGE_NAME"
+            source_image_name="$full_image_name"
+          else
+            echo "Base image $full_image_name doesn't exist, will use $MATRIX_BUILD_SOURCE_IMAGE_NAME"
+          fi
+          echo "source_image_name=$full_image_name" | tee -a "$GITHUB_OUTPUT"
+        env:
+          MATRIX_BUILD_IMAGE_NAME: ${{ matrix.build.image_name }}
+          MATRIX_BUILD_SOURCE_IMAGE_NAME: ${{ matrix.build.source_image_name }}
+
       - name: Build fat image with packer
         id: packer_build
         run: |
@@ -129,12 +147,12 @@ jobs:
           PACKER_LOG=1 packer build \
           -on-error="$PACKER_ON_ERROR" \
           -var-file="$PKR_VAR_environment_root/${CI_CLOUD}.pkrvars.hcl" \
-          -var "source_image_name=$MATRIX_BUILD_SOURCE_IMAGE_NAME" \
+          -var "source_image_name=$SOURCE_IMAGE_NAME" \
           -var "image_name=$MATRIX_BUILD_IMAGE_NAME" \
           -var "inventory_groups=$MATRIX_BUILD_INVENTORY_GROUPS" \
           openstack.pkr.hcl
         env:
-          MATRIX_BUILD_SOURCE_IMAGE_NAME: ${{ matrix.build.source_image_name }}
+          SOURCE_IMAGE_NAME: ${{ steps.compute_base_image_name_version.outputs.source_image_name }}
           MATRIX_BUILD_IMAGE_NAME: ${{ matrix.build.image_name }}
           MATRIX_BUILD_INVENTORY_GROUPS: ${{ matrix.build.inventory_groups }}
 

--- a/ansible/baseimage.yml
+++ b/ansible/baseimage.yml
@@ -84,6 +84,15 @@
     - name: Install CVMFS
       ansible.builtin.dnf:
         name: cvmfs
+    - name: Install R from EPEL
+      ansible.builtin.dnf:
+        name: R
+    - name: Install squid package
+      ansible.builtin.dnf:
+        name: squid
+    - name: Install Xfce desktop
+      ansible.builtin.dnf:
+        name: "@Xfce"
 
 - hosts: builder
   become: true

--- a/ansible/baseimage.yml
+++ b/ansible/baseimage.yml
@@ -1,0 +1,83 @@
+---
+# Stripped-down version of fatimage, just updating base packages
+
+- hosts: builder
+  become: false
+  gather_facts: false
+  tasks:
+    - name: Report hostname (= final image name)
+      ansible.builtin.command: hostname # noqa: no-changed-when
+    - name: Report inventory groups
+      ansible.builtin.debug:
+        var: group_names
+    - name: Report ssh command to connect
+      ansible.builtin.debug:
+        msg: >
+          connect to builder machine using:
+          ssh {% if ansible_ssh_port | default(false) %}-p {{ ansible_ssh_port }}{% endif %}
+          {% if ansible_ssh_private_key_file | default(false) %} -i {{ ansible_ssh_private_key_file }}{% endif %}
+          {{ ansible_ssh_common_args | default('') }}
+          {{ ansible_ssh_extra_args | default('') }}
+          -o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null
+          {{ ansible_user }}@{{ ansible_host }}
+
+- hosts: builder
+  tags: dnf_repos
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Replace system repos with pulp repos
+      ansible.builtin.include_role:
+        name: dnf_repos
+        tasks_from: set_repos.yml
+
+- hosts: builder
+  gather_facts: false
+  become: true
+  tags: cockpit
+  tasks:
+    - name: Remove RHEL cockpit # noqa: no-changed-when
+      ansible.builtin.command: dnf -y remove cockpit-ws cockpit-system cockpit-bridge
+      register: dnf_remove_output
+      ignore_errors: true # Avoid failing if a lock or other error happens
+
+- hosts: builder
+  gather_facts: false
+  become: true
+  tags:
+    - update
+  tasks:
+    - name: Update selected packages
+      ansible.builtin.dnf:
+        name: "*"
+        state: latest
+      async: "{{ 30 * 60 }}" # wait for up to 30 minutes
+      poll: 15 # check every 15 seconds
+      register: updates
+    - name: Log updated packages
+      ansible.builtin.debug:
+        msg: |
+          {{ updates.results | length }} changes to packages
+          {{ updates.results | join('\n') }}
+
+- hosts: builder
+  become: true
+  tags: dnf_repos
+  tasks:
+    - name: Disable pulp repos
+      ansible.builtin.include_role:
+        name: dnf_repos
+        tasks_from: disable_repos.yml
+      when: not dnf_repos_enabled | default(false) | bool
+
+
+# NB: Reusing cleanup tasks
+- hosts: builder
+  become: true
+  gather_facts: true
+  tags: finalise
+  tasks:
+    - name: Cleanup image
+      ansible.builtin.import_tasks: cleanup.yml
+    - name: Shutdown Packer VM
+      community.general.shutdown:

--- a/ansible/baseimage.yml
+++ b/ansible/baseimage.yml
@@ -74,6 +74,16 @@
 
 - hosts: builder
   become: true
+  tasks:
+    - name: Install podman
+      ansible.builtin.dnf:
+        name:
+          - podman
+          - python3
+        state: installed
+
+- hosts: builder
+  become: true
   tags: dnf_repos
   tasks:
     - name: Disable pulp repos

--- a/ansible/baseimage.yml
+++ b/ansible/baseimage.yml
@@ -34,6 +34,18 @@
 - hosts: builder
   gather_facts: false
   become: true
+  tags:
+    - selinux
+  tasks:
+    - name: Set SELinux state and policy
+      ansible.posix.selinux:
+        state: "{{ selinux_state }}"
+        policy: "{{ selinux_policy }}"
+      register: sestatus
+
+- hosts: builder
+  gather_facts: false
+  become: true
   tags: cockpit
   tasks:
     - name: Remove RHEL cockpit # noqa: no-changed-when

--- a/ansible/baseimage.yml
+++ b/ansible/baseimage.yml
@@ -21,6 +21,27 @@
           -o StrictHostKeyChecking=no -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null
           {{ ansible_user }}@{{ ansible_host }}
 
+- hosts: cluster
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Add system user groups
+      ansible.builtin.group: "{{ item.group }}" # noqa: args[module]
+      loop: "{{ appliances_local_users }}"
+      when:
+        - item.enable | default(true) | bool
+        - "'group' in item"
+      become_method: ansible.builtin.sudo
+      # Need to change working directory otherwise we try to switch back to non-existent directory.
+      become_flags: "-i"
+    - name: Add system users
+      ansible.builtin.user: "{{ item.user }}" # noqa: args[module]
+      loop: "{{ appliances_local_users }}"
+      when: item.enable | default(true) | bool
+      become_method: ansible.builtin.sudo
+      # Need to change working directory otherwise we try to switch back to non-existent directory.
+      become_flags: "-i"
+
 - hosts: builder
   tags: dnf_repos
   gather_facts: true

--- a/ansible/baseimage.yml
+++ b/ansible/baseimage.yml
@@ -131,6 +131,8 @@
   become: true
   gather_facts: true
   tags: finalise
+  vars:
+    appliances_fatimage_cleanup_dnf: false
   tasks:
     - name: Cleanup image
       ansible.builtin.import_tasks: cleanup.yml

--- a/ansible/baseimage.yml
+++ b/ansible/baseimage.yml
@@ -81,6 +81,9 @@
           - podman
           - python3
         state: installed
+    - name: Install CVMFS
+      ansible.builtin.dnf:
+        name: cvmfs
 
 - hosts: builder
   become: true

--- a/ansible/baseimage.yml
+++ b/ansible/baseimage.yml
@@ -114,6 +114,38 @@
     - name: Install Xfce desktop
       ansible.builtin.dnf:
         name: "@Xfce"
+    - name: Install Slurm packages
+      ansible.builtin.dnf:
+        name:
+          # Generic
+          - mariadb-connector-c
+          - hwloc-libs
+          # Control
+          - ohpc-slurm-server
+          - slurm-slurmctld-ohpc
+          - slurm-example-configs-ohpc
+          # batch
+          - ohpc-base-compute
+          - ohpc-slurm-client
+          # runtime
+          - slurm-ohpc
+          - munge
+          - slurm-slurmd-ohpc
+          - slurm-example-configs-ohpc
+          - lmod-ohpc
+          # database
+          - slurm-slurmdbd-ohpc
+          # openhpc_packages
+          - slurm-libpmi-ohpc
+          # other packages
+          - mysql
+          # environments/common openhpc_packages
+          - slurm-libpmi-ohpc
+          - ohpc-gnu12-openmpi4-perf-tools
+          - openblas-gnu12-ohpc
+          - nhc-ohpc
+          - apptainer
+          - podman-compose
 
 - hosts: builder
   become: true

--- a/ansible/baseimage.yml
+++ b/ansible/baseimage.yml
@@ -62,7 +62,7 @@
     - name: Update selected packages
       ansible.builtin.dnf:
         name: "*"
-        state: latest
+        state: latest # noqa: package-latest
       async: "{{ 30 * 60 }}" # wait for up to 30 minutes
       poll: 15 # check every 15 seconds
       register: updates

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -251,7 +251,7 @@
             exclude: "{{ update_exclude }}"
             disablerepo: "{{ update_disablerepo }}"
           async: "{{ 30 * 60 }}" # wait for up to 30 minutes
-          poll: 15 # check every 15 seconds
+          poll: 5 # check every 5 seconds
           register: updates
         - name: Ensure update log directory on localhost exists
           ansible.builtin.file:

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -208,6 +208,7 @@
       ansible.builtin.command: dnf -y remove cockpit-ws cockpit-system cockpit-bridge
       register: dnf_remove_output
       ignore_errors: true # Avoid failing if a lock or other error happens
+      changed_when: '"Nothing to do." not in dnf_remove_output.stdout'
 
 - hosts: firewalld
   gather_facts: false

--- a/ansible/cleanup.yml
+++ b/ansible/cleanup.yml
@@ -60,16 +60,25 @@
     - /var/www/ood/apps/sys/dashboard/node_modules/@esbuild/linux-x64/bin/esbuild
     - /usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/esbuild
 
-- name: Replace rclone with a no-op script
-  ansible.builtin.copy:
-    content: |
-      #!/bin/sh
-      echo "The rclone executable has been removed in ansible-slurm-appliance images due to too many security warnings." 1>&2
-      exit 1
-    dest: /usr/bin/rclone
-    owner: root
-    group: root
-    mode: "0555"
+- name: Replace rclone with a no-op script if it exists
+  block:
+    - name: Check rclone existence
+      ansible.builtin.stat:
+        path: /usr/bin/rclone
+        get_checksum: false
+        get_mime: false
+      register: rclone_present
+    - name: Replace rclone with a no-op script
+      when: rclone_present.stat.exists
+      ansible.builtin.copy:
+        content: |
+          #!/bin/sh
+          echo "The rclone executable has been removed in ansible-slurm-appliance images due to too many security warnings." 1>&2
+          exit 1
+        dest: /usr/bin/rclone
+        owner: root
+        group: root
+        mode: "0555"
 
 - name: Stop journald
   # Stop journald from writing data to the journal after we have cleared it.

--- a/ansible/cleanup.yml
+++ b/ansible/cleanup.yml
@@ -4,6 +4,7 @@
 - ansible.builtin.meta: flush_handlers
 
 - name: Remove dnf caches # noqa: no-changed-when
+  when: appliances_fatimage_cleanup_dnf | default(True)
   ansible.builtin.command: dnf clean all
 
 # If image build happens on a Neutron subnet with property dns_namservers defined, then cloud-init

--- a/ansible/roles/compute_init/tasks/install.yml
+++ b/ansible/roles/compute_init/tasks/install.yml
@@ -14,10 +14,47 @@
     - tasks
     - roles
 
+- name: Prepare Inject files from roles
+  delegate_to: localhost
+  changed_when: true
+  ansible.builtin.shell: |
+    rm -rf __tmp_inject_files
+    mkdir -p \
+      __tmp_inject_files/files \
+      __tmp_inject_files/roles \
+      __tmp_inject_files/tasks \
+      __tmp_inject_files/templates
+    cp \
+      roles/resolv_conf/templates/resolv.conf.j2 \
+      roles/stackhpc.os-manila-mount/templates/ceph.conf.j2 \
+      roles/stackhpc.os-manila-mount/templates/ceph.keyring.j2 \
+      __tmp_inject_files/templates/
+    cp \
+      roles/resolv_conf/files/NetworkManager-dns-none.conf \
+      __tmp_inject_files/files/
+    cp -r \
+      roles/basic_users \
+      roles/cacerts \
+      roles/sssd \
+      roles/sshd \
+      roles/stackhpc.nfs \
+      roles/mrlesmithjr.chrony \
+      roles/lustre \
+      roles/nhc \
+      roles/eessi \
+      roles/mounts \
+      roles/journald \
+      __tmp_inject_files/roles/
+    cp \
+      roles/tuned/tasks/configure.yml \
+      __tmp_inject_files/tasks/tuned.yml
+  args:
+    chdir: "{{ role_path }}/../.."  # this is $APPLIANCES_REPO_ROOT/ansible
+
 - name: Inject files from roles
   ansible.posix.synchronize:
-    src: "{{ item.src }}"
-    dest: "/etc/ansible-init/playbooks/{{ item.dest }}"
+    src: "{{ role_path }}/../../__tmp_inject_files/"
+    dest: "/etc/ansible-init/playbooks/"
     archive: true
     rsync_opts:
       - "-p"
@@ -25,39 +62,12 @@
     recursive: true
     use_ssh_args: true
   become: true
-  loop:
-    - src: ../../resolv_conf/templates/resolv.conf.j2
-      dest: templates/resolv.conf.j2
-    - src: ../../stackhpc.os-manila-mount/templates/ceph.conf.j2
-      dest: templates/ceph.conf.j2
-    - src: ../../stackhpc.os-manila-mount/templates/ceph.keyring.j2
-      dest: templates/ceph.keyring.j2
-    - src: ../../resolv_conf/files/NetworkManager-dns-none.conf
-      dest: files/NetworkManager-dns-none.conf
-    - src: ../../basic_users
-      dest: roles/
-    - src: ../../cacerts
-      dest: roles/
-    - src: ../../sssd
-      dest: roles/
-    - src: ../../sshd
-      dest: roles/
-    - src: ../../tuned/tasks/configure.yml
-      dest: tasks/tuned.yml
-    - src: ../../stackhpc.nfs
-      dest: roles/
-    - src: ../../mrlesmithjr.chrony
-      dest: roles/
-    - src: ../../lustre
-      dest: roles/
-    - src: ../../nhc
-      dest: roles/
-    - src: ../../eessi
-      dest: roles/
-    - src: ../../mounts
-      dest: roles/
-    - src: ../../journald
-      dest: roles/
+
+- name: Cleanup Inject files from roles
+  delegate_to: localhost
+  ansible.builtin.file:
+    path: "{{ role_path }}/../../__tmp_inject_files"
+    state: absent
 
 - name: Add filter_plugins to ansible.cfg
   ansible.builtin.lineinfile:

--- a/dev/setup-env.sh
+++ b/dev/setup-env.sh
@@ -39,7 +39,9 @@ fi
 pip install -U pip
 pip install -r requirements.txt
 ansible --version
-# Install or update ansible dependencies ...
-ansible-galaxy role install -fr requirements.yml -p ansible/roles
-ansible-galaxy collection install -fr requirements.yml -p ansible/collections
-cp requirements.yml requirements.yml.last
+if ! "${SKIP_ANSIBLE_GALAXY:-false}"; then
+  # Install or update ansible dependencies ...
+  ansible-galaxy role install -fr requirements.yml -p ansible/roles
+  ansible-galaxy collection install -fr requirements.yml -p ansible/collections
+  cp requirements.yml requirements.yml.last
+fi

--- a/environments/.stackhpc/inventory/group_vars/builder.yml
+++ b/environments/.stackhpc/inventory/group_vars/builder.yml
@@ -17,3 +17,8 @@ pulp_site_upstream_password: "{{ lookup('ansible.builtin.env', 'ARK_PASSWORD') }
 # Open Ondemand osc.ood package installs - see ansible/roles/osc.ood/tasks/install-package.yml
 install_ondemand_dex: true # install DEX
 oidc_uri: '' # install mod_auth_openidc for OIDC
+
+# Speed-up build by avoiding copying binaries from runner to packer VM
+alertmanager_download_host: "{{ inventory_hostname }}"
+node_exporter_download_host: "{{ inventory_hostname }}"
+prometheus_download_host: "{{ inventory_hostname }}"

--- a/packer/openstack.pkr.hcl
+++ b/packer/openstack.pkr.hcl
@@ -167,6 +167,12 @@ variable "image_name_version" {
   default = "auto"
 }
 
+variable "playbook" {
+  type = string
+  description = "Playbook to use by the ansible provisionner"
+  default = "fatimage.yml"
+}
+
 source "openstack" "openhpc" {
   # Build VM:
   flavor = var.flavor
@@ -214,7 +220,7 @@ build {
   }
 
   provisioner "ansible" {
-    playbook_file = "${var.repo_root}/ansible/fatimage.yml"
+    playbook_file = "${var.repo_root}/ansible/${var.playbook}"
     groups = concat(["builder"], var.inventory_groups == "" ? [] : split(",", var.inventory_groups))
     keep_inventory_file = true # for debugging
     use_proxy = false # see https://www.packer.io/docs/provisioners/ansible#troubleshooting

--- a/requirements.yml
+++ b/requirements.yml
@@ -52,4 +52,4 @@ collections:
   - name: prometheus.prometheus
     source: https://github.com/stackhpc/prometheus-community-ansible
     type: git
-    version: 0.28.0+stackhpc.1
+    version: ft/configurable-download-host


### PR DESCRIPTION
New `ansible/baseimage.yml` playbook doing:
 - package updates
 - disable SELinux
 - create system users
 - install a few big packages (podman, cvmfs, R, squid, Xfce)
It tries to hit the good balance between a good build speedup and being vulnerable to code or params changes.

New `build-baseimage.yml` workflow. Trigger it manually when you change `dnf_repo_timestamps.yml` or the new `baseimage.yml` playbook.
It builds a base image with name `base-RL<8|9>-<sha256 of dnf_repo_timestamps>`. 

The fatimage.yml workflow checks if a base image with such name exists and if it does it uses it. Otherwise it falls back to the upstream image as base. All roles are still applied in the fatimage build, to make it (almost) oblivious of using baseimage.

Examples of inconsistencies:
- if we upgrade `dnf_repo_timestamps.yml`, we build from scratch until a new baseimage is produced. This is not a problem.
 - if a system user is removed after baseimage is built, it will be present in the fatimage build because users won't be removed by it. We shouldn't attempt to correct this kind of things in playbooks: just rebuild the baseimage with the minimal content.
 - if we don't need some packages pre-installed in baseimage, they will still be there until next rebuild. This could trip us, when we remove them, re-run fatimage and see it still working. We could potentially include a checksum of the baseimage.yml playbook, but it would not cover variable use. Better rebuild baseimage regularly