### PR TITLE
Mitgate ovswrap via configurable kernel module denylist

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -652,6 +652,15 @@ ignore:
     package:
       location: /opt/jupyter-py312/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock
 
+# GHSA-r277-6w6q-xmqw: kin-openapi auth bypass
+# Not present in final binary https://github.com/grafana/grafana/pull/129271
+  - vulnerability: GHSA-r277-6w6q-xmqw
+    package:
+      location: /usr/share/grafana/bin/grafana
+  - vulnerability: GHSA-r277-6w6q-xmqw
+    package:
+      location: /var/lib/grafana/plugins/grafana-opensearch-datasource/gpx_opensearch-datasource_linux_amd64
+
 # Exclude podman images from scan, pending MySQL+OpenSearch+Filebeat upgrade
 # NB: these do not even show in grype's ignored matches
 exclude:

--- a/ansible/mitigations.yml
+++ b/ansible/mitigations.yml
@@ -1,5 +1,6 @@
 - name: Denylist kernel modules
   hosts: kernel_modules
+  tags: kernel_modules
   gather_facts: false
   become: true
   tasks:
@@ -10,7 +11,7 @@
         group: root
         mode: u=rw,go=r
         content: |
-          {% for module in kernel_module_denylist %}
+          {% for module in kernel_modules_denylist %}
           install {{ module }} /bin/false
           {% endfor %}
     - name: Unload modules
@@ -18,7 +19,7 @@
         cmd: "rmmod {{ item }}"
       failed_when: false
       changed_when: true
-      loop: "{{ kernel_module_denylist }}"
+      loop: "{{ kernel_modules_denylist }}"
 
 - name: Apply ssh-keysign-pwn mitigation
   hosts: mitigate_ssh_keysign_pwn

--- a/ansible/mitigations.yml
+++ b/ansible/mitigations.yml
@@ -18,7 +18,9 @@
       ansible.builtin.command:
         cmd: "rmmod {{ item }}"
       failed_when: false
-      changed_when: true
+      register: _kernel_modules_rmmod
+      changed_when: >
+         "ERROR: Module " + item + " is not currently loaded" not in _kernel_modules_rmmod.stderr
       loop: "{{ kernel_modules_denylist }}"
     - name: Ensure modules cannot be loaded
       ansible.builtin.command:

--- a/ansible/mitigations.yml
+++ b/ansible/mitigations.yml
@@ -1,28 +1,24 @@
-- name: Apply dirtyfrag mitigation
-  hosts: mitigate_dirtyfrag
+- name: Denylist kernel modules
+  hosts: kernel_modules
   gather_facts: false
   become: true
   tasks:
     - name: Prevent modules loading
       ansible.builtin.copy:
-        dest: /etc/modprobe.d/dirtyfrag.conf
+        dest: /etc/modprobe.d/appliance.conf
         owner: root
         group: root
         mode: u=rw,go=r
         content: |
-          install esp4 /bin/false
-          install esp6 /bin/false
-          install rxrpc /bin/false
-    # below probably is not needed but is safer
+          {% for module in kernel_module_denylist %}
+          install {{ module }} /bin/false
+          {% endfor %}
     - name: Unload modules
       ansible.builtin.command:
-        cmd: rmmod esp4 esp6 rxrpc
+        cmd: "rmmod {{ item }}"
       failed_when: false
       changed_when: true
-    - name: Clear page cache
-      ansible.builtin.command:
-        cmd: echo 3 > /proc/sys/vm/drop_caches
-      changed_when: true
+      loop: "{{ kernel_module_denylist }}"
 
 - name: Apply ssh-keysign-pwn mitigation
   hosts: mitigate_ssh_keysign_pwn
@@ -57,43 +53,3 @@
         owner: root
         group: root
         mode: "0644"
-
-- name: Apply CVE-2026-43037 mitigation
-  hosts: mitigate_cve_2026_43037
-  gather_facts: false
-  become: true
-  tasks:
-    - name: Prevent modules loading
-      ansible.builtin.copy:
-        dest: /etc/modprobe.d/cve_2026_43037.conf
-        owner: root
-        group: root
-        mode: u=rw,go=r
-        content: |
-          install ip6_tunnel /bin/false
-    # below probably is not needed but is safer
-    - name: Unload modules
-      ansible.builtin.command:
-        cmd: rmmod ip6_tunnel
-      failed_when: false
-      changed_when: true
-
-- name: Apply pedit COW (CVE-2026-46331) mitigation
-  hosts: mitigate_cve_2026_46331
-  gather_facts: false
-  become: true
-  tasks:
-    - name: Prevent modules loading
-      ansible.builtin.copy:
-        dest: /etc/modprobe.d/cve_2026_46331.conf
-        owner: root
-        group: root
-        mode: u=rw,go=r
-        content: |
-          install act_pedit /bin/false
-    # below probably is not needed but is safer
-    - name: Unload modules
-      ansible.builtin.command:
-        cmd: rmmod act_pedit
-      failed_when: false
-      changed_when: true

--- a/ansible/mitigations.yml
+++ b/ansible/mitigations.yml
@@ -20,6 +20,13 @@
       failed_when: false
       changed_when: true
       loop: "{{ kernel_modules_denylist }}"
+    - name: Ensure modules cannot be loaded
+      ansible.builtin.command:
+        cmd: "modprobe {{ item }}"
+      register: _kernel_modules_modprobe
+      failed_when: _kernel_modules_modprobe.rc == 0
+      changed_when: false
+      loop: "{{ kernel_modules_denylist }}"
 
 - name: Apply ssh-keysign-pwn mitigation
   hosts: mitigate_ssh_keysign_pwn

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -13,6 +13,8 @@
 - ansible.builtin.import_playbook: validate.yml
   when: appliances_validate | default(true)
 
+- ansible.builtin.import_playbook: mitigations.yml
+
 - ansible.builtin.import_playbook: bootstrap.yml
 
 - name: Run post-bootstrap.yml hook

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260724-1046-3267c585",
-    "RL9": "openhpc-RL9-260724-1045-3267c585"
+    "RL8": "openhpc-RL8-260729-0831-035787f3",
+    "RL9": "openhpc-RL9-260729-0832-035787f3"
   }
 }

--- a/environments/common/inventory/group_vars/all/kernel_modules.yml
+++ b/environments/common/inventory/group_vars/all/kernel_modules.yml
@@ -1,0 +1,11 @@
+kernel_module_denylist:
+  # CVE-2026-43500, CVE-2026-43284 (dirtyfrag)
+  - esp4
+  - esp6
+  - rxrpc
+  # CVE-2026-43037
+  - ip6_tunnel
+  # CVE-2026-46331 (pedit COW)
+  - act_pedit
+  # CVE-2026-64531 (ovswrap)
+  - openvswitch

--- a/environments/common/inventory/group_vars/all/kernel_modules.yml
+++ b/environments/common/inventory/group_vars/all/kernel_modules.yml
@@ -1,4 +1,4 @@
-kernel_module_denylist:
+kernel_modules_denylist:
   # CVE-2026-43500, CVE-2026-43284 (dirtyfrag)
   - esp4
   - esp6

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -238,7 +238,5 @@ doca
 # Hosts to run opkssh to allow SSH via OIDC
 
 ## Vulnerability mitigation groups
-[mitigate_dirtyfrag]
+[kernel_modules]
 [mitigate_ssh_keysign_pwn]
-[mitigate_cve_2026_43037]
-[mitigate_cve_2026_46331]

--- a/environments/site/inventory/groups
+++ b/environments/site/inventory/groups
@@ -218,11 +218,7 @@ compute
 # Hosts to run opkssh to allow SSH via OIDC
 
 ## Vulnerability mitigation groups
-[mitigate_dirtyfrag:children]
+[kernel_modules:children]
 builder
 [mitigate_ssh_keysign_pwn:children]
-builder
-[mitigate_cve_2026_43037:children]
-builder
-[mitigate_cve_2026_46331:children]
 builder


### PR DESCRIPTION
- Provides a new image with kernel module openvswitch blocked to mitigate CVE-2026-64531 (ovswrap)
- Adds configurable blocking/unloading of kernel modules, by default during image build, but can also be used on live clusters:
  - The mitigations playbook now runs from site playbook
  - See new group `kernel_modules` defaulting to `builder` and variable `kernel_modules_denylist`