### PR TITLE
Update OS packages to fix ghostlock in RL8

### DIFF
--- a/ansible/ci/check_compute_rebuild.yml
+++ b/ansible/ci/check_compute_rebuild.yml
@@ -3,7 +3,7 @@
   become: false
   tasks:
     - name: Set localhost fact for appliance image version
-      set_fact:
+      ansible.builtin.set_fact:
         appliance_image_label: "RL{{ ansible_distribution_major_version }}"
       delegate_to: localhost
       delegate_facts: true
@@ -28,7 +28,7 @@
       changed_when: true
 
     - name: Get cluster image file contents at latest release
-      ansible.builtin.command:
+      ansible.builtin.command: # noqa: command-instead-of-module
         cmd: "git show {{ ci_latest_release_tag }}:environments/.stackhpc/tofu/cluster_image.auto.tfvars.json"
       register: git_show_cluster_image
       changed_when: false
@@ -38,7 +38,8 @@
         ci_cluster_image_updated: "{{ latest_release_image != current_image }}"
       vars:
         latest_release_image: "{{ (git_show_cluster_image.stdout | from_json).cluster_image[appliance_image_label] }}"
-        current_image: "{{ (lookup('file', 'environments/.stackhpc/tofu/cluster_image.auto.tfvars.json') | from_json).cluster_image[appliance_image_label] }}"
+        current_image: "{{ (lookup('file', cluster_image_file_abspath) | from_json).cluster_image[appliance_image_label] }}"
+        cluster_image_file_abspath: "{{ appliances_repository_root }}/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json"
 
 - ansible.builtin.import_playbook: ../adhoc/rebuild-status.yml
 

--- a/ansible/ci/check_compute_rebuild.yml
+++ b/ansible/ci/check_compute_rebuild.yml
@@ -1,3 +1,13 @@
+- hosts: control
+  gather_facts: true
+  become: false
+  tasks:
+    - name: Set localhost fact for appliance image version
+      set_fact:
+        appliance_image_label: "RL{{ ansible_distribution_major_version }}"
+      delegate_to: localhost
+      delegate_facts: true
+
 - hosts: localhost
   become: false
   gather_facts: false
@@ -17,12 +27,18 @@
         chdir: "{{ appliances_repository_root }}"
       changed_when: true
 
+    - name: Get cluster image file contents at latest release
+      ansible.builtin.command:
+        cmd: "git show {{ ci_latest_release_tag }}:environments/.stackhpc/tofu/cluster_image.auto.tfvars.json"
+      register: git_show_cluster_image
+      changed_when: false
+
     - name: Check if current branch image differs from last release
-      ansible.builtin.command: # noqa: command-instead-of-module
-        cmd: "git diff {{ ci_latest_release_tag }} -- environments/.stackhpc/tofu/cluster_image.auto.tfvars.json"
-        chdir: "{{ appliances_repository_root }}"
-      changed_when: true
-      register: ci_diff_cluster_images
+      ansible.builtin.set_fact:
+        ci_cluster_image_updated: "{{ latest_release_image != current_image }}"
+      vars:
+        latest_release_image: "{{ (git_show_cluster_image.stdout | from_json).cluster_image[appliance_image_label] }}"
+        current_image: "{{ (lookup('file', 'environments/.stackhpc/tofu/cluster_image.auto.tfvars.json') | from_json).cluster_image[appliance_image_label] }}"
 
 - ansible.builtin.import_playbook: ../adhoc/rebuild-status.yml
 
@@ -44,7 +60,7 @@
       ansible.builtin.assert:
         that: rebuild_status.rebuild_count == 1
         fail_msg: "Expected 1 rebuild, found {{ rebuild_status.rebuild_count }}"
-      when: hostvars['localhost'].ci_diff_cluster_images.stdout != ''
+      when: hostvars['localhost'].ci_cluster_image_updated
 
     - name: Check uptime shows rebuild or reboot occurred
       ansible.builtin.assert:

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -68,31 +68,3 @@
     repo_name: "{{ repo_values.repo_name | default(item.key) }}"
     repo_content_url: "{{ repo_values.pulp_content_url | default(dnf_repos_pulp_content_url) }}"
 
-- name: Disable all Perl module streams on Rocky 8
-  ansible.builtin.command:
-    cmd: dnf module disable perl -y
-  changed_when: false
-  when:
-    - ansible_facts['distribution_major_version'] == "8"
-    - "'builder' in group_names"
-
-- name: Switch to Perl 5.24 module on Rocky 8 (workaround for conflicting module streams)
-  ansible.builtin.command:
-    cmd: dnf module enable perl:5.24 -y
-  changed_when: false
-  # NOTE: This can be dropped when the base image is bumped to a version with consistent
-  #       Perl module streams, but currently a newer base image does not exist.
-  when:
-    - ansible_facts['distribution_major_version'] == "8"
-    - "'builder' in group_names"
-
-- name: Sync all packages to repo versions (distro-sync)
-  # NOTE(wszumski): Sync all packages after configuring repos as packages in
-  # base image may be newer than snapshots or vice versa. This can lead to
-  # dependency hell.
-  ansible.builtin.command:
-    cmd: dnf distro-sync -y --allowerasing
-  register: distro_sync_result
-  changed_when: "'Nothing to do' not in distro_sync_result.stdout"
-  when:
-    - "'builder' in group_names"

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -67,3 +67,12 @@
     repo_values: "{{ item.value.get(repo_os, {}) }}"
     repo_name: "{{ repo_values.repo_name | default(item.key) }}"
     repo_content_url: "{{ repo_values.pulp_content_url | default(dnf_repos_pulp_content_url) }}"
+
+- name: Sync all packages to repo versions (distro-sync)
+  # NOTE(wszumski): Sync all packages after configuring repos as packages in
+  # base image may be newer than snapshots or vice versa. This can lead to
+  # dependency hell.
+  ansible.builtin.command:
+    cmd: dnf distro-sync -y
+  register: distro_sync_result
+  changed_when: "'Nothing to do' not in distro_sync_result.stdout"

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -68,6 +68,14 @@
     repo_name: "{{ repo_values.repo_name | default(item.key) }}"
     repo_content_url: "{{ repo_values.pulp_content_url | default(dnf_repos_pulp_content_url) }}"
 
+- name: Disable all Perl module streams on Rocky 8
+  ansible.builtin.command:
+    cmd: dnf module disable perl -y
+  changed_when: false
+  when:
+    - ansible_facts['distribution_major_version'] == "8"
+    - "'builder' in group_names"
+
 - name: Reset Perl module on Rocky 8 (workaround for conflicting module streams)
   ansible.builtin.command:
     cmd: dnf module reset perl -y
@@ -76,6 +84,7 @@
   #       Perl module streams, but currently a newer base image does not exist.
   when:
     - ansible_facts['distribution_major_version'] == "8"
+    - "'builder' in group_names"
 
 - name: Sync all packages to repo versions (distro-sync)
   # NOTE(wszumski): Sync all packages after configuring repos as packages in
@@ -85,3 +94,5 @@
     cmd: dnf distro-sync -y --allowerasing
   register: distro_sync_result
   changed_when: "'Nothing to do' not in distro_sync_result.stdout"
+  when:
+    - "'builder' in group_names"

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -68,6 +68,15 @@
     repo_name: "{{ repo_values.repo_name | default(item.key) }}"
     repo_content_url: "{{ repo_values.pulp_content_url | default(dnf_repos_pulp_content_url) }}"
 
+- name: Reset Perl module on Rocky 8 (workaround for conflicting module streams)
+  ansible.builtin.command:
+    cmd: dnf module reset perl -y
+  changed_when: false
+  # NOTE: This can be dropped when the base image is bumped to a version with consistent
+  #       Perl module streams, but currently a newer base image does not exist.
+  when:
+    - ansible_facts['distribution_major_version'] == "8"
+
 - name: Sync all packages to repo versions (distro-sync)
   # NOTE(wszumski): Sync all packages after configuring repos as packages in
   # base image may be newer than snapshots or vice versa. This can lead to

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -67,4 +67,3 @@
     repo_values: "{{ item.value.get(repo_os, {}) }}"
     repo_name: "{{ repo_values.repo_name | default(item.key) }}"
     repo_content_url: "{{ repo_values.pulp_content_url | default(dnf_repos_pulp_content_url) }}"
-

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -76,9 +76,9 @@
     - ansible_facts['distribution_major_version'] == "8"
     - "'builder' in group_names"
 
-- name: Reset Perl module on Rocky 8 (workaround for conflicting module streams)
+- name: Switch to Perl 5.24 module on Rocky 8 (workaround for conflicting module streams)
   ansible.builtin.command:
-    cmd: dnf module reset perl -y
+    cmd: dnf module enable perl:5.24 -y
   changed_when: false
   # NOTE: This can be dropped when the base image is bumped to a version with consistent
   #       Perl module streams, but currently a newer base image does not exist.

--- a/ansible/roles/dnf_repos/tasks/set_repos.yml
+++ b/ansible/roles/dnf_repos/tasks/set_repos.yml
@@ -73,6 +73,6 @@
   # base image may be newer than snapshots or vice versa. This can lead to
   # dependency hell.
   ansible.builtin.command:
-    cmd: dnf distro-sync -y
+    cmd: dnf distro-sync -y --allowerasing
   register: distro_sync_result
   changed_when: "'Nothing to do' not in distro_sync_result.stdout"

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260715-0828-72b8075d",
+    "RL8": "openhpc-RL8-260717-1018-bcd59178",
     "RL9": "openhpc-RL9-260715-0828-72b8075d"
   }
 }

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -47,7 +47,7 @@ dnf_repos_default:
   appstream:
     '8.10':
       pulp_path: rocky/8.10/AppStream/x86_64/os
-      pulp_timestamp: 20260716T140715
+      pulp_timestamp: 20260714T215346
       repo_file: Rocky-AppStream
     '9.4':
       pulp_path: rocky/9.4/AppStream/x86_64/os
@@ -67,12 +67,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/AppStream/x86_64/os
-      pulp_timestamp: 20260715T213338
+      pulp_timestamp: 20260714T213458
       repo_file: rocky
   appstream-source:
     '8.10':
       pulp_path: rocky/8.10/AppStream/source/tree
-      pulp_timestamp: 20260716T140715
+      pulp_timestamp: 20260712T231534
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/AppStream/source/tree
@@ -84,7 +84,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/AppStream/source/tree
-      pulp_timestamp: 20260716T221817
+      pulp_timestamp: 20260712T233423
       repo_file: rocky
   baseos:
     '8.10':
@@ -109,7 +109,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/x86_64/os
-      pulp_timestamp: 20260716T222336
+      pulp_timestamp: 20260714T220645
       repo_file: rocky
   baseos-source:
     '8.10':
@@ -126,7 +126,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/source/tree
-      pulp_timestamp: 20260715T214639
+      pulp_timestamp: 20260713T053209
       repo_file: rocky
   cernvmfs_cfg:
     '8':
@@ -158,7 +158,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20260716T213030
+      pulp_timestamp: 20260714T215346
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -179,7 +179,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/CRB/x86_64/os
-      pulp_timestamp: 20260716T214748
+      pulp_timestamp: 20260714T213458
       repo_file: rocky
   crb-source:
     '8.10':
@@ -202,11 +202,11 @@ dnf_repos_default:
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
-      pulp_timestamp: 20260716T214147
+      pulp_timestamp: 20260713T214000
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/x86_64
-      pulp_timestamp: 20260716T214147
+      pulp_timestamp: 20260714T212748
       repo_file: epel
   epel-cisco-openh264:
     '9':
@@ -216,11 +216,11 @@ dnf_repos_default:
   epel-source:
     '8':
       pulp_path: epel/8/Everything/source/tree
-      pulp_timestamp: 20260716T214147
+      pulp_timestamp: 20260713T214000
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/source/tree
-      pulp_timestamp: 20260716T214147
+      pulp_timestamp: 20260708T214809
       repo_file: epel
   extras:
     '8.10':
@@ -267,11 +267,11 @@ dnf_repos_default:
   grafana:
     '8':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260715T203903
+      pulp_timestamp: 20260711T203515
       repo_file: grafana
     '9':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260715T203903
+      pulp_timestamp: 20260711T203515
       repo_file: grafana
   ondemand-web:
     '8':

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -47,7 +47,7 @@ dnf_repos_default:
   appstream:
     '8.10':
       pulp_path: rocky/8.10/AppStream/x86_64/os
-      pulp_timestamp: 20260714T215346
+      pulp_timestamp: 20260716T140715
       repo_file: Rocky-AppStream
     '9.4':
       pulp_path: rocky/9.4/AppStream/x86_64/os
@@ -67,12 +67,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/AppStream/x86_64/os
-      pulp_timestamp: 20260714T213458
+      pulp_timestamp: 20260715T213338
       repo_file: rocky
   appstream-source:
     '8.10':
       pulp_path: rocky/8.10/AppStream/source/tree
-      pulp_timestamp: 20260712T231534
+      pulp_timestamp: 20260716T140715
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/AppStream/source/tree
@@ -84,12 +84,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/AppStream/source/tree
-      pulp_timestamp: 20260712T233423
+      pulp_timestamp: 20260715T214639
       repo_file: rocky
   baseos:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/x86_64/os
-      pulp_timestamp: 20260714T215346
+      pulp_timestamp: 20260716T140715
       repo_file: Rocky-BaseOS
     '9.4':
       pulp_path: rocky/9.4/BaseOS/x86_64/os
@@ -109,12 +109,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/x86_64/os
-      pulp_timestamp: 20260714T220645
+      pulp_timestamp: 20260715T222343
       repo_file: rocky
   baseos-source:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/source/tree
-      pulp_timestamp: 20260714T211343
+      pulp_timestamp: 20260715T211522
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/BaseOS/source/tree
@@ -126,7 +126,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/source/tree
-      pulp_timestamp: 20260713T053209
+      pulp_timestamp: 20260715T214639
       repo_file: rocky
   cernvmfs_cfg:
     '8':
@@ -158,7 +158,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20260714T215346
+      pulp_timestamp: 20260716T140715
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -179,7 +179,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/CRB/x86_64/os
-      pulp_timestamp: 20260714T213458
+      pulp_timestamp: 20260715T213338
       repo_file: rocky
   crb-source:
     '8.10':
@@ -202,11 +202,11 @@ dnf_repos_default:
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
-      pulp_timestamp: 20260713T214000
+      pulp_timestamp: 20260715T215027
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/x86_64
-      pulp_timestamp: 20260714T212748
+      pulp_timestamp: 20260715T215027
       repo_file: epel
   epel-cisco-openh264:
     '9':
@@ -216,11 +216,11 @@ dnf_repos_default:
   epel-source:
     '8':
       pulp_path: epel/8/Everything/source/tree
-      pulp_timestamp: 20260713T214000
+      pulp_timestamp: 20260715T215027
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/source/tree
-      pulp_timestamp: 20260708T214809
+      pulp_timestamp: 20260715T215027
       repo_file: epel
   extras:
     '8.10':
@@ -267,11 +267,11 @@ dnf_repos_default:
   grafana:
     '8':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260711T203515
+      pulp_timestamp: 20260715T203903
       repo_file: grafana
     '9':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260711T203515
+      pulp_timestamp: 20260715T203903
       repo_file: grafana
   ondemand-web:
     '8':

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -84,12 +84,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/AppStream/source/tree
-      pulp_timestamp: 20260715T214639
+      pulp_timestamp: 20260716T221817
       repo_file: rocky
   baseos:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/x86_64/os
-      pulp_timestamp: 20260716T140715
+      pulp_timestamp: 20260716T213030
       repo_file: Rocky-BaseOS
     '9.4':
       pulp_path: rocky/9.4/BaseOS/x86_64/os
@@ -109,7 +109,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/x86_64/os
-      pulp_timestamp: 20260715T222343
+      pulp_timestamp: 20260716T222336
       repo_file: rocky
   baseos-source:
     '8.10':
@@ -158,7 +158,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20260716T140715
+      pulp_timestamp: 20260716T213030
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -179,7 +179,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/CRB/x86_64/os
-      pulp_timestamp: 20260715T213338
+      pulp_timestamp: 20260716T214748
       repo_file: rocky
   crb-source:
     '8.10':
@@ -202,11 +202,11 @@ dnf_repos_default:
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
-      pulp_timestamp: 20260715T215027
+      pulp_timestamp: 20260716T214147
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/x86_64
-      pulp_timestamp: 20260715T215027
+      pulp_timestamp: 20260716T214147
       repo_file: epel
   epel-cisco-openh264:
     '9':
@@ -216,11 +216,11 @@ dnf_repos_default:
   epel-source:
     '8':
       pulp_path: epel/8/Everything/source/tree
-      pulp_timestamp: 20260715T215027
+      pulp_timestamp: 20260716T214147
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/source/tree
-      pulp_timestamp: 20260715T215027
+      pulp_timestamp: 20260716T214147
       repo_file: epel
   extras:
     '8.10':


### PR DESCRIPTION
- Bumped RockyLinux 8 snapshots to bring in: `kernel-4.18.0-553.144.1.el8_10.x86_64.rpm` in RL8. This fixes the ghostlock CVE.
- Only bumped BaseOS as AppStream is missing some perl 5.26 packages at this moment in time.