### PR TITLE
Disable nightly-cleanup in ARCUS cloud

### DIFF
--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -16,7 +16,6 @@ jobs:
         cloud:
           - LEAFCLOUD
           - SMS
-          - ARCUS
     runs-on: ubuntu-24.04
     env:
       OS_CLOUD: openstack


### PR DESCRIPTION
It's not used anymore and config is missing so the cleanup always fails