### PR TITLE
Avoid rebooting nodes from site.yml

### DIFF
--- a/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
+++ b/environments/.stackhpc/tofu/cluster_image.auto.tfvars.json
@@ -1,6 +1,6 @@
 {
   "cluster_image": {
-    "RL8": "openhpc-RL8-260807-0756-398534e4",
-    "RL9": "openhpc-RL9-260807-0756-398534e4"
+    "RL8": "openhpc-RL8-260812-0916-83ace25d",
+    "RL9": "openhpc-RL9-260812-0915-83ace25d"
   }
 }

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -80,9 +80,8 @@ mysql
 [node_exporter]
 # All hosts to monitor for hardware and OS metrics.
 
-[selinux:children]
+[selinux]
 # All hosts requiring control of SELinux status.
-cluster
 
 [rebuild]
 # Enable rebuild of nodes on an OpenStack cloud; add 'control' group.

--- a/environments/site/inventory/groups
+++ b/environments/site/inventory/groups
@@ -33,6 +33,10 @@ control
 [node_exporter:children]
 cluster
 
+[selinux:children]
+# All hosts requiring control of SELinux status.
+fatimage
+
 [opensearch:children]
 control
 


### PR DESCRIPTION
Fixes site.yml rebooting nodes if dnf thinks a reboot is required. This is not safe as it could break running jobs.

The problem is that site.yml runs a `bootstrap.yml` [reboot task](https://github.com/stackhpc/ansible-slurm-appliance/blob/9bfc38743017618a83790b34774d5ddcb4e9c570/ansible/bootstrap.yml#L292C14-L292C22) on `update` and `selinux` groups and the latter was set to `cluster` in the common environment. Setting groups in common env is not current practice anyway as it cannot be overriden.

Fix is to change the selinux group to default in site groups to `fatimage`, because actually changing selinux state is really only appropriate during build anyway.