### PR TITLE
Revert "Mitigate ssh-keysign-pwn exploits (#965)"

### DIFF
--- a/ansible/mitigations.yml
+++ b/ansible/mitigations.yml
@@ -29,37 +29,3 @@
       failed_when: _kernel_modules_modprobe.rc == 0
       changed_when: false
       loop: "{{ kernel_modules_denylist }}"
-
-- name: Apply ssh-keysign-pwn mitigation
-  hosts: mitigate_ssh_keysign_pwn
-  become: true
-  gather_facts: false
-  tasks:
-    # See https://docs.kernel.org/admin-guide/LSM/Yama.html for explanation
-    # Implementation note: we've decided to not use ansible.posix.sysctl for
-    # this one because we wanted to show the command to run manually if need be
-    # and also wanted to have a comment in the generated sysctl.d file.
-    - name: Apply ssh-keysign-pwn mitigation to live system
-      ansible.builtin.command: sysctl kernel.yama.ptrace_scope=2
-      changed_when: true
-    - name: Get current ptrace_scope value
-      ansible.builtin.slurp:
-        src: /proc/sys/kernel/yama/ptrace_scope
-      check_mode: false
-      changed_when: false
-      register: ptrace_scope
-    - name: Show ptrace_scope after fix
-      ansible.builtin.debug:
-        msg: "/proc/sys/kernel/yama/ptrace_scope={{ ptrace_scope.content|b64decode }}"
-    - name: Prepare sysctl.d file to apply mitigation upon reboot
-      ansible.builtin.copy:
-        # beware: /usr/lib/sysctl.d/10-default-yama-scope.conf will set it to 0
-        # so filename prefix needs to be greater than 10.
-        dest: /etc/sysctl.d/99-prevent-ptrace_scope.conf
-        content: |
-          # this is a mitigation for ssh-keysign-pwn
-          # See https://seclists.org/oss-sec/2026/q2/529 for the announcement
-          kernel.yama.ptrace_scope=2
-        owner: root
-        group: root
-        mode: "0644"

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260812-0916-83ace25d",
-    "RL9": "openhpc-RL9-260812-0915-83ace25d"
+    "RL8": "openhpc-RL8-260812-1517-fb1e0ac3",
+    "RL9": "openhpc-RL9-260812-1517-fb1e0ac3"
   }
 }

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -238,4 +238,3 @@ doca
 
 ## Vulnerability mitigation groups
 [kernel_modules]
-[mitigate_ssh_keysign_pwn]

--- a/environments/site/inventory/groups
+++ b/environments/site/inventory/groups
@@ -224,5 +224,3 @@ compute
 ## Vulnerability mitigation groups
 [kernel_modules:children]
 builder
-[mitigate_ssh_keysign_pwn:children]
-builder


### PR DESCRIPTION
This reverts commit ecc88f5bb0f5bfef15f79d113ae50303c082a509.

Reason for revert:

- Vulnerability fixed in newer kernels
- This breaks or limits several debugging, monitoring, and troubleshooting tools when run as non-root users