### PR TITLE
Fix ansible-init scontrol update check

### DIFF
--- a/ansible/roles/compute_init/files/compute-init.yml
+++ b/ansible/roles/compute_init/files/compute-init.yml
@@ -383,4 +383,4 @@
       register: _scontrol_update
       failed_when:
         - _scontrol_update.rc > 0
-        - "'slurm_update error: Invalid node state specified' not in _scontrol_update.stderr"
+        - "'slurm_update error: Invalid node state transition' not in _scontrol_update.stderr"


### PR DESCRIPTION
With the update to Slurm v25.11.4 in the ansible-slurm-appliance v2.20, the error message from scontrol when updating to an invalid state has changed [1]. Fixes the `when` clause to check for this new error message.

1. https://github.com/SchedMD/slurm/commit/439717cb4889289136917ec78ca8e219d38e6f78