### PR TITLE
Fix opensearch role idempotence regarding owner/group

### DIFF
--- a/ansible/ci/library/grafana_elasticsearch_query.py
+++ b/ansible/ci/library/grafana_elasticsearch_query.py
@@ -92,6 +92,10 @@ def run_module():
         + "/_search"
     )
     r = requests.get(datasource_proxy_url, auth=auth)
+    if r.status_code != 200:
+        raise Exception(
+            f"Invalid status returned by {datasource_proxy_url}: {r.status_code} ({r.reason})\n{r.text}"
+        )
     search = json.loads(r.text)
     # see
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-api-response-body:

--- a/ansible/ci/retrieve_inventory.yml
+++ b/ansible/ci/retrieve_inventory.yml
@@ -10,7 +10,7 @@
     cluster_prefix: "{{ undef(hint='cluster_prefix must be defined') }}" # e.g. slurmci-RL8-1030
     ci_vars_file: "{{ appliances_environment_root + '/tofu/' + lookup('env', 'CI_CLOUD') }}.tfvars"
     network_regex: 'network = "(.+)"$'
-    cluster_network: "{{ lookup('ansible.builtin.file', ci_vars_file) | ansible.builtin.regex_search(network_regex, '\\1', multiline=True) }}"
+    cluster_network: "{{ lookup('ansible.builtin.file', ci_vars_file) | ansible.builtin.regex_search(network_regex, '\\1', multiline=True) | first }}"
   tasks:
     - name: Get control host IP
       ansible.builtin.set_fact:

--- a/ansible/roles/opensearch/tasks/certs.yml
+++ b/ansible/roles/opensearch/tasks/certs.yml
@@ -3,8 +3,8 @@
   ansible.builtin.file:
     path: "{{ opensearch_config_path }}/certs"
     state: directory
-    owner: "{{ opensearch_podman_user }}"
-    group: "{{ opensearch_podman_user }}"
+    owner: "{{ opensearch_host_user_id }}"
+    group: "{{ opensearch_host_group_id }}"
     mode: ug=rwx,o=
 
 # Cert generation based on https://opensearch.org/docs/latest/security-plugin/configuration/generate-certificates/
@@ -12,8 +12,8 @@
 - name: Generate root private key
   community.crypto.openssl_privatekey:
     path: "{{ opensearch_config_path }}/certs/root-ca-key.pem"
-    owner: "{{ opensearch_podman_user }}"
-    group: "{{ opensearch_podman_user }}"
+    owner: "{{ opensearch_host_user_id }}"
+    group: "{{ opensearch_host_group_id }}"
     mode: ug=rw,o=
     return_content: false
 
@@ -32,8 +32,8 @@
     privatekey_path: "{{ opensearch_config_path }}/certs/root-ca-key.pem"
     path: "{{ opensearch_config_path }}/certs/root-ca.pem"
     csr_content: "{{ _opensearch_root_csr.csr }}"
-    owner: "{{ opensearch_podman_user }}"
-    group: "{{ opensearch_podman_user }}"
+    owner: "{{ opensearch_host_user_id }}"
+    group: "{{ opensearch_host_group_id }}"
     mode: ug=rw,o=
     return_content: false
 
@@ -41,8 +41,8 @@
   community.crypto.openssl_privatekey:
     path: "{{ opensearch_config_path }}/certs/esnode-key.pem"
     format: pkcs8
-    owner: "{{ opensearch_podman_user }}"
-    group: "{{ opensearch_podman_user }}"
+    owner: "{{ opensearch_host_user_id }}"
+    group: "{{ opensearch_host_group_id }}"
     mode: ug=rw,o=
     return_content: false
 
@@ -65,7 +65,7 @@
     ownca_privatekey_path: "{{ opensearch_config_path }}/certs/root-ca-key.pem"
     path: "{{ opensearch_config_path }}/certs/esnode.pem"
     csr_content: "{{ _opensearch_node_csr.csr }}"
-    owner: "{{ opensearch_podman_user }}"
-    group: "{{ opensearch_podman_user }}"
+    owner: "{{ opensearch_host_user_id }}"
+    group: "{{ opensearch_host_group_id }}"
     mode: ug=rw,o=
     return_content: false

--- a/ansible/roles/opensearch/tasks/runtime.yml
+++ b/ansible/roles/opensearch/tasks/runtime.yml
@@ -14,6 +14,15 @@
     path: /etc/systemd/system/opendistro.service
     state: absent
 
+- name: Collect usernamespace facts
+  user_namespace_facts:
+
+- name: Set facts containing group_ids
+  ansible.builtin.set_fact:
+    # Elastic search user is 1000
+    opensearch_host_user_id: "{{ opensearch_host_user_id | default(ansible_facts.subuid[opensearch_podman_user]['start'] + 1000 - 1) }}"
+    opensearch_host_group_id: "{{ opensearch_host_group_id | default(ansible_facts.subgid[opensearch_podman_user]['start'] + 1000 - 1) }}"
+
 - name: Enumerate files in data directory
   ansible.builtin.find:
     path: "{{ opensearch_data_path }}"
@@ -29,8 +38,8 @@
   ansible.builtin.file:
     state: directory
     path: "{{ item }}"
-    owner: "{{ opensearch_podman_user }}"
-    group: "{{ opensearch_podman_user }}"
+    owner: "{{ opensearch_host_user_id }}"
+    group: "{{ opensearch_host_group_id }}"
     mode: "0770"
   become: true
   loop:
@@ -43,8 +52,8 @@
     content: |
       This is a flag file to indicate that filebeat is pushing data
       indexed by Slurm JobID to prevent duplicate OpenSearch records
-    owner: "{{ opensearch_podman_user }}"
-    group: "{{ opensearch_podman_user }}"
+    owner: "{{ opensearch_host_user_id }}"
+    group: "{{ opensearch_host_group_id }}"
     mode: "0644"
 
 - name: Create certs
@@ -53,10 +62,8 @@
   ansible.builtin.template:
     src: opensearch.yml.j2
     dest: "{{ opensearch_config_path }}/opensearch.yml"
-    owner: "{{ opensearch_podman_user }}"
-    group: "{{ opensearch_podman_user }}"
-    # NOTE: root user in container maps to user on host, so this will appear as
-    # owned by root in the container.
+    owner: "{{ opensearch_host_user_id }}"
+    group: "{{ opensearch_host_group_id }}"
     mode: "0660"
   notify: Restart opensearch service
   become: true
@@ -65,16 +72,15 @@
   ansible.builtin.template:
     src: "{{ opensearch_internal_users_path }}"
     dest: "{{ opensearch_config_path }}/internal_users.yml"
-    owner: "{{ opensearch_podman_user }}"
-    group: "{{ opensearch_podman_user }}"
-    # NOTE: root user in container maps to user on host, so this will appear as
-    # owned by root in the container.
+    owner: "{{ opensearch_host_user_id }}"
+    group: "{{ opensearch_host_group_id }}"
     mode: "0660"
   notify: Restart opensearch service
   become: true
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
+
 - name: Ensure opensearch service state
   ansible.builtin.systemd:
     name: opensearch.service

--- a/ansible/roles/opensearch/templates/opensearch.service.j2
+++ b/ansible/roles/opensearch/templates/opensearch.service.j2
@@ -20,10 +20,10 @@ ExecStart=/usr/bin/podman run \
     --name opensearch \
     --restart=no --user opensearch \
     --ulimit memlock=-1:-1 --ulimit nofile=65536:65536 \
-    --volume {{ opensearch_data_path }}:/usr/share/opensearch/data:U \
-    --volume {{ opensearch_config_path }}/internal_users.yml:/usr/share/opensearch/config/opensearch-security/internal_users.yml:U \
-    --volume {{ opensearch_config_path }}/opensearch.yml:/usr/share/opensearch/config/opensearch.yml:U \
-    --volume {{ opensearch_config_path}}/certs:/usr/share/opensearch/config/certs:U \
+    --volume {{ opensearch_data_path }}:/usr/share/opensearch/data \
+    --volume {{ opensearch_config_path }}/internal_users.yml:/usr/share/opensearch/config/opensearch-security/internal_users.yml \
+    --volume {{ opensearch_config_path }}/opensearch.yml:/usr/share/opensearch/config/opensearch.yml \
+    --volume {{ opensearch_config_path}}/certs:/usr/share/opensearch/config/certs \
     --env node.name=opensearch \
     --env discovery.type=single-node \
     --env bootstrap.memory_lock=true \


### PR DESCRIPTION
- `username_facts` parses simple forms of `/etc/subuid` `/etc/subgid`.
- a simple computation gives the likely uid:gid of the opensearch user (rootless podman with `--userns=host`)

It can be overriden via `opensearch_host_user_id` `opensearch_host_group_id`, but then the situation might be more complex, eg using `--userns=auto:size=1000` or `--uidmap=...` that makes it unpredictible.

Also removed the :U flag from the `podman run` command in the service, because we generate files with correct permissions in the first place.