### PR TITLE
Squid - limit default acl ports

### DIFF
--- a/ansible/roles/squid/README.md
+++ b/ansible/roles/squid/README.md
@@ -52,7 +52,7 @@ These role variables apply to both `squid_conf_mode` settings.
 
 - `squid_acls`: Optional str, can be multiline. Define access lists. Default is
   `acl local_nodes src {{ squid_local_nodes_cidr }}`, i.e. only permit connections
-  from address in defined CIDR. In this mode acls for `SSL_ports` and `Safe_ports`
+  from address in defined CIDR. In this mode acls for `TLS_ports` and `Safe_ports`
   are also defined as is common practice.
 - `squid_http_access`: Optional str, can be multiline. Allow/deny access based
   on access lists. Default:
@@ -60,8 +60,8 @@ These role variables apply to both `squid_conf_mode` settings.
   ```text
   # Deny requests to certain unsafe ports
   http_access deny !Safe_ports
-  # Deny CONNECT to other than secure SSL ports
-  http_access deny CONNECT !SSL_ports
+  # Deny CONNECT to other than secure TLS ports
+  http_access deny CONNECT !TLS_ports
   # Only allow cachemgr access from localhost
   http_access allow localhost manager
   http_access deny manager

--- a/ansible/roles/squid/defaults/main.yml
+++ b/ansible/roles/squid/defaults/main.yml
@@ -21,8 +21,8 @@ squid_acls: "acl local_nodes src {{ squid_local_nodes_cidr }}"
 squid_http_access: |
   # Deny requests to certain unsafe ports
   http_access deny !Safe_ports
-  # Deny CONNECT to other than secure SSL ports
-  http_access deny CONNECT !SSL_ports
+  # Deny CONNECT to other than secure TLS ports
+  http_access deny CONNECT !TLS_ports
   # Only allow cachemgr access from localhost
   http_access allow localhost manager
   http_access deny manager

--- a/ansible/roles/squid/templates/squid-general.conf.j2
+++ b/ansible/roles/squid/templates/squid-general.conf.j2
@@ -9,15 +9,7 @@ acl local_nodes src {{ squid_local_nodes_cidr }}
 
 acl SSL_ports port 443
 acl Safe_ports port 80		# http
-acl Safe_ports port 21		# ftp
 acl Safe_ports port 443		# https
-acl Safe_ports port 70		# gopher
-acl Safe_ports port 210		# wais
-acl Safe_ports port 1025-65535	# unregistered ports
-acl Safe_ports port 280		# http-mgmt
-acl Safe_ports port 488		# gss-http
-acl Safe_ports port 591		# filemaker
-acl Safe_ports port 777		# multiling http
 acl CONNECT method CONNECT
 
 # Rules allowing http access

--- a/ansible/roles/squid/templates/squid-general.conf.j2
+++ b/ansible/roles/squid/templates/squid-general.conf.j2
@@ -7,7 +7,7 @@
 # Define ACLs:
 acl local_nodes src {{ squid_local_nodes_cidr }}
 
-acl SSL_ports port 443
+acl TLS_ports port 443
 acl Safe_ports port 80		# http
 acl Safe_ports port 443		# https
 acl CONNECT method CONNECT


### PR DESCRIPTION
The default Squid config considers ports for several ancient protocols to be needed and safe.

We really don't (or shouldn't) need Gopher,  WAIS or FTP enabled by default in 2026, so this change removes all ports except for 80 and 443.

A second commit also renames SSL to TLS, in the spirit of updating things.

Mitigates CVE-2026-47729.