### PR TITLE
Add systemtap role

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -110,3 +110,5 @@ roles/*
 !roles/opkssh/**
 !roles/weka/
 !roles/weka/**
+!roles/systemtap/
+!roles/systemtap/**

--- a/ansible/roles/systemtap/defaults/main.yml
+++ b/ansible/roles/systemtap/defaults/main.yml
@@ -1,0 +1,10 @@
+# Directory to store modules
+systemtap_modules_directory: /var/lib/appliance-stap-modules
+# List of objects defining systemtap scripts
+# to compile to modules and run. Each object is in
+# the form:
+# - name - unique identifier for module
+#   script - multiline string defining script content
+#   persist - bool indicating whether to load module
+#             at boot (use with caution)
+systemtap_scripts:

--- a/ansible/roles/systemtap/defaults/main.yml
+++ b/ansible/roles/systemtap/defaults/main.yml
@@ -7,4 +7,4 @@ systemtap_modules_directory: /var/lib/appliance-stap-modules
 #   script - multiline string defining script content
 #   persist - bool indicating whether to load module
 #             at boot (use with caution)
-systemtap_scripts:
+systemtap_scripts: []

--- a/ansible/roles/systemtap/tasks/build-module.yml
+++ b/ansible/roles/systemtap/tasks/build-module.yml
@@ -20,6 +20,7 @@
     owner: root
     group: root
     mode: "0600"
+    remote_src: true
 
 - name: Create systemd service
   ansible.builtin.template:

--- a/ansible/roles/systemtap/tasks/build-module.yml
+++ b/ansible/roles/systemtap/tasks/build-module.yml
@@ -1,0 +1,36 @@
+---
+- name: Create script file
+  ansible.builtin.copy:
+    dest: "/tmp/{{ _systemtap_script.name }}.stp"
+    content: "{{ _systemtap_script.script }}"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Compile script to module
+  ansible.builtin.command:
+    cmd: stap -p 4 -g -m {{ _systemtap_script.name }} {{ _systemtap_script.name }}.stp
+    chdir: /tmp
+  changed_when: true
+
+- name: Move module to modules directory
+  ansible.builtin.copy:
+    src: "/tmp/{{ _systemtap_script.name }}.ko"
+    dest: "{{ systemtap_modules_directory }}/{{ _systemtap_script.name }}.ko"
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Create systemd service
+  ansible.builtin.template:
+    src: stap-unit.service.j2
+    dest: "/etc/systemd/system/stap-{{ _systemtap_script.name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Start systemd service
+  ansible.builtin.systemd_service:
+    enabled: "{{ _systemtap_script.persist }}"
+    state: started
+    name: "stap-{{ _systemtap_script.name }}.service"

--- a/ansible/roles/systemtap/tasks/configure.yml
+++ b/ansible/roles/systemtap/tasks/configure.yml
@@ -1,0 +1,14 @@
+---
+- name: Ensure stap module directory
+  ansible.builtin.file:
+    path: "{{ systemtap_modules_directory }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Build modules from stap scripts
+  ansible.builtin.include_tasks: build-module.yml
+  loop: "{{ systemtap_scripts }}"
+  loop_control:
+    loop_var: _systemtap_script

--- a/ansible/roles/systemtap/tasks/install.yml
+++ b/ansible/roles/systemtap/tasks/install.yml
@@ -1,0 +1,9 @@
+---
+- name: Install systemtap and required kernel packages
+  ansible.builtin.dnf:
+    name:
+      - systemtap
+      - "kernel-debuginfo-{{ ansible_kernel }}"
+      - "kernel-debuginfo-common-{{ ansible_architecture }}-{{ ansible_kernel }}"
+      - "kernel-devel-{{ ansible_kernel }}"
+    state: present

--- a/ansible/roles/systemtap/tasks/main.yml
+++ b/ansible/roles/systemtap/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- ansible.builtin.import_tasks: install.yml
+- ansible.builtin.import_tasks: configure.yml

--- a/ansible/roles/systemtap/templates/stap-unit.service.j2
+++ b/ansible/roles/systemtap/templates/stap-unit.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Appliance created stap probe - {{ _systemtap_script.name }}
+After=sysinit.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/staprun {{ systemtap_modules_directory }}/{{ _systemtap_script.name }}.ko
+ExecStop=/usr/bin/staprun -d {{ _systemtap_script.name }}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/environments/common/inventory/groups
+++ b/environments/common/inventory/groups
@@ -246,3 +246,6 @@ doca
 # Hosts to get loaded modules and run modulejail onto (doesn't modify the host's modprobe.d)
 # Add at least one host per hardware kind. Don't forget VMs.
 # Can add the whole cluster if you want.
+
+[systemtap]
+# Hosts to install systemtap and run probes on

--- a/environments/site/inventory/groups
+++ b/environments/site/inventory/groups
@@ -227,3 +227,7 @@ compute
 ## Vulnerability mitigation groups
 [kernel_modules:children]
 cluster
+
+[systemtap:children]
+login
+compute


### PR DESCRIPTION
Installs systemtap and allows configuring probe scripts to be compiled into modules and optionally loaded on boot. This makes it easier to roll out systemtap based CVE mitigations without the need to install stap live at sites, such as the mitigations suggested for copy-fail and RefluXFS.