### PR TITLE
dev/delete-cluster.py: purge volume snapshots

### DIFF
--- a/dev/delete-cluster.py
+++ b/dev/delete-cluster.py
@@ -15,7 +15,11 @@ import json
 import subprocess
 import sys
 
-CLUSTER_RESOURCES = ["server", "port", "volume"]
+CLUSTER_RESOURCES = {
+    "server": [],
+    "port": [],
+    "volume": ["--purge"],  # remove volume with snapshots
+}
 
 
 def delete_cluster(cluster_prefix, force=False):
@@ -40,16 +44,23 @@ def delete_cluster(cluster_prefix, force=False):
                 raise
 
     if force or input("Delete these (y/n)?:") == "y":
-        for resource_type in CLUSTER_RESOURCES:
+        for resource_type, extra_args in CLUSTER_RESOURCES.items():
             items = [v["ID"] for v in to_delete[resource_type]]
             if items:
+                cmd = ["openstack", resource_type, "delete", *extra_args, *items]
                 # delete all resources of each type in a single call for speed:
-                subprocess.run(
-                    f"openstack {resource_type} delete {' '.join(items)}",
-                    stdout=subprocess.PIPE,
-                    shell=True,
-                    check=True,
-                )
+                try:
+                    subprocess.run(
+                        cmd,
+                        capture_output=True,
+                        check=True,
+                        encoding="utf-8",
+                    )
+                except subprocess.CalledProcessError as e:
+                    print(
+                        f"Error calling {e.cmd!r}: returncode={e.returncode} stdout={e.stdout} stderr={e.stderr}"
+                    )
+                    sys.exit(1)
                 print(f"Deleted {len(items)} {resource_type}s")
     else:
         print("Cancelled - no resources deleted")


### PR DESCRIPTION
This is required since a snapshot is taken when testing Slurm upgrades:
Volumes with snapshots need the '--purge' option to be deleted