### PR TITLE
Support running HPC tests in a Slurm reservation

### DIFF
--- a/ansible/roles/hpctests/README.md
+++ b/ansible/roles/hpctests/README.md
@@ -28,6 +28,7 @@ All tests use GCC 9 and OpenMPI 4 with UCX. The HPL-based tests use OpenBLAS.
   `/home/{{ hpctests_user }}/hpctests`. **NB:** Do not use `~` in this path.
 - `hpctests_account`: Optional. Slurm account to use, otherwise no account is specified to Slurm.
 - `hpctests_partition`: Optional. Name of partition to use, otherwise default partition is used.
+- `hpctests_reservation`: Optional. Name of reservation to use.
 - `hpctests_qos`: Optional. Slurm QoS to use, otherwise no qos is specified to Slurm.
 - `hpctests_nodes`: Optional. A Slurm node expression, e.g. `'compute-[0-15,19]'` defining the nodes to use. If not set all nodes in the selected partition are used.
 - `hpctests_ucx_net_devices`: Optional. Control which network device/interface to use, e.g. `mlx5_1:0`.

--- a/ansible/roles/hpctests/defaults/main.yml
+++ b/ansible/roles/hpctests/defaults/main.yml
@@ -23,5 +23,6 @@ hpctests_hpl_mem_frac: 0.3
 hpctests_hpl_arch: linux64
 # hpctests_nodes:
 # hpctests_partition:
+# hpctests_reservation:
 # hpctests_account:
 # hpctests_qos:

--- a/ansible/roles/hpctests/templates/hpl-build.sh.j2
+++ b/ansible/roles/hpctests/templates/hpl-build.sh.j2
@@ -5,6 +5,9 @@
 #SBATCH --error=%x.%a.out
 #SBATCH --exclusive
 #SBATCH --partition={{ hpctests_partition }}
+{% if hpctests_reservation is defined %}
+#SBATCH --reservation={{ hpctests_reservation }}
+{% endif %}
 {%if hpctests_nodes is defined %}
 #SBATCH --nodelist={{ hpctests_computes.stdout_lines[0] }}
 {% endif %}

--- a/ansible/roles/hpctests/templates/hpl-solo.sh.j2
+++ b/ansible/roles/hpctests/templates/hpl-solo.sh.j2
@@ -6,6 +6,9 @@
 #SBATCH --exclusive
 #SBATCH --array=0-{{ hpctests_computes.stdout_lines | length - 1 }}
 #SBATCH --partition={{ hpctests_partition }}
+{% if hpctests_reservation is defined %}
+#SBATCH --reservation={{ hpctests_reservation }}
+{% endif %}
 {% if hpctests_hplsolo_excluded_nodes | length > 0 %}
 #SBATCH --exclude={{ hpctests_hplsolo_excluded_nodes | join(',') }}
 {% endif %}

--- a/ansible/roles/hpctests/templates/pingmatrix.sh.j2
+++ b/ansible/roles/hpctests/templates/pingmatrix.sh.j2
@@ -6,6 +6,9 @@
 #SBATCH --error=%x.out
 #SBATCH --exclusive
 #SBATCH --partition={{ hpctests_partition }}
+{% if hpctests_reservation is defined %}
+#SBATCH --reservation={{ hpctests_reservation }}
+{% endif %}
 {%if hpctests_nodes is defined %}
 #SBATCH --nodelist={{ hpctests_computes.stdout_lines[0] }}
 {% endif %}

--- a/ansible/roles/hpctests/templates/pingpong.sh.j2
+++ b/ansible/roles/hpctests/templates/pingpong.sh.j2
@@ -6,6 +6,9 @@
 #SBATCH --error=%x.out
 #SBATCH --exclusive
 #SBATCH --partition={{ hpctests_partition }}
+{% if hpctests_reservation is defined %}
+#SBATCH --reservation={{ hpctests_reservation }}
+{% endif %}
 {%if hpctests_nodes is defined %}
 #SBATCH --nodelist={{ hpctests_computes.stdout_lines[0] }}
 {% endif %}


### PR DESCRIPTION
This can be used to validate nodes while they are in a maintenance reservation.