### PR TITLE
Bump openhpc role for DB timeout and validation fixes

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: v26.2.1
     name: stackhpc.nfs
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: v1.6.0
+    version: v1.7.0
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-grafana.git
     name: cloudalchemy.grafana


### PR DESCRIPTION
See https://github.com/stackhpc/ansible-role-openhpc/releases/tag/v1.7.0.

Does not need an image build as the role is not copied into the image.