### PR TITLE
Bump pulp snapshots to fix CVE-2026-64600

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -645,6 +645,12 @@ ignore:
   - vulnerability: CVE-2026-43037
     package:
       location: /var/lib/rpm/Packages
+  # CVE-2026-59873 Node.js tar tool in JupyterLab allowing zip bombs
+  # https://access.redhat.com/security/cve/cve-2026-59873
+  # FIXME: Prioritising releasing kernels for CVE-2026-64600
+  - vulnerability: GHSA-23hp-3jrh-7fpw
+    package:
+      location: /opt/jupyter-py312/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock
 
 # Exclude podman images from scan, pending MySQL+OpenSearch+Filebeat upgrade
 # NB: these do not even show in grype's ignored matches

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260717-1018-bcd59178",
-    "RL9": "openhpc-RL9-260715-0828-72b8075d"
+    "RL8": "openhpc-RL8-260724-0953-329e159f",
+    "RL9": "openhpc-RL9-260724-0900-329e159f"
   }
 }

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260724-0953-329e159f",
-    "RL9": "openhpc-RL9-260724-0900-329e159f"
+    "RL8": "openhpc-RL8-260724-1046-3267c585",
+    "RL9": "openhpc-RL9-260724-1045-3267c585"
   }
 }

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -109,12 +109,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/x86_64/os
-      pulp_timestamp: 20260723T220206
+      pulp_timestamp: 20260724T095616
       repo_file: rocky
   baseos-source:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/source/tree
-      pulp_timestamp: 20260723T211605
+      pulp_timestamp: 20260724T095616
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/BaseOS/source/tree
@@ -126,7 +126,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/source/tree
-      pulp_timestamp: 20260723T215614
+      pulp_timestamp: 20260724T095616
       repo_file: rocky
   cernvmfs_cfg:
     '8':
@@ -158,7 +158,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20260723T220750
+      pulp_timestamp: 20260724T095616
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -179,7 +179,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/CRB/x86_64/os
-      pulp_timestamp: 20260723T212946
+      pulp_timestamp: 20260724T095616
       repo_file: rocky
   crb-source:
     '8.10':

--- a/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
+++ b/environments/common/inventory/group_vars/all/dnf_repo_timestamps.yml
@@ -47,7 +47,7 @@ dnf_repos_default:
   appstream:
     '8.10':
       pulp_path: rocky/8.10/AppStream/x86_64/os
-      pulp_timestamp: 20260714T215346
+      pulp_timestamp: 20260723T220750
       repo_file: Rocky-AppStream
     '9.4':
       pulp_path: rocky/9.4/AppStream/x86_64/os
@@ -67,12 +67,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/AppStream/x86_64/os
-      pulp_timestamp: 20260714T213458
+      pulp_timestamp: 20260723T212946
       repo_file: rocky
   appstream-source:
     '8.10':
       pulp_path: rocky/8.10/AppStream/source/tree
-      pulp_timestamp: 20260712T231534
+      pulp_timestamp: 20260723T211605
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/AppStream/source/tree
@@ -84,12 +84,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/AppStream/source/tree
-      pulp_timestamp: 20260712T233423
+      pulp_timestamp: 20260723T215614
       repo_file: rocky
   baseos:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/x86_64/os
-      pulp_timestamp: 20260716T213030
+      pulp_timestamp: 20260723T220750
       repo_file: Rocky-BaseOS
     '9.4':
       pulp_path: rocky/9.4/BaseOS/x86_64/os
@@ -109,12 +109,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/x86_64/os
-      pulp_timestamp: 20260714T220645
+      pulp_timestamp: 20260723T220206
       repo_file: rocky
   baseos-source:
     '8.10':
       pulp_path: rocky/8.10/BaseOS/source/tree
-      pulp_timestamp: 20260715T211522
+      pulp_timestamp: 20260723T211605
       repo_file: Rocky-Sources
     '9.6':
       pulp_path: rocky/9.6/BaseOS/source/tree
@@ -126,7 +126,7 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/BaseOS/source/tree
-      pulp_timestamp: 20260713T053209
+      pulp_timestamp: 20260723T215614
       repo_file: rocky
   cernvmfs_cfg:
     '8':
@@ -158,7 +158,7 @@ dnf_repos_default:
   crb:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/x86_64/os
-      pulp_timestamp: 20260714T215346
+      pulp_timestamp: 20260723T220750
       repo_file: Rocky-PowerTools
       repo_name: powertools
     '9.4':
@@ -179,12 +179,12 @@ dnf_repos_default:
       repo_file: rocky
     '9.8':
       pulp_path: rocky/9.8/CRB/x86_64/os
-      pulp_timestamp: 20260714T213458
+      pulp_timestamp: 20260723T212946
       repo_file: rocky
   crb-source:
     '8.10':
       pulp_path: rocky/8.10/PowerTools/source/tree
-      pulp_timestamp: 20260709T213322
+      pulp_timestamp: 20260723T211605
       repo_file: Rocky-Sources
       repo_name: powertools-source
     '9.6':
@@ -202,11 +202,11 @@ dnf_repos_default:
   epel:
     '8':
       pulp_path: epel/8/Everything/x86_64
-      pulp_timestamp: 20260713T214000
+      pulp_timestamp: 20260723T212426
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/x86_64
-      pulp_timestamp: 20260714T212748
+      pulp_timestamp: 20260721T213447
       repo_file: epel
   epel-cisco-openh264:
     '9':
@@ -216,11 +216,11 @@ dnf_repos_default:
   epel-source:
     '8':
       pulp_path: epel/8/Everything/source/tree
-      pulp_timestamp: 20260713T214000
+      pulp_timestamp: 20260723T212426
       repo_file: epel
     '9':
       pulp_path: epel/9/Everything/source/tree
-      pulp_timestamp: 20260708T214809
+      pulp_timestamp: 20260723T212426
       repo_file: epel
   extras:
     '8.10':
@@ -267,11 +267,11 @@ dnf_repos_default:
   grafana:
     '8':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260711T203515
+      pulp_timestamp: 20260723T204029
       repo_file: grafana
     '9':
       pulp_path: grafana/oss/rpm
-      pulp_timestamp: 20260711T203515
+      pulp_timestamp: 20260723T204029
       repo_file: grafana
   ondemand-web:
     '8':


### PR DESCRIPTION
Brings in fix for:

-  https://access.redhat.com/security/cve/cve-2026-64600