### PR TITLE
Update RockyLinux 8.10 inc. OpenHPC v2.10, disable act_pedit

### DIFF
--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -227,7 +227,7 @@ jobs:
           . environments/.stackhpc/activate
           ansible all -m wait_for_connection
           ansible-playbook ansible/adhoc/generate-passwords.yml
-          ansible-playbook -v ansible/site.yml
+          ansible-playbook -vv ansible/site.yml
           ansible-playbook -v ansible/ci/check_slurm.yml
 
       - name: Reimage compute nodes to image in current branch using slurm

--- a/.github/workflows/stackhpc.yml
+++ b/.github/workflows/stackhpc.yml
@@ -227,7 +227,7 @@ jobs:
           . environments/.stackhpc/activate
           ansible all -m wait_for_connection
           ansible-playbook ansible/adhoc/generate-passwords.yml
-          ansible-playbook -vv ansible/site.yml
+          ansible-playbook -v ansible/site.yml
           ansible-playbook -v ansible/ci/check_slurm.yml
 
       - name: Reimage compute nodes to image in current branch using slurm

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -578,6 +578,42 @@ ignore:
 
 # CVE-2026-39831/GO-2026-5019: Invoking bypass of FIDO/U2F security keys physical interaction in golang.org/x/crypto/ssh
 # Ignore: not using ssh
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/bin/apptainer
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/local/bin/node_exporter
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/share/grafana/bin/grafana
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/local/bin/promtool
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/sbin/ondemand-dex-session
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/libexec/apptainer/bin/starter
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/libexec/apptainer/bin/gocryptfs
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/local/bin/alertmanager
+  - vulnerability: GO-2026-5019
+    package:
+      location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/local/bin/amtool
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/local/bin/prometheus
+  - vulnerability: GO-2026-5019
+    package:
+      location: /usr/sbin/ondemand-dex
   - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/bin/apptainer

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -323,7 +323,7 @@ ignore:
     package:
       location: /usr/sbin/ondemand-dex
 
-# CVE-2026-39834/GO-2026-5020: ssh doens't make progress for data > 4GB in single write call
+# CVE-2026-39834/GO-2026-5020: ssh doesn't make progress for data > 4GB in single write call
 # Ignore: Not using ssh
   - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
@@ -361,6 +361,43 @@ ignore:
   - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/sbin/ondemand-dex
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/bin/apptainer
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/local/bin/node_exporter
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/share/grafana/bin/grafana
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/local/bin/promtool
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/sbin/ondemand-dex-session
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/libexec/apptainer/bin/starter
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/libexec/apptainer/bin/gocryptfs
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/local/bin/alertmanager
+  - vulnerability: GO-2026-5020
+    package:
+      location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/local/bin/amtool
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/local/bin/prometheus
+  - vulnerability: GO-2026-5020
+    package:
+      location: /usr/sbin/ondemand-dex
+
 
 # CVE-2026-39821: Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
 # govulncheck -mode=binary found no issue:
@@ -539,42 +576,42 @@ ignore:
     package:
       location: /usr/sbin/ondemand-dex
 
-# CVE-2026-39831: Invoking bypass of FIDO/U2F security keys physical interaction in golang.org/x/crypto/ssh
+# CVE-2026-39831/GO-2026-5019: Invoking bypass of FIDO/U2F security keys physical interaction in golang.org/x/crypto/ssh
 # Ignore: not using ssh
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/bin/apptainer
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/local/bin/node_exporter
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/share/grafana/bin/grafana
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/local/bin/promtool
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/sbin/ondemand-dex-session
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/libexec/apptainer/bin/starter
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/libexec/apptainer/bin/gocryptfs
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/local/bin/alertmanager
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/local/bin/amtool
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/local/bin/prometheus
-  - vulnerability: GO-2026-5019
+  - vulnerability: GHSA-89gr-r52h-f8rx
     package:
       location: /usr/sbin/ondemand-dex
 

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -188,44 +188,44 @@ ignore:
     package:
       location: /var/www/ood/apps/sys/dashboard/Gemfile.lock
 
-# CVE-2026-39832: # https://nvd.nist.gov/vuln/detail/CVE-2026-39832
+# CVE-2026-39832/GO-2026-5006: # https://nvd.nist.gov/vuln/detail/CVE-2026-39832
 # Destination restrictions are stripped when adding ssh keys to remote agents,
 # allowing unrestricted use of the key on the remote host
 # Ignore: Packages don't use ssh
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/bin/apptainer
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/local/bin/node_exporter
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/share/grafana/bin/grafana
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/local/bin/promtool
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/sbin/ondemand-dex-session
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/libexec/apptainer/bin/starter
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/libexec/apptainer/bin/gocryptfs
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/local/bin/alertmanager
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/local/bin/amtool
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/local/bin/prometheus
-  - vulnerability: GO-2026-5006
+  - vulnerability: GHSA-f5wc-c3c7-36mc
     package:
       location: /usr/sbin/ondemand-dex
 
@@ -245,120 +245,120 @@ ignore:
     package:
       location: /usr/share/grafana/bin/grafana
 
-# CVE-2026-46595: Extension of CVE-2024-45337 to non-public-key callbacks
+# CVE-2026-46595/GO-2026-5023: Extension of CVE-2024-45337 to non-public-key callbacks
 # Ignore: Not using ssh
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/bin/apptainer
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/local/bin/node_exporter
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/share/grafana/bin/grafana
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/local/bin/promtool
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/sbin/ondemand-dex-session
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/libexec/apptainer/bin/starter
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/libexec/apptainer/bin/gocryptfs
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/local/bin/alertmanager
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/local/bin/amtool
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/local/bin/prometheus
-  - vulnerability: GO-2026-5023
+  - vulnerability: GHSA-x527-x647-q7gg
     package:
       location: /usr/sbin/ondemand-dex
 
-# CVE-2026-39830: ssh connection blocked by unsolicited global request responses
+# CVE-2026-39830/GO-2026-5017: ssh connection blocked by unsolicited global request responses
 # Ignore: Not using ssh
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/bin/apptainer
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/local/bin/node_exporter
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/share/grafana/bin/grafana
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/local/bin/promtool
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/sbin/ondemand-dex-session
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/libexec/apptainer/bin/starter
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/libexec/apptainer/bin/gocryptfs
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/local/bin/alertmanager
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/local/bin/amtool
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/local/bin/prometheus
-  - vulnerability: GO-2026-5017
+  - vulnerability: GHSA-vgwf-h737-ff37
     package:
       location: /usr/sbin/ondemand-dex
 
-# CVE-2026-39834: ssh doens't make progress for data > 4GB in single write call
+# CVE-2026-39834/GO-2026-5020: ssh doens't make progress for data > 4GB in single write call
 # Ignore: Not using ssh
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/bin/apptainer
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/local/bin/node_exporter
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/share/grafana/bin/grafana
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/local/bin/promtool
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/sbin/ondemand-dex-session
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/libexec/apptainer/bin/starter
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/libexec/apptainer/bin/gocryptfs
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/local/bin/alertmanager
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/local/bin/amtool
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/local/bin/prometheus
-  - vulnerability: GO-2026-5020
+  - vulnerability: GHSA-rm3j-f69w-wqmq
     package:
       location: /usr/sbin/ondemand-dex
 
@@ -422,42 +422,42 @@ ignore:
     package:
       location: /usr/sbin/ondemand-dex-session
 
-# CVE-2026-39833: Invoking key constraints not enforced in golang.org/x/crypto/ssh/agent
+# CVE-2026-39833/GO-2026-5005: Invoking key constraints not enforced in golang.org/x/crypto/ssh/agent
 # Ignore: Not using ssh
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/bin/apptainer
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/local/bin/node_exporter
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/share/grafana/bin/grafana
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/local/bin/promtool
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/sbin/ondemand-dex-session
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/libexec/apptainer/bin/starter
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/libexec/apptainer/bin/gocryptfs
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/local/bin/alertmanager
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/local/bin/amtool
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/local/bin/prometheus
-  - vulnerability: GO-2026-5005
+  - vulnerability: GHSA-jppx-rxg9-jmrx
     package:
       location: /usr/sbin/ondemand-dex
 
@@ -500,42 +500,42 @@ ignore:
     package:
       location: /usr/sbin/ondemand-dex
 
-# CVE-2026-42508: Invoking auth bypass via unenforced @revoked status in golang.org/x/crypto/ssh/knownhosts
+# CVE-2026-42508/GO-2026-5021: Invoking auth bypass via unenforced @revoked status in golang.org/x/crypto/ssh/knownhosts
 # Ignore: not using ssh
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/bin/apptainer
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/local/bin/node_exporter
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/share/grafana/bin/grafana
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/local/bin/promtool
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/sbin/ondemand-dex-session
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/libexec/apptainer/bin/starter
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/libexec/apptainer/bin/gocryptfs
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/local/bin/alertmanager
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/local/bin/amtool
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/local/bin/prometheus
-  - vulnerability: GO-2026-5021
+  - vulnerability: GHSA-5cgq-3rg8-m6cv
     package:
       location: /usr/sbin/ondemand-dex
 

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -149,13 +149,6 @@ ignore:
     package:
       location: /usr/sbin/ondemand-dex-session
 
-
-# CVE-2026-33186 (GO-2026-4762) gRPC-Go server auth bypass -- TMP disable to check ignores are working
-# FIXME: should upgrade grafana to  Grafana 12.4.2
-  - vulnerability: GHSA-p77j-4mvh-x3m3
-    package:
-      location: /usr/share/grafana/bin/grafana
-
 # CVE-2024-45337 (GO-2024-3321) Misuse of ServerConfig.PublicKeyCallback -- not using ssh
   - vulnerability: GHSA-v778-237x-gjrc
     package:
@@ -447,17 +440,6 @@ ignore:
   - vulnerability: GO-2026-5026
     package:
       location: /usr/bin/ondemand_exporter
-# DEX: Negligible risk, unless used with IDNA URLs, which require an internationalised
-# domain name for the ondemand "servername" parameter. Leaving as fixme as should
-# patch when possible.
-# FIXME:
-  - vulnerability: GO-2026-5026
-    package:
-      location: /usr/sbin/ondemand-dex
-# FIXME:
-  - vulnerability: GO-2026-5026
-    package:
-      location: /usr/sbin/ondemand-dex-session
 
 # CVE-2026-39833/GO-2026-5005: Invoking key constraints not enforced in golang.org/x/crypto/ssh/agent
 # Ignore: Not using ssh

--- a/ansible/mitigations.yml
+++ b/ansible/mitigations.yml
@@ -77,3 +77,23 @@
         cmd: rmmod ip6_tunnel
       failed_when: false
       changed_when: true
+
+- name: Apply pedit COW (CVE-2026-46331) mitigation
+  hosts: mitigate_cve_2026_46331
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Prevent modules loading
+      ansible.builtin.copy:
+        dest: /etc/modprobe.d/cve_2026_46331.conf
+        owner: root
+        group: root
+        mode: u=rw,go=r
+        content: |
+          install act_pedit /bin/false
+    # below probably is not needed but is safer
+    - name: Unload modules
+      ansible.builtin.command:
+        cmd: rmmod act_pedit
+      failed_when: false
+      changed_when: true

--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -84,10 +84,6 @@
     - ansible.builtin.include_role:
         name: stackhpc.openhpc
         tasks_from: "{{ 'runtime.yml' if appliances_mode == 'configure' else 'main.yml' }}"
-      vars:
-        # We used python3.9 to install a recent pymysql version, with fixed SQL injection vulnerability
-        # It is needed in the stackhpc.openhpc/tasks/upgrade.yml
-        ansible_python_interpreter: /usr/bin/python3.9
 
     - name: Flush handler
       ansible.builtin.meta: flush_handlers # get fresh ansible_local.slurm facts

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260702-1250-dc51b044",
-    "RL9": "openhpc-RL9-260702-1250-dc51b044"
+    "RL8": "openhpc-RL8-260707-1610-61ab7b7a",
+    "RL9": "openhpc-RL9-260707-1348-61ab7b7a"
   }
 }

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260707-1610-61ab7b7a",
-    "RL9": "openhpc-RL9-260707-1348-61ab7b7a"
+    "RL8": "openhpc-RL8-260709-1110-095e2432",
+    "RL9": "openhpc-RL9-260709-1110-095e2432"
   }
 }

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260701-1309-c96fa636",
-    "RL9": "openhpc-RL9-260701-1309-c96fa636"
+    "RL8": "openhpc-RL8-260702-1250-dc51b044",
+    "RL9": "openhpc-RL9-260702-1250-dc51b044"
   }
 }

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -20,7 +20,7 @@ dnf_repos_default:
   OpenHPC-updates:
     '8':
       pulp_path: OpenHPC/2/updates/EL_8
-      pulp_timestamp: 20250512T003315
+      pulp_timestamp: 20260622T230143
       repo_file: OpenHPC
     '9':
       pulp_path: OpenHPC/3/updates/EL_9
@@ -47,7 +47,7 @@ dnf_repos_default:
   appstream:
     '8.10':
       pulp_path: rocky/8.10/AppStream/x86_64/os
-      pulp_timestamp: 20260626T221031
+      pulp_timestamp: 20260706T220507
       repo_file: Rocky-AppStream
     '9.4':
       pulp_path: rocky/9.4/AppStream/x86_64/os
@@ -72,7 +72,7 @@ dnf_repos_default:
   appstream-source:
     '8.10':
       pulp_path: rocky/8.10/AppStream/source/tree
-      pulp_timestamp: 20260625T224657
+      pulp_timestamp: 20260706T214107
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/AppStream/source/tree
@@ -89,7 +89,7 @@ dnf_repos_default:
   baseos:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/x86_64/os
-      pulp_timestamp: 20260626T221031
+      pulp_timestamp: 20260706T220507
       repo_file: Rocky-BaseOS
     '9.4':
       pulp_path: rocky/9.4/BaseOS/x86_64/os
@@ -114,7 +114,7 @@ dnf_repos_default:
   baseos-source:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/source/tree
-      pulp_timestamp: 20260626T212639
+      pulp_timestamp: 20260706T214107
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/BaseOS/source/tree
@@ -158,7 +158,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20260625T235148
+      pulp_timestamp: 20260706T220507
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -202,7 +202,7 @@ dnf_repos_default:
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
-      pulp_timestamp: 20260629T220539
+      pulp_timestamp: 20260706T214454
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/x86_64
@@ -216,7 +216,7 @@ dnf_repos_default:
   epel-source:
     '8':
       pulp_path: epel/8/Everything/source/tree
-      pulp_timestamp: 20260629T220539
+      pulp_timestamp: 20260706T214454
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/source/tree

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -47,7 +47,7 @@ dnf_repos_default:
   appstream:
     '8.10':
       pulp_path: rocky/8.10/AppStream/x86_64/os
-      pulp_timestamp: 20260605T221539
+      pulp_timestamp: 20260626T221031
       repo_file: Rocky-AppStream
     '9.4':
       pulp_path: rocky/9.4/AppStream/x86_64/os
@@ -72,7 +72,7 @@ dnf_repos_default:
   appstream-source:
     '8.10':
       pulp_path: rocky/8.10/AppStream/source/tree
-      pulp_timestamp: 20260606T213518
+      pulp_timestamp: 20260625T224657
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/AppStream/source/tree
@@ -89,7 +89,7 @@ dnf_repos_default:
   baseos:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/x86_64/os
-      pulp_timestamp: 20260605T221539
+      pulp_timestamp: 20260626T221031
       repo_file: Rocky-BaseOS
     '9.4':
       pulp_path: rocky/9.4/BaseOS/x86_64/os
@@ -114,7 +114,7 @@ dnf_repos_default:
   baseos-source:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/source/tree
-      pulp_timestamp: 20260606T213518
+      pulp_timestamp: 20260626T212639
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/BaseOS/source/tree
@@ -140,7 +140,7 @@ dnf_repos_default:
   cernvmfs_eessi_cfg:
     '8':
       pulp_path: eessi/rhel/8/noarch
-      pulp_timestamp: 20251119T202303
+      pulp_timestamp: 20260616T214234
       repo_file: cvmfs-config-eessi
     '9':
       pulp_path: eessi/rhel/8/noarch
@@ -158,7 +158,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20260531T214327
+      pulp_timestamp: 20260625T235148
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -202,7 +202,7 @@ dnf_repos_default:
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
-      pulp_timestamp: 20260610T221908
+      pulp_timestamp: 20260629T220539
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/x86_64
@@ -216,7 +216,7 @@ dnf_repos_default:
   epel-source:
     '8':
       pulp_path: epel/8/Everything/source/tree
-      pulp_timestamp: 20260610T221908
+      pulp_timestamp: 20260629T220539
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/source/tree
@@ -250,7 +250,7 @@ dnf_repos_default:
   extras-source:
     '8.10':
       pulp_path: rocky/8.10/extras/source/tree
-      pulp_timestamp: 20260506T212931
+      pulp_timestamp: 20260625T224657
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/extras/source/os
@@ -267,7 +267,7 @@ dnf_repos_default:
   grafana:
     '8':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260610T211431
+      pulp_timestamp: 20260701T070549
       repo_file: grafana
     '9':
       pulp_path: grafana/oss/rpm

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -53,10 +53,7 @@ openhpc_state_save_location: "{{ appliances_state_dir + '/slurmctld' if applianc
 openhpc_config_extra: {}
 
 # additional default slurm.conf parameters for the appliance:
-openhpc_config_default:
-  TaskPlugin: task/cgroup,task/affinity
-  ProctrackType: proctrack/cgroup
-  JobAcctGatherType: jobacct_gather/cgroup
+openhpc_config_default: {}
 
 # additional default slurm.conf parameters when "rebuild" enabled:
 openhpc_config_rebuild:

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -105,9 +105,6 @@ ohpc_default_extra_repos:
 # configure slurm database pre-upgrade backups:
 openhpc_slurm_accounting_storage_service: mysql
 openhpc_slurm_accounting_storage_backup_cmd: >-
-  echo $HOSTNAME &&
-  which openstack &&
-  echo $PATH &&
   openstack volume snapshot create
   --volume {{ openhpc_cluster_name }}-state
   --force

--- a/environments/common/inventory/group_vars/all/openhpc.yml
+++ b/environments/common/inventory/group_vars/all/openhpc.yml
@@ -105,6 +105,9 @@ ohpc_default_extra_repos:
 # configure slurm database pre-upgrade backups:
 openhpc_slurm_accounting_storage_service: mysql
 openhpc_slurm_accounting_storage_backup_cmd: >-
+  echo $HOSTNAME &&
+  which openstack &&
+  echo $PATH &&
   openstack volume snapshot create
   --volume {{ openhpc_cluster_name }}-state
   --force

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -241,3 +241,4 @@ doca
 [mitigate_dirtyfrag]
 [mitigate_ssh_keysign_pwn]
 [mitigate_cve_2026_43037]
+[mitigate_cve_2026_46331]

--- a/environments/site/inventory/groups
+++ b/environments/site/inventory/groups
@@ -224,3 +224,5 @@ builder
 builder
 [mitigate_cve_2026_43037:children]
 builder
+[mitigate_cve_2026_46331:children]
+builder

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: v26.2.1
     name: stackhpc.nfs
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v1.5.0
+    version: fix/mysql-interpreter # TODO: move to release
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-grafana.git
     name: cloudalchemy.grafana

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: v26.2.1
     name: stackhpc.nfs
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: fix/mysql-interpreter # TODO: move to release
+    version: v1.6.0
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-grafana.git
     name: cloudalchemy.grafana


### PR DESCRIPTION
- Update system packages on RockyLinux 8.10 including to kernel-core-4.18.0-553.136.1.el8_10 to fix CVE-2026-46331 (pedit-COW). Note system packages for RockyLinux 9.8 are not updated as kernel-core-5.14.0-687.17.1.el9_8 breaks DOCA-OFED.
- Disable kernel module `act_pedit` (on both OSes) to mitigate this CVE for RockyLinux 9.8.
- Update to [OpenHPC v2.10](https://github.com/openhpc/ohpc/releases/tag/v2.10.GA) on RockyLinux 8.10, including Slurm major upgrade from v23.11.10 -> v25.05.8.
- Update `stackhpc.openhpc` role to [v1.6.0](https://github.com/stackhpc/ansible-role-openhpc/releases/tag/v1.6.0), mostly moving appliance defaults into the role. However it fixes slurmdbd upgrade logic and does change defaults for the following `slurm.conf` parameters:
  - RebootProgram: unset -> `/sbin/reboot`: Allows `scontrol reboot` to be used to reboot nodes. If slurm controlled rebuild is configured this is overriden.
  - StateSaveLocation: `/var/spool/slurm` -> `/var/spool/slurmctld`: Slurmd state is lost on rebuild anyway so this is backwards-compatible.
  - [Amended 16/09/2026]: `SlurmdSpoolDir`: `/var/spool/slurm` -> slurm default of `/var/spool/slurmd`. **WARNING: THIS WILL BREAK RUNNING JOBS**