### PR TITLE
Update OS packages to fix ghostlock in RL9

### DIFF
--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -42,7 +42,7 @@ jobs:
             volume_size: 35 # needed for cuda
           - image_name: openhpc-extra-RL9
             source_image_name_key: RL9
-            inventory_groups: doca,cuda
+            inventory_groups: cuda # doca disabled due to no RL9.8 kernel compatibility
             volume_size: 35 # needed for cuda
     env:
       ANSIBLE_FORCE_COLOR: 'true'

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260709-1110-095e2432",
-    "RL9": "openhpc-RL9-260709-1110-095e2432"
+    "RL8": "openhpc-RL8-260715-0828-72b8075d",
+    "RL9": "openhpc-RL9-260715-0828-72b8075d"
   }
 }

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -47,7 +47,7 @@ dnf_repos_default:
   appstream:
     '8.10':
       pulp_path: rocky/8.10/AppStream/x86_64/os
-      pulp_timestamp: 20260706T220507
+      pulp_timestamp: 20260714T215346
       repo_file: Rocky-AppStream
     '9.4':
       pulp_path: rocky/9.4/AppStream/x86_64/os
@@ -67,12 +67,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/AppStream/x86_64/os
-      pulp_timestamp: 20260605T221153
+      pulp_timestamp: 20260714T213458
       repo_file: rocky
   appstream-source:
     '8.10':
       pulp_path: rocky/8.10/AppStream/source/tree
-      pulp_timestamp: 20260706T214107
+      pulp_timestamp: 20260712T231534
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/AppStream/source/tree
@@ -84,12 +84,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/AppStream/source/tree
-      pulp_timestamp: 20260605T225017
+      pulp_timestamp: 20260712T233423
       repo_file: rocky
   baseos:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/x86_64/os
-      pulp_timestamp: 20260706T220507
+      pulp_timestamp: 20260714T215346
       repo_file: Rocky-BaseOS
     '9.4':
       pulp_path: rocky/9.4/BaseOS/x86_64/os
@@ -109,12 +109,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/x86_64/os
-      pulp_timestamp: 20260606T221517
+      pulp_timestamp: 20260714T220645
       repo_file: rocky
   baseos-source:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/source/tree
-      pulp_timestamp: 20260706T214107
+      pulp_timestamp: 20260714T211343
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/BaseOS/source/tree
@@ -126,7 +126,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/source/tree
-      pulp_timestamp: 20260605T225017
+      pulp_timestamp: 20260713T053209
       repo_file: rocky
   cernvmfs_cfg:
     '8':
@@ -144,7 +144,7 @@ dnf_repos_default:
       repo_file: cvmfs-config-eessi
     '9':
       pulp_path: eessi/rhel/8/noarch
-      pulp_timestamp: 20251119T202303
+      pulp_timestamp: 20260616T214234
       repo_file: cvmfs-config-eessi
   cernvmfs_pkgs:
     '8':
@@ -158,7 +158,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20260706T220507
+      pulp_timestamp: 20260714T215346
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -179,12 +179,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/CRB/x86_64/os
-      pulp_timestamp: 20260605T221153
+      pulp_timestamp: 20260714T213458
       repo_file: rocky
   crb-source:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/source/tree
-      pulp_timestamp: 20260514T213644
+      pulp_timestamp: 20260709T213322
       repo_file: Rocky-Sources
       repo_name: powertools-source
     '9.6':
@@ -197,16 +197,16 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/CRB/source/tree
-      pulp_timestamp: 20260531T220752
+      pulp_timestamp: 20260710T221031
       repo_file: rocky
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
-      pulp_timestamp: 20260706T214454
+      pulp_timestamp: 20260713T214000
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/x86_64
-      pulp_timestamp: 20260610T221908
+      pulp_timestamp: 20260714T212748
       repo_file: epel
   epel-cisco-openh264:
     '9':
@@ -216,11 +216,11 @@ dnf_repos_default:
   epel-source:
     '8':
       pulp_path: epel/8/Everything/source/tree
-      pulp_timestamp: 20260706T214454
+      pulp_timestamp: 20260713T214000
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/source/tree
-      pulp_timestamp: 20260610T221908
+      pulp_timestamp: 20260708T214809
       repo_file: epel
   extras:
     '8.10':
@@ -250,7 +250,7 @@ dnf_repos_default:
   extras-source:
     '8.10':
       pulp_path: rocky/8.10/extras/source/tree
-      pulp_timestamp: 20260625T224657
+      pulp_timestamp: 20260710T211745
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/extras/source/os
@@ -267,18 +267,18 @@ dnf_repos_default:
   grafana:
     '8':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260701T070549
+      pulp_timestamp: 20260711T203515
       repo_file: grafana
     '9':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260610T211431
+      pulp_timestamp: 20260711T203515
       repo_file: grafana
   ondemand-web:
     '8':
       pulp_path: ondemand/4.1/web/el8/x86_64
-      pulp_timestamp: 20260505T205939
+      pulp_timestamp: 20260708T211238
       repo_file: ondemand-web
     '9':
       pulp_path: ondemand/4.1/web/el9/x86_64
-      pulp_timestamp: 20260430T204741
+      pulp_timestamp: 20260707T211425
       repo_file: ondemand-web


### PR DESCRIPTION
Updates all dnf packages to latest timestamps. This includes a fix for CVE-2026-43499 (ghostlock) in the RockyLinux 9 image only.

> [!IMPORTANT]
> NVIDIA doca-ofed is currently not compatible with the latest RockyLinux 9.8 kernel. Upgrades to this appliance version should **not** include `doca` in any site image builds.

Kernel updates:
- RL9: 5.14.0-687.12.1.el9_8.x86_64 -> 5.14.0-687.25.1.el9_8.x86_64
- RL8: 4.18.0-553.137.1.el8_10.x86_64 -> 4.18.0-553.141.1.el8_10.x86_64