### PR TITLE
Fix proxy defaults for ansible-core 2.16.14

### DIFF
--- a/ansible/roles/proxy/defaults/main.yml
+++ b/ansible/roles/proxy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # proxy_http_proxy:
 proxy_https_proxy: "{{ proxy_http_proxy }}"
-proxy_no_proxy_defaults: "{{ ['localhost', '127.0.0.1', '169.254.169.254'] + groups['all'] + hostvars.values() | map(attribute='ansible_host') }}"
+proxy_no_proxy_defaults: "{{ ['localhost', '127.0.0.1', '169.254.169.254'] + groups['all'] + hostvars.values() | selectattr('ansible_host', 'defined') | map(attribute='ansible_host') }}"
 proxy_no_proxy_extras: []
 proxy_no_proxy: "{{ (proxy_no_proxy_defaults + proxy_no_proxy_extras) | unique | sort | join(',') }}"
 proxy_dnf: true


### PR DESCRIPTION
The [CVE-2024-11079 ](https://github.com/ansible/ansible/pull/84353/changes#diff-b36fa2cf8e062dc662300f9e707a65fcdd9d6c3a51927a589643b67d3352e4f0R101) fix in ansible-core 2.16.14 changed hostvars iteration to include the implicit localhost once it has variables. Implicit localhost does not define ansible_host, causing no_proxy generation to fail when mapping ansible_host across every host.

This commit filters hostvars to entries that define ansible_host before constructing the default no_proxy list.