### PR TITLE
Fix logic when with-mkhomedir is not currently configured

### DIFF
--- a/ansible/roles/sssd/tasks/configure.yml
+++ b/ansible/roles/sssd/tasks/configure.yml
@@ -25,7 +25,7 @@
 
 - name: Configure nsswitch and PAM for SSSD # noqa: no-changed-when
   ansible.builtin.command: "authselect select sssd --force{% if sssd_enable_mkhomedir | bool %} with-mkhomedir{% endif %}"
-  when: "'sssd' not in _authselect_current.stdout"
+  when: "'sssd' not in _authselect_current.stdout or (sssd_enable_mkhomedir | bool and 'with-mkhomedir' not in _authselect_current.stdout)"
 
 - name: "Ensure oddjob is started"
   ansible.builtin.service:

--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260812-1517-fb1e0ac3",
-    "RL9": "openhpc-RL9-260812-1517-fb1e0ac3"
+    "RL8": "openhpc-RL8-260813-1452-8c9b2e9e",
+    "RL9": "openhpc-RL9-260813-1452-8c9b2e9e"
   }
 }


### PR DESCRIPTION
We only checked that `sssd` appeared in the output of `authselect current --raw`.  This meant that if `with-mkhomedir` was missing, but sssd was present, we failed to add with-mkhomedir.