### PR TITLE
Fix nhc export task undefined variable in templating by copying live config

### DIFF
--- a/ansible/roles/nhc/tasks/export.yml
+++ b/ansible/roles/nhc/tasks/export.yml
@@ -1,8 +1,15 @@
 ---
 # Used for compute-init
-- name: Template out host specific NHC config
-  ansible.builtin.template:
-    src: "{{ nhc_config_template }}"
+- name: Fetch current host NHC config
+  check_mode: false
+  failed_when: false
+  register: _nhc_current_host_config
+  ansible.builtin.slurp:
+    src: "/etc/nhc/nhc.conf"
+
+- name: Export current host NHC config
+  ansible.builtin.copy:
+    content: "{{ _nhc_current_host_config.content | b64decode }}"
     dest: "/exports/cluster/hostconfig/{{ inventory_hostname }}/nhc.conf"
     owner: ansible-init
     group: ansible-init


### PR DESCRIPTION
Avoid templating failure when the `facts.yml` tasks have not been called - introduced by https://github.com/stackhpc/ansible-slurm-appliance/pull/988.

Eg. when calling `ansible-playbook -D ansible/final.yml --tags compute_init` during development.

Note: the preferred pattern is now  to fetch custom files from live hosts in the export phase instead of duplicating the templating task to a different destination with `delegate_to: control`, to avoid this kind of issues.
Now don't forget to run  `ansible-playbook -D ansible/site.yml --tags nhc,compute_init --limit my-test-host` when you are developing the nhc role in compute_init mode. This will generate the config file on the live node, then export it.