### PR TITLE
Bump innodb_buffer_pool_size to use slurm suggested defaults

### DIFF
--- a/environments/common/inventory/group_vars/all/mysql.yml
+++ b/environments/common/inventory/group_vars/all/mysql.yml
@@ -9,7 +9,8 @@ mysql_podman_user: podman
 
 # Slurm recommends larger than default values: https://slurm.schedmd.com/accounting.html
 mysql_mysqld_options:
-  - innodb-buffer-pool-size=1024M
+  - >-
+    innodb-buffer-pool-size={{ [((ansible_facts.memtotal_mb | int) // 10), 4096] | max }}M
   - innodb-lock-wait-timeout=900
 
 mysql_root_password: "{{ vault_mysql_root_password }}"


### PR DESCRIPTION
The recommendation is [1]:

```
innodb_buffer_pool_size: We recommend assigning between 5 and 50 percent of the available memory on the SQL server, and at least 4 GiB. Setting this value too small can cause problems when upgrading large Slurm databases or when purging old records.
```

And causes the the following error message:

```
Increase the MySQL parameter innodb_buffer_pool_size from 1024M to 4096M to match the SchedMD recommendation:
Jun 05 13:37:42 prod-control-1 slurmdbd[2580148]: slurmdbd: error: Database settings not recommended values: innodb_buffer_pool_size
```

[1] https://slurm.schedmd.com/accounting.html#slurm-accounting-configuration-before-build