### PR TITLE
Include git commit in /var/lib/image/image.json

### DIFF
--- a/ansible/cleanup.yml
+++ b/ansible/cleanup.yml
@@ -99,6 +99,7 @@
   vars:
     image_info:
       branch: "{{ lookup('pipe', 'git rev-parse --abbrev-ref HEAD') }}"
+      commit: "{{ lookup('pipe', 'git rev-parse HEAD') }}"
       build: "{{ ansible_nodename | split('.') | first }}" # hostname is image name, which contains build info
       os: "{{ ansible_distribution }} {{ ansible_distribution_version }}"
       kernel: "{{ ansible_kernel }}"


### PR DESCRIPTION
The git ref is present in the image name by default, which goes into the build field.
But we might as well include it explicitely, in case the image suffix is overridden and for clarity.