### PR TITLE
Support attaching pre-existing volumes to node groups

### DIFF
--- a/environments/site/tofu/inventory.tpl
+++ b/environments/site/tofu/inventory.tpl
@@ -29,6 +29,7 @@ ${cluster_name}_${group_name}:
             networks: ${jsonencode({for n in node.network: n.name => {"fixed_ip_v4": n.fixed_ip_v4, "fixed_ip_v6": n.fixed_ip_v6}})}
             node_fqdn: ${login_groups[group_name]["fqdns"][nodename]}
             node_fip: ${login_groups[group_name]["nodegroup_fips"][nodename]}
+            volumes: ${jsonencode(try(login_groups[group_name]["volumes"][nodename], {}))}
 %{ endfor ~}
 
 ${group_name}:
@@ -53,6 +54,7 @@ ${cluster_name}_${group_name}:
             instance_id: ${ node.id }
             networks: ${jsonencode({for n in node.network: n.name => {"fixed_ip_v4": n.fixed_ip_v4, "fixed_ip_v6": n.fixed_ip_v6}})}
             node_fqdn: ${compute_groups[group_name]["fqdns"][nodename]}
+            volumes: ${jsonencode(try(compute_groups[group_name]["volumes"][nodename], {}))}
 %{ endfor ~}
     vars:
         # NB: this is the target image, not necessarily what is provisioned

--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -9,6 +9,8 @@ locals {
   # this is a mapping with
   # keys "compute-0-vol-a", "compute-0-vol-b" ...
   # values which are a mapping e.g. {"node"="compute-0", "volume"="vol-a"}
+  all_compute_volume_ids = {for k, v in local.all_compute_volumes: k => try(openstack_blockstorage_volume_v3.compute[k].id, data.openstack_blockstorage_volume_v3.compute[k].id) }
+  
 
   # Workaround for lifecycle meta-argument only taking static values
   compute_instances = var.ignore_image_changes ? openstack_compute_instance_v2.compute_fixed_image : openstack_compute_instance_v2.compute
@@ -34,9 +36,14 @@ locals {
   baremetal_az = var.availability_zone != null ? var.availability_zone : "nova"
 }
 
+data "openstack_blockstorage_volume_v3" "compute" {
+  for_each = {for k, v in local.all_compute_volumes: k => v if var.extra_volumes[v.volume].size == null}
+  name        = "${var.cluster_name}-${each.key}"
+}
+
 resource "openstack_blockstorage_volume_v3" "compute" {
 
-  for_each = local.all_compute_volumes
+  for_each = {for k, v in local.all_compute_volumes: k => v if var.extra_volumes[v.volume].size != null}
 
   name        = "${var.cluster_name}-${each.key}"
   description = "Compute node ${each.value.node} volume ${each.value.volume}"
@@ -49,7 +56,7 @@ resource "openstack_compute_volume_attach_v2" "compute" {
   for_each = local.all_compute_volumes
 
   instance_id = local.compute_instances[each.value.node].id
-  volume_id   = openstack_blockstorage_volume_v3.compute[each.key].id
+  volume_id   = local.all_compute_volume_ids[each.key]
 }
 
 resource "openstack_networking_port_v2" "compute" {
@@ -237,4 +244,8 @@ output "fqdns" {
 
 output "nodegroup_fips" {
   value = local.nodegroup_fips
+}
+
+output "volumes" {
+  value = {for nn in var.nodes: nn => {for vn, vv in var.extra_volumes: vn => local.all_compute_volume_ids["${nn}-${vn}"]}}
 }

--- a/environments/site/tofu/node_group/nodes.tf
+++ b/environments/site/tofu/node_group/nodes.tf
@@ -9,8 +9,8 @@ locals {
   # this is a mapping with
   # keys "compute-0-vol-a", "compute-0-vol-b" ...
   # values which are a mapping e.g. {"node"="compute-0", "volume"="vol-a"}
-  all_compute_volume_ids = {for k, v in local.all_compute_volumes: k => try(openstack_blockstorage_volume_v3.compute[k].id, data.openstack_blockstorage_volume_v3.compute[k].id) }
-  
+  all_compute_volume_ids = { for k, v in local.all_compute_volumes : k => try(openstack_blockstorage_volume_v3.compute[k].id, data.openstack_blockstorage_volume_v3.compute[k].id) }
+
 
   # Workaround for lifecycle meta-argument only taking static values
   compute_instances = var.ignore_image_changes ? openstack_compute_instance_v2.compute_fixed_image : openstack_compute_instance_v2.compute
@@ -37,13 +37,13 @@ locals {
 }
 
 data "openstack_blockstorage_volume_v3" "compute" {
-  for_each = {for k, v in local.all_compute_volumes: k => v if var.extra_volumes[v.volume].size == null}
-  name        = "${var.cluster_name}-${each.key}"
+  for_each = { for k, v in local.all_compute_volumes : k => v if var.extra_volumes[v.volume].size == null }
+  name     = "${var.cluster_name}-${each.key}"
 }
 
 resource "openstack_blockstorage_volume_v3" "compute" {
 
-  for_each = {for k, v in local.all_compute_volumes: k => v if var.extra_volumes[v.volume].size != null}
+  for_each = { for k, v in local.all_compute_volumes : k => v if var.extra_volumes[v.volume].size != null }
 
   name        = "${var.cluster_name}-${each.key}"
   description = "Compute node ${each.value.node} volume ${each.value.volume}"
@@ -247,5 +247,5 @@ output "nodegroup_fips" {
 }
 
 output "volumes" {
-  value = {for nn in var.nodes: nn => {for vn, vv in var.extra_volumes: vn => local.all_compute_volume_ids["${nn}-${vn}"]}}
+  value = { for nn in var.nodes : nn => { for vn, vv in var.extra_volumes : vn => local.all_compute_volume_ids["${nn}-${vn}"] } }
 }

--- a/environments/site/tofu/node_group/variables.tf
+++ b/environments/site/tofu/node_group/variables.tf
@@ -65,7 +65,7 @@ variable "extra_volumes" {
         EOF
   type = map(
     object({
-      size        = number
+      size        = optional(number)
       volume_type = optional(string)
     })
   )

--- a/environments/site/tofu/variables.tf
+++ b/environments/site/tofu/variables.tf
@@ -65,12 +65,15 @@ variable "login" {
       vnic_types: Overrides variable vnic_types
       volume_backed_instances: Overrides variable volume_backed_instances
       root_volume_size: Overrides variable root_volume_size
-      extra_volumes: Mapping defining additional volumes to create and attach
-                     Keys are unique volume name.
-                     Values are a mapping with:
-                          size: Size of volume in GB
-                          volume_type: Optional. Type of volume, or cloud default
-                     **NB**: The order in /dev is not guaranteed to match the mapping
+      extra_volumes: Mapping defining additional volumes. Keys are a unique volume
+                     name. Values are a mapping with:
+                      - size: Optional. Size of volume to create in GB.
+                      - volume_type: Optional. Type of volume, or cloud default.
+                     If size is not given then a volume `cluster_name-node-volume_key`
+                     must already exist, where `node` is an entry in this group's
+                     `nodes` parameter. Such volumes will not be managed by the
+                     appliance.
+                     **NB**: The order in /dev is not guaranteed to match the mapping.
       fip_addresses: List of addresses of floating IPs to associate with
                      nodes, in the same order as nodes parameter. The
                      floating IPs must already be allocated to the project.
@@ -136,12 +139,15 @@ variable "compute" {
       ignore_image_changes: Ignore changes to the image_id parameter (see docs/experimental/compute-init.md)
       volume_backed_instances: Overrides variable volume_backed_instances
       root_volume_size: Overrides variable root_volume_size
-      extra_volumes: Mapping defining additional volumes to create and attach
-                     Keys are unique volume name.
-                     Values are a mapping with:
-                          size: Size of volume in GB
-                          volume_type: Optional. Type of volume, or cloud default
-                     **NB**: The order in /dev is not guaranteed to match the mapping
+      extra_volumes: Mapping defining additional volumes. Keys are a unique volume
+                     name. Values are a mapping with:
+                      - size: Optional. Size of volume to create in GB.
+                      - volume_type: Optional. Type of volume, or cloud default.
+                     If size is not given then a volume `cluster_name-node-volume_key`
+                     must already exist, where `node` is an entry in this group's
+                     `nodes` parameter. Such volumes will not be managed by the
+                     appliance.
+                     **NB**: The order in /dev is not guaranteed to match the mapping.
       ip_addresses: Mapping of list of fixed IP addresses for nodes, keyed
                     by network name, in same order as nodes parameter.
                     For any networks not specified here the cloud will


### PR DESCRIPTION
The login and compute nodegroups parameter `extra_volumes` can now attach to existing volumes. For both managed and existing volumes, the volume UUID is now provided as hostvars via the templated inventory.

Tested using the following where volumes for "dev-extra-{0,1}-foo" already exist (because `size` is not given) and it creates volumes for "dev-extra-{0,1}-bar".

```
# environments/.stackhpc/tofu/main.tf:
...
     extra = {
      nodes = ["extra-0", "extra-1"]
       flavor = var.other_node_flavor
      extra_volumes = {
        foo = {
        }
        bar = {
          size = 1
        }
      }
...
```

with `openstack volume list` showing volumes attached to correct instances:
```
| d4fbf3cd-5313-41d3-a184-52c10b1c130c | dev-extra-1-bar                           | in-use    |    1 | Attached to dev-extra-1 on /dev/vdc          |
| 30923c99-1e10-4abf-b347-93bc92793895 | dev-extra-0-bar                           | in-use    |    1 | Attached to dev-extra-0 on /dev/vdc          |
| 9702b1aa-9870-4a39-9ccc-9cb8c33482e9 | dev-extra-1-foo                           | in-use    |    2 | Attached to dev-extra-1 on /dev/vdb          |
| 8d4b4f9d-958a-45ee-a724-80f5a68a1d4c | dev-extra-0-foo                           | in-use    |    1 | Attached to dev-extra-0 on /dev/vdb 
```

and the inventory being the correct way around:
```yaml
# environments/.stackhpc/inventory/hosts.yml:
...
dev_head:
    hosts:
        dev-login-0:
            ansible_host: 172.16.0.132
            instance_id: 50504e1a-805f-4392-bba6-6a6b9a442bbb
            image_id: 399c3446-557b-450f-812e-bcbabd507a55
            networks: {"stackhpc-ipv4-geneve":{"fixed_ip_v4":"172.16.0.132","fixed_ip_v6":""}}
            node_fqdn: dev-login-0.dev.internal
            node_fip: 
            volumes: {}
...
dev_extra:
    hosts:
        dev-extra-0:
            ansible_host: 172.16.0.90
            instance_id: 878d7c87-0184-43ff-8141-c72607a077c3
            networks: {"stackhpc-ipv4-geneve":{"fixed_ip_v4":"172.16.0.90","fixed_ip_v6":""}}
            node_fqdn: dev-extra-0.dev.internal
            volumes: {"bar":"30923c99-1e10-4abf-b347-93bc92793895","foo":"8d4b4f9d-958a-45ee-a724-80f5a68a1d4c"}
        dev-extra-1:
            ansible_host: 172.16.1.31
            instance_id: d9f7d9b9-df16-4196-9792-66f5001bab69
            networks: {"stackhpc-ipv4-geneve":{"fixed_ip_v4":"172.16.1.31","fixed_ip_v6":""}}
            node_fqdn: dev-extra-1.dev.internal
            volumes: {"bar":"d4fbf3cd-5313-41d3-a184-52c10b1c130c","foo":"9702b1aa-9870-4a39-9ccc-9cb8c33482e9"}
...
```